### PR TITLE
Add clear score button to game4

### DIFF
--- a/game4/app.js
+++ b/game4/app.js
@@ -68,7 +68,7 @@ let startButton,playAgainButton,backToTopButton;
 let startScreen,gameScreen,endScreen;
 let timerDisplay,scoreDisplay,finalScoreDisplay,resultMessage;
 let shapeBtns,inputBtns,timeBtns;
-let topTable,recentTable;
+let topTable,recentTable,clearScoresButton;
 
 /* ---------- 初期化 ---------- */
 document.addEventListener('DOMContentLoaded',()=>{
@@ -106,6 +106,7 @@ function cacheDom(){
 
   topTable   =document.getElementById('topScoresTable');
   recentTable=document.getElementById('recentScoresTable');
+  clearScoresButton=document.getElementById('clearScoresButton');
 }
 
 /* ---------- Canvas HiDPI ---------- */
@@ -161,6 +162,9 @@ function initButtons(){
       renderTables();
     });
   });
+
+  /* 記録削除 */
+  clearScoresButton.addEventListener('click',clearScores);
 
   /* メインボタン */
   startButton     .addEventListener('click',startGame);
@@ -409,4 +413,13 @@ function toRows(arr,rank){
       <td>${r.date}</td><td>${r.time}</td><td>${r.input==='pen'?'✍️':'☝️'}</td>
       <td>${shapes[r.shape].name}</td><td>${r.timeLimit}秒</td><td>${r.score}</td>
     </tr>`).join('');
+}
+
+/* ---------- 記録削除 ---------- */
+function clearScores(){
+  if(!confirm('保存した記録をすべて削除しますか？')) return;
+  Object.keys(localStorage)
+    .filter(k=>k.startsWith('trace_'))
+    .forEach(k=>localStorage.removeItem(k));
+  renderTables();
 }

--- a/game4/index.html
+++ b/game4/index.html
@@ -60,6 +60,9 @@
 
           <h3 class="mt-16 mb-4">📜 直近10件</h3>
           <table id="recentScoresTable"></table>
+          <div class="mt-8">
+            <button id="clearScoresButton" class="btn btn--outline btn--sm">記録を削除</button>
+          </div>
         </section>
 
         <button id="startButton" class="btn btn--primary btn--lg mt-24">START!</button>


### PR DESCRIPTION
## Summary
- add a button on the game4 start screen to clear saved scores
- implement `clearScores` function with confirmation and update tables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68417094c2d0832581e8f35f27dac175