### PR TITLE
Initialize Basho map on DOM ready

### DIFF
--- a/game10/app.js
+++ b/game10/app.js
@@ -698,3 +698,7 @@ class BashoJourneyMap {
         }, 5000);
     }
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+    new BashoJourneyMap();
+});


### PR DESCRIPTION
## Summary
- instantiate `BashoJourneyMap` when the DOM loads so the map is displayed immediately

## Testing
- `npm install puppeteer` *(fails: blocked download)*

------
https://chatgpt.com/codex/tasks/task_e_6856285de5f08325b8592db9739542d8