### PR TITLE
Update stage progress handling

### DIFF
--- a/game8/app.js
+++ b/game8/app.js
@@ -207,8 +207,10 @@ function updateUI() {
     elements.livesHearts.textContent = '❤️'.repeat(gameState.lives);
     
     // プログレスバー更新
-    // 最終ステージはstageConfigから自動取得
-    const maxStage = stageConfig[stageConfig.length - 1]?.stage || 7;
+    // コンフィグに存在する最終ステージを基準にしつつ、
+    // それを超えた場合は現在のステージを最大値として扱う
+    const configuredMax = stageConfig[stageConfig.length - 1]?.stage || 1;
+    const maxStage = Math.max(configuredMax, gameState.currentStage);
     const progress = (gameState.currentStage / maxStage) * 100;
     elements.progressFill.style.width = `${Math.min(progress, 100)}%`;
     elements.progressText.textContent = `${gameState.currentStage}/${maxStage}`;

--- a/game8/index.html
+++ b/game8/index.html
@@ -62,7 +62,7 @@
                     <div class="progress-bar">
                         <div id="progressFill" class="progress-fill"></div>
                     </div>
-                    <span id="progressText" class="progress-text">1/?</span>
+                    <span id="progressText" class="progress-text">1/1</span>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- allow unlimited stages by basing progress bar on current stage when exceeding config
- make placeholder progress text `1/1` so JS can overwrite cleanly

## Testing
- `node -c game8/app.js`

------
https://chatgpt.com/codex/tasks/task_e_685613567b3483259df610f7aca92819