### PR TITLE
Display extra info for Basho journey locations

### DIFF
--- a/game10/app.js
+++ b/game10/app.js
@@ -13,7 +13,10 @@ const BASHO_JOURNEY_DATA = {
             haiku: "草の戸も住み替はる代ぞ雛の家",
             reading: "くさのとも すみかわるよぞ ひなのいえ",
             description: "芭蕉庵があった出発地。『奥の細道』の旅路の始まり。",
-            context: "江戸深川は新開地で、多くの文人墨客が住んでいた地域。"
+            context: "江戸深川は新開地で、多くの文人墨客が住んでいた地域。",
+            disciples: "曽良",
+            climate: "春から夏へ向かう温暖な気候",
+            historicalEvents: "江戸町人文化が発展し始めた頃"
         },
         {
             name: "白河の関",
@@ -23,7 +26,10 @@ const BASHO_JOURNEY_DATA = {
             haiku: "風流の初やおくの田植歌",
             reading: "ふうりゅうの はじめやおくの たうえうた",
             description: "奥州への入口となる重要な関所。本格的な旅の始まり。",
-            context: "古来より歌枕として有名で、都から遠い「みちのく」への入口。"
+            context: "古来より歌枕として有名で、都から遠い\u300cみちのく\u300dへの入口。",
+            disciples: "曽良",
+            climate: "初夏の爽やかな気候",
+            historicalEvents: "関所として古くから機能していた"
         },
         {
             name: "平泉",
@@ -33,7 +39,10 @@ const BASHO_JOURNEY_DATA = {
             haiku: "夏草や兵どもが夢の跡",
             reading: "なつくさや つわものどもが ゆめのあと",
             description: "奥州藤原氏の栄華の跡地。源義経の最期の地。",
-            context: "平泉は奥州藤原氏三代の栄華の舞台で、芭蕉は栄枯盛衰の無常を感じた。"
+            context: "平泉は奥州藤原氏三代の栄華の舞台で、芭蕉は栄枯盛衰の無常を感じた。",
+            disciples: "曽良",
+            climate: "梅雨期で湿潤",
+            historicalEvents: "藤原氏滅亡から約500年後の姿"
         },
         {
             name: "立石寺（山寺）",
@@ -43,7 +52,10 @@ const BASHO_JOURNEY_DATA = {
             haiku: "閑さや岩にしみ入る蝉の声",
             reading: "しずかさや いわにしみいる せみのこえ",
             description: "山形の名刹。1015段の石段を登り、静寂の中の蝉の声に感動。",
-            context: "立石寺は慈覚大師円仁が開いた天台宗の古刹で、断崖絶壁に建つ。"
+            context: "立石寺は慈覚大師円仁が開いた天台宗の古刹で、断崖絶壁に建つ。",
+            disciples: "曽良",
+            climate: "夏の暑さの中でも山間は涼しい",
+            historicalEvents: "開基から約800年を迎えていた"
         },
         {
             name: "最上川",
@@ -53,7 +65,10 @@ const BASHO_JOURNEY_DATA = {
             haiku: "五月雨をあつめて早し最上川",
             reading: "さみだれを あつめてはやし もがみがわ",
             description: "山形を流れる大河を舟で下る。梅雨の雨で増水した川の迫力。",
-            context: "最上川は山形県を流れる一級河川で、当時は重要な交通路。"
+            context: "最上川は山形県を流れる一級河川で、当時は重要な交通路。",
+            disciples: "曽良",
+            climate: "梅雨明け間近で水量が多い",
+            historicalEvents: "水運による商業が盛んだった"
         },
         {
             name: "象潟",
@@ -63,7 +78,10 @@ const BASHO_JOURNEY_DATA = {
             haiku: "象潟や雨に西施がねぶの花",
             reading: "きさかたや あめにせいしが ねぶのはな",
             description: "旅の最北端。松島と並び称される景勝地。",
-            context: "象潟は松島と並び称される景勝地で、芭蕉の時代は美しい潟湖だった。"
+            context: "象潟は松島と並び称される景勝地で、芭蕉の時代は美しい潟湖だった。",
+            disciples: "曽良",
+            climate: "夏でも涼しい海風が吹く",
+            historicalEvents: "後に地震で潟湖が陸地化"
         },
         {
             name: "出雲崎",
@@ -73,7 +91,10 @@ const BASHO_JOURNEY_DATA = {
             haiku: "荒海や佐渡によこたふ天河",
             reading: "あらうみや さどによこたう あまのがわ",
             description: "日本海に面した港町。佐渡島を望む海岸で天の川を詠む。",
-            context: "出雲崎は佐渡金山の積出港として栄えた港町。"
+            context: "出雲崎は佐渡金山の積出港として栄えた港町。",
+            disciples: "曽良",
+            climate: "潮風が強い夏の海岸",
+            historicalEvents: "北前船交易で賑わっていた"
         },
         {
             name: "大垣",
@@ -83,7 +104,10 @@ const BASHO_JOURNEY_DATA = {
             haiku: "蛤のふたみにわかれ行秋ぞ",
             reading: "はまぐりの ふたみにわかれ ゆくあきぞ",
             description: "約2400キロの旅の終着点。約98日間の長旅の終わり。",
-            context: "大垣は美濃国の城下町で、芭蕉の旅の終着点となった。"
+            context: "大垣は美濃国の城下町で、芭蕉の旅の終着点となった。",
+            disciples: "曽良",
+            climate: "夏の終わりで朝晩は涼しい",
+            historicalEvents: "西国への交通の要衝として発展"
         }
     ]
 };
@@ -304,6 +328,9 @@ class BashoJourneyMap {
             'special-reading': location.reading || '',
             'description-text': location.description || '詳細情報はありません',
             'context-text': location.context || '追加情報はありません',
+            'disciples-text': location.disciples || '情報なし',
+            'climate-text': location.climate || '情報なし',
+            'historical-events-text': location.historicalEvents || '情報なし',
             'location-counter': `${this.currentIndex + 1} / ${this.journeyData.journeyData.length}`,
             'progress-indicator': this.currentIndex === this.journeyData.journeyData.length - 1 ? '旅程完了' : '旅程進行中...'
         };

--- a/game10/index.html
+++ b/game10/index.html
@@ -55,6 +55,18 @@
                         <h3>歴史的背景</h3>
                         <p id="context-text">江戸深川は新開地で、多くの文人墨客が住んでいた地域。</p>
                     </div>
+                    <div class="disciples" id="disciples">
+                        <h3>弟子・同行者</h3>
+                        <p id="disciples-text">曽良</p>
+                    </div>
+                    <div class="climate" id="climate">
+                        <h3>気候</h3>
+                        <p id="climate-text">春から夏へ向かう温暖な気候</p>
+                    </div>
+                    <div class="historical-events" id="historical-events">
+                        <h3>関連する歴史的出来事</h3>
+                        <p id="historical-events-text">江戸町人文化が発展し始めた頃</p>
+                    </div>
                 </div>
                 <div class="navigation-info">
                     <span id="location-counter">1 / 8</span>

--- a/game10/style.css
+++ b/game10/style.css
@@ -1466,7 +1466,10 @@ select.form-control {
 
 .special-content,
 .description,
-.context {
+.context,
+.disciples,
+.climate,
+.historical-events {
     background: var(--color-background);
     padding: var(--space-16);
     border-radius: var(--radius-base);
@@ -1475,7 +1478,10 @@ select.form-control {
 
 .special-content h3,
 .description h3,
-.context h3 {
+.context h3,
+.disciples h3,
+.climate h3,
+.historical-events h3 {
     margin: 0 0 var(--space-8) 0;
     font-size: var(--font-size-lg);
     color: var(--color-primary);
@@ -1484,7 +1490,10 @@ select.form-control {
 
 .special-content p,
 .description p,
-.context p {
+.context p,
+.disciples p,
+.climate p,
+.historical-events p {
     margin: 0;
     line-height: var(--line-height-normal);
 }


### PR DESCRIPTION
## Summary
- enrich each Basho location in `app.js` with disciples, climate, and historical events
- update `updateDisplay()` to render the new fields
- add placeholders in `index.html` for these sections
- style the new sections via `style.css`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68560d256bac8325b2f9f11cb245ce90