### PR TITLE
Update Game5 grid and colors

### DIFF
--- a/game5/app.js
+++ b/game5/app.js
@@ -1,10 +1,10 @@
-  /* うずまき練習帳 – 24 canvases, trace stays until reset */
+  /* うずまき練習帳 – 40 canvases, trace stays until reset */
 'use strict';
 
 const GRID_EL   = document.getElementById('grid');
 const BTN_CW    = document.getElementById('btnCW');
 const BTN_CCW   = document.getElementById('btnCCW');
-const CANVAS_CNT = 24;     // 6×4
+const CANVAS_CNT = 40;     // 8×5
 
 let currentDir = 'cw';     // 'cw' | 'ccw'
 
@@ -68,7 +68,7 @@ function drawSpiral(ctx, w, h, clockwise=true){
     ctx.lineTo(cx + r * Math.cos(theta),
                cy + r * Math.sin(theta));
   }
-  ctx.strokeStyle = '#888';
+  ctx.strokeStyle = '#ccc';
   ctx.lineWidth = 4;
   ctx.stroke();
 }
@@ -89,7 +89,7 @@ function attachDrawing(cv){
     ctx.beginPath();
     ctx.moveTo(prev.x,prev.y);
     ctx.lineTo(p.x,p.y);
-    ctx.strokeStyle = '#0066ff';
+    ctx.strokeStyle = '#8000ff';
     ctx.lineWidth = widthFromPressure(e);
     ctx.stroke();
     prev = p;

--- a/game5/index.html
+++ b/game5/index.html
@@ -14,7 +14,7 @@
     <span id="timestamp" class="timestamp"></span>
   </header>
 
-  <!-- スパイラル 24 枚 -->
+  <!-- スパイラル 40 枚 -->
   <main id="grid" class="spiral-grid"></main>
 
   <script src="app.js"></script>

--- a/game5/style.css
+++ b/game5/style.css
@@ -19,8 +19,8 @@ html,body{height:100%;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Ro
 .tool-btn.active{background:#0088cc}
 
 .spiral-grid{
-  /* iPad 横向きを想定: 6 列固定 */
-  display:grid;grid-template-columns:repeat(6,1fr);
+  /* iPad 横向きを想定: 8 列固定 */
+  display:grid;grid-template-columns:repeat(8,1fr);
   gap:0.5rem;
   padding:4rem 0.5rem 0.5rem; /* ヘッダー高さぶん余白 */
   height:100%;


### PR DESCRIPTION
## Summary
- expand Game5 grid to 8×5 and create 40 canvases
- lighten spiral color
- change drawing trace color to purple

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68461b476cc083259272962e92389a57