### PR TITLE
Implement square zones and target marker in training mode

### DIFF
--- a/game6/app.js
+++ b/game6/app.js
@@ -29,20 +29,31 @@ class ReactionTimeGame {
             isReady: false,
             isGameActive: false,
             startTime: 0,
-            waitTimeout: null
+            waitTimeout: null,
+            activeZoneIndex: null
         };
+
+        // Default mode is reaction measurement
+        this.mode = 'measure';
 
         this.initializeElements();
         this.bindEvents();
+        this.updateModeButton();
+        document.body.classList.add('mode-measure');
         this.updateUI();
     }
 
     initializeElements() {
         this.elements = {
-            gameZone: document.getElementById('gameZone'),
+            zonesContainer: document.getElementById('gameZones'),
+            gameZones: document.querySelectorAll('.game-zone'),
+            zone1: document.getElementById('zone1'),
+            zone2: document.getElementById('zone2'),
+            zone3: document.getElementById('zone3'),
             gameText: document.getElementById('gameText'),
             startBtn: document.getElementById('startBtn'),
             resetBtn: document.getElementById('resetBtn'),
+            modeSwitch: document.getElementById('modeSwitch'),
             currentTest: document.getElementById('currentTest'),
             testStatus: document.getElementById('testStatus'),
             resultsGrid: document.getElementById('resultsGrid'),
@@ -61,14 +72,32 @@ class ReactionTimeGame {
         this.elements.resetBtn.addEventListener('click', () => this.resetGame());
         
         // Game zone clicks (mouse and touch)
-        this.elements.gameZone.addEventListener('click', (e) => this.handleGameZoneClick(e));
-        this.elements.gameZone.addEventListener('touchstart', (e) => {
-            e.preventDefault();
-            this.handleGameZoneClick(e);
+        this.elements.gameZones.forEach(zone => {
+            zone.addEventListener('click', (e) => this.handleGameZoneClick(e));
+            zone.addEventListener('touchstart', (e) => {
+                e.preventDefault();
+                this.handleGameZoneClick(e);
+            });
+            zone.addEventListener('contextmenu', (e) => e.preventDefault());
         });
 
-        // Prevent context menu on game zone
-        this.elements.gameZone.addEventListener('contextmenu', (e) => e.preventDefault());
+        // Mode switch button
+        this.elements.modeSwitch.addEventListener('click', () => this.toggleMode());
+    }
+
+    toggleMode() {
+        this.mode = this.mode === 'measure' ? 'train' : 'measure';
+        document.body.classList.toggle('mode-measure', this.mode === 'measure');
+        document.body.classList.toggle('mode-train', this.mode === 'train');
+        this.resetGame();
+    }
+
+    updateModeButton() {
+        if (this.mode === 'measure') {
+            this.elements.modeSwitch.textContent = 'トレーニングモードへ';
+        } else {
+            this.elements.modeSwitch.textContent = '測定モードへ';
+        }
     }
 
     startGame() {
@@ -97,7 +126,13 @@ class ReactionTimeGame {
         this.gameState.isWaiting = true;
         this.gameState.isReady = false;
         
-        this.elements.gameZone.className = 'game-zone waiting';
+        if (this.mode === 'measure') {
+            this.elements.zone1.className = 'game-zone waiting';
+        } else {
+            this.elements.gameZones.forEach(zone => {
+                zone.className = 'game-zone waiting';
+            });
+        }
         this.elements.gameText.textContent = this.gameData.messages.waiting;
         this.elements.testStatus.textContent = `第${this.gameState.currentTest}回目の測定中...`;
         
@@ -116,7 +151,19 @@ class ReactionTimeGame {
         this.gameState.isReady = true;
         this.gameState.startTime = performance.now();
         
-        this.elements.gameZone.className = 'game-zone ready pulse';
+        let idx = 0;
+        if (this.mode === 'train') {
+            idx = Math.floor(Math.random() * this.elements.gameZones.length);
+        }
+        this.gameState.activeZoneIndex = idx;
+
+        if (this.mode === 'measure') {
+            this.elements.zone1.className = 'game-zone ready pulse';
+        } else {
+            this.elements.gameZones.forEach((zone, i) => {
+                zone.className = 'game-zone ready' + (i === idx ? ' pulse target' : '');
+            });
+        }
         this.elements.gameText.textContent = this.gameData.messages.ready;
         this.elements.testStatus.textContent = '今すぐクリック！';
     }
@@ -130,15 +177,27 @@ class ReactionTimeGame {
             // Flying - clicked too early
             this.handleFlying();
         } else if (this.gameState.isReady) {
-            // Valid click - measure reaction time
-            this.measureReactionTime();
+            const targetZone = this.mode === 'measure' ? this.elements.zone1 : this.elements.gameZones[this.gameState.activeZoneIndex];
+            if (event.currentTarget === targetZone) {
+                // Valid click - measure reaction time
+                this.measureReactionTime();
+            } else {
+                // Wrong zone clicked
+                this.handleFlying();
+            }
         }
     }
 
     handleFlying() {
         clearTimeout(this.gameState.waitTimeout);
         
-        this.elements.gameZone.className = 'game-zone flying';
+        if (this.mode === 'measure') {
+            this.elements.zone1.className = 'game-zone flying';
+        } else {
+            this.elements.gameZones.forEach(zone => {
+                zone.className = 'game-zone flying';
+            });
+        }
         this.elements.gameText.textContent = this.gameData.messages.tooSoon;
         this.elements.testStatus.textContent = 'フライング！次の測定に進みます...';
         
@@ -150,7 +209,10 @@ class ReactionTimeGame {
         });
         
         this.addResultToGrid(this.gameState.currentTest, null, true);
-        
+
+        this.gameState.isReady = false;
+        this.gameState.activeZoneIndex = null;
+
         // Continue to next test after delay
         setTimeout(() => {
             this.startNextTest();
@@ -160,7 +222,13 @@ class ReactionTimeGame {
     measureReactionTime() {
         const reactionTime = Math.round(performance.now() - this.gameState.startTime);
         
-        this.elements.gameZone.className = 'game-zone neutral fade-in';
+        if (this.mode === 'measure') {
+            this.elements.zone1.className = 'game-zone neutral fade-in';
+        } else {
+            this.elements.gameZones.forEach(zone => {
+                zone.className = 'game-zone neutral fade-in';
+            });
+        }
         this.elements.gameText.textContent = `${reactionTime}ms`;
         this.elements.testStatus.textContent = this.getRankingForTime(reactionTime).message;
         
@@ -172,8 +240,9 @@ class ReactionTimeGame {
         });
         
         this.addResultToGrid(this.gameState.currentTest, reactionTime, false);
-        
+
         this.gameState.isReady = false;
+        this.gameState.activeZoneIndex = null;
         
         // Continue to next test after delay
         setTimeout(() => {
@@ -201,7 +270,13 @@ class ReactionTimeGame {
     endGame() {
         this.gameState.isGameActive = false;
         
-        this.elements.gameZone.className = 'game-zone neutral';
+        if (this.mode === 'measure') {
+            this.elements.zone1.className = 'game-zone neutral';
+        } else {
+            this.elements.gameZones.forEach(zone => {
+                zone.className = 'game-zone neutral';
+            });
+        }
         this.elements.gameText.textContent = this.gameData.messages.completed;
         this.elements.testStatus.textContent = '全ての測定が完了しました！';
         
@@ -255,7 +330,8 @@ class ReactionTimeGame {
             isReady: false,
             isGameActive: false,
             startTime: 0,
-            waitTimeout: null
+            waitTimeout: null,
+            activeZoneIndex: null
         };
         
         // Reset UI
@@ -264,8 +340,16 @@ class ReactionTimeGame {
         this.elements.finalResults.classList.add('hidden');
         this.elements.resultsGrid.innerHTML = '';
         
-        this.elements.gameZone.className = 'game-zone neutral';
+        if (this.mode === 'measure') {
+            this.elements.zone1.className = 'game-zone neutral';
+        } else {
+            this.elements.gameZones.forEach(zone => {
+                zone.className = 'game-zone neutral';
+            });
+        }
         this.elements.gameText.textContent = '準備はいいですか？';
+
+        this.updateModeButton();
         
         this.updateUI();
     }

--- a/game6/index.html
+++ b/game6/index.html
@@ -15,9 +15,12 @@
 
         <main class="game-main">
             <div class="game-area" id="gameArea">
-                <div class="game-zone" id="gameZone">
-                    <div class="game-text" id="gameText">準備はいいですか？</div>
+                <div class="zones" id="gameZones">
+                    <div class="game-zone" id="zone1"></div>
+                    <div class="game-zone" id="zone2"></div>
+                    <div class="game-zone" id="zone3"></div>
                 </div>
+                <div class="game-text" id="gameText">準備はいいですか？</div>
             </div>
 
             <div class="game-info">
@@ -30,6 +33,7 @@
             <div class="game-controls">
                 <button class="btn btn--primary btn--lg" id="startBtn">スタート</button>
                 <button class="btn btn--secondary btn--lg hidden" id="resetBtn">リセット</button>
+                <button class="btn btn--outline btn--sm" id="modeSwitch">トレーニングモードへ</button>
             </div>
         </main>
 

--- a/game6/style.css
+++ b/game6/style.css
@@ -681,15 +681,37 @@ select.form-control {
     margin-bottom: var(--space-32);
 }
 
+body.mode-train .game-main {
+    align-items: stretch;
+}
+
 .game-area {
     width: 100%;
     max-width: 500px;
     margin: 0 auto;
+    position: relative;
+}
+
+body.mode-train .game-area {
+    max-width: none;
+    margin: 0;
+}
+
+.zones {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-8);
+    width: 100%;
+}
+
+body.mode-measure #zone2,
+body.mode-measure #zone3 {
+    display: none;
 }
 
 .game-zone {
-    width: 100%;
-    height: 300px;
+    flex: 1;
+    aspect-ratio: 1 / 1;
     border-radius: var(--radius-lg);
     display: flex;
     align-items: center;
@@ -697,19 +719,22 @@ select.form-control {
     cursor: pointer;
     transition: all var(--duration-normal) var(--ease-standard);
     border: 2px solid var(--color-border);
+    position: relative;
     user-select: none;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
 }
 
+
 .game-zone.waiting {
-    background-color: #FF4444;
+    background-color: #ff9999;
     color: white;
 }
 
+
 .game-zone.ready {
-    background-color: #44FF44;
+    background-color: #99ff99;
     color: #333333;
 }
 
@@ -718,9 +743,32 @@ select.form-control {
     color: var(--color-text);
 }
 
+
 .game-zone.flying {
-    background-color: #FF8888;
+    background-color: #ffcccc;
     color: white;
+}
+
+.game-zone.target::after {
+    content: "\25CE"; /* ◎ */
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 2rem;
+    color: #333;
+}
+
+body.mode-measure .game-zone.waiting {
+    background-color: #FF4444;
+}
+
+body.mode-measure .game-zone.ready {
+    background-color: #44FF44;
+}
+
+body.mode-measure .game-zone.flying {
+    background-color: #FF8888;
 }
 
 .game-text {
@@ -920,7 +968,7 @@ select.form-control {
     }
     
     .game-zone {
-        height: 250px;
+        /* height adjusted by aspect-ratio */
     }
     
     .game-text {
@@ -948,7 +996,7 @@ select.form-control {
     }
     
     .game-zone {
-        height: 200px;
+        /* height adjusted by aspect-ratio */
     }
     
     .game-text {


### PR DESCRIPTION
## Summary
- stretch game area to screen edges in training mode
- make game zones square using `aspect-ratio`
- show a target mark on the active zone and turn all zones green

## Testing
- `node -c game6/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6843e75ddd84832592b2c67e56abd93f