### PR TITLE
Add sequence number display feature to game8

### DIFF
--- a/game8/app.js
+++ b/game8/app.js
@@ -234,6 +234,7 @@ function showButton(buttonType) {
 
 // カウントダウン開始
 async function startCountdown() {
+    clearSequenceNumbers();
     showButton(null);
     showMessage('');
     
@@ -300,6 +301,28 @@ async function showSequence() {
     }
 }
 
+// シーケンス番号表示
+function displaySequenceNumbers() {
+    clearSequenceNumbers();
+    const counters = {};
+    gameState.sequence.forEach((idx, seqPos) => {
+        const square = elements.squares[idx];
+        if (!square) return;
+        counters[idx] = (counters[idx] || 0) + 1;
+        const span = document.createElement('span');
+        span.classList.add('sequence-num', `offset-${counters[idx]}`);
+        span.textContent = seqPos + 1;
+        square.appendChild(span);
+    });
+}
+
+// シーケンス番号クリア
+function clearSequenceNumbers() {
+    elements.squares.forEach(sq => {
+        sq.querySelectorAll('.sequence-num').forEach(el => el.remove());
+    });
+}
+
 // マスクリック処理
 function handleSquareClick(index) {
     if (!gameState.isAcceptingInput) return;
@@ -339,6 +362,7 @@ function checkInput() {
 // 成功処理
 async function handleSuccess() {
     gameState.isAcceptingInput = false;
+    displaySequenceNumbers();
     gameState.failCount = 0;
     gameState.lives = gameState.maxLives; // ライフ回復
     
@@ -365,6 +389,7 @@ async function handleSuccess() {
 // 失敗処理
 async function handleFailure() {
     gameState.isAcceptingInput = false;
+    displaySequenceNumbers();
     gameState.lives--;
     gameState.failCount++;
     

--- a/game8/style.css
+++ b/game8/style.css
@@ -959,6 +959,22 @@ body {
   box-shadow: 0 0 10px rgba(50, 184, 198, 0.4);
 }
 
+/* Sequence numbers */
+.sequence-num {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, 0);
+  font-size: 0.75rem;
+  font-weight: bold;
+  color: #fff;
+  pointer-events: none;
+}
+.sequence-num.offset-1 { top: 0; }
+.sequence-num.offset-2 { top: 12px; }
+.sequence-num.offset-3 { top: 24px; }
+.sequence-num.offset-4 { top: 36px; }
+.sequence-num.offset-5 { top: 48px; }
+
 @keyframes flashEffect {
   0% { transform: scale(1); }
   50% { transform: scale(1.05); }


### PR DESCRIPTION
## Summary
- show sequence numbers after each round
- clear any previous numbers when a new round starts
- style sequence number labels

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68561a3088048325b67986c21f817698