### PR TITLE
Improve progress UI logic

### DIFF
--- a/game8/app.js
+++ b/game8/app.js
@@ -205,9 +205,10 @@ function updateUI() {
     elements.livesHearts.textContent = '❤️'.repeat(gameState.lives);
     
     // プログレスバー更新
-    const maxStage = 7;
-    const progress = Math.min((gameState.currentStage / maxStage) * 100, 100);
-    elements.progressFill.style.width = `${progress}%`;
+    // 最終ステージはstageConfigから自動取得
+    const maxStage = stageConfig[stageConfig.length - 1]?.stage || 7;
+    const progress = (gameState.currentStage / maxStage) * 100;
+    elements.progressFill.style.width = `${Math.min(progress, 100)}%`;
     elements.progressText.textContent = `${gameState.currentStage}/${maxStage}`;
 }
 

--- a/game8/index.html
+++ b/game8/index.html
@@ -62,7 +62,7 @@
                     <div class="progress-bar">
                         <div id="progressFill" class="progress-fill"></div>
                     </div>
-                    <span id="progressText" class="progress-text">1/7</span>
+                    <span id="progressText" class="progress-text">1/?</span>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- show dynamic progress text in game8 progress bar
- use stageConfig to calculate the maximum stage
- update placeholder text in index.html

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68560a0bf5c88325bff96841cbb8fd93