### PR TITLE
Fix game10 fetch path and add server instructions

### DIFF
--- a/game10/app.js
+++ b/game10/app.js
@@ -587,11 +587,20 @@ class BashoJourneyMap {
 }
 
 async function loadJourneyData() {
-    const response = await fetch('journey-data.json');
+    const response = await fetch('./journey-data.json');
     if (!response.ok) {
         throw new Error('journey-data.json の読み込みに失敗しました');
     }
-    return await response.json();
+
+    const cloned = response.clone();
+    try {
+        return await response.json();
+    } catch (err) {
+        console.error('JSON parsing failed', err);
+        console.log('response.status', cloned.status);
+        console.log('response text', await cloned.text());
+        throw err;
+    }
 }
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/game10/travel-template-guide.md
+++ b/game10/travel-template-guide.md
@@ -52,6 +52,17 @@ travel-map/
 
 `travel-data.js` ファイルを編集して、あなたの旅行データを設定します。
 
+### 4. ローカルサーバーで起動
+
+ブラウザのセキュリティ制限を避けるため、`index.html` はHTTPサーバー経由で表示してください。
+
+```bash
+cd game10
+python3 -m http.server
+```
+
+その後、`http://localhost:8000/index.html` を開きます。
+
 ## データ設定ガイド
 
 ### 基本設定


### PR DESCRIPTION
## Summary
- fix loadJourneyData to fetch `./journey-data.json`
- log response status and text when JSON parsing fails
- explain how to start a local server in `travel-template-guide.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68567892e748832586c93a1f57c533a2