### PR TITLE
Improve spawn randomness in watermelon game

### DIFF
--- a/game7/app.js
+++ b/game7/app.js
@@ -59,7 +59,12 @@ function spawnFruit() {
   const type = nextType;
   nextType = Math.floor(Math.random() * 3); // next is one of first three types
   nextEl.textContent = 'NEXT: ' + FRUITS[nextType].name;
-  activeFruit = createFruit(type, width / 2, 40);
+
+  // randomize spawn position so fruits don't always drop from the center
+  const radius = FRUITS[type].radius;
+  const x = radius + Math.random() * (width - radius * 2);
+
+  activeFruit = createFruit(type, x, 40);
   Body.setStatic(activeFruit, true);
 }
 


### PR DESCRIPTION
## Summary
- make newly spawned fruit appear at a random horizontal location

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684aee254eb0832596f2f5a77922ba63