### PR TITLE
Update Game 8 to support five squares

### DIFF
--- a/game8/app.js
+++ b/game8/app.js
@@ -95,6 +95,8 @@ function init() {
 
 // イベントリスナーの設定
 function setupEventListeners() {
+    // Ensure all squares are selected (including any new ones)
+    elements.squares = document.querySelectorAll('.game-square');
     // Settings screen
     elements.speedButtons.forEach(btn => {
         btn.addEventListener('click', () => selectSpeed(btn.dataset.speed));
@@ -272,7 +274,7 @@ function generateSequence() {
     for (let i = 0; i < gameState.flashCount; i++) {
         let nextIndex;
         do {
-            nextIndex = Math.floor(Math.random() * 4);
+            nextIndex = Math.floor(Math.random() * 5);
         } while (!gameState.allowRepeat && i > 0 && nextIndex === gameState.sequence[i - 1]);
         
         gameState.sequence.push(nextIndex);

--- a/game8/index.html
+++ b/game8/index.html
@@ -82,6 +82,7 @@
                 <div class="game-square" data-index="1"></div>
                 <div class="game-square" data-index="2"></div>
                 <div class="game-square" data-index="3"></div>
+                <div class="game-square" data-index="4"></div>
             </div>
 
             <!-- ゲームコントロール -->

--- a/game8/style.css
+++ b/game8/style.css
@@ -917,7 +917,7 @@ body {
 /* Game board styles */
 .game-board {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   gap: var(--space-16);
   margin-bottom: var(--space-32);
   padding: var(--space-20);


### PR DESCRIPTION
## Summary
- expand the game board in Game 8 with a fifth square
- adjust layout to display five columns
- generate sequences from five squares
- refresh square selection before adding listeners

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68560a019fe8832592103426517a06da