### PR TITLE
Improve JSON error reporting

### DIFF
--- a/game10/app.js
+++ b/game10/app.js
@@ -591,7 +591,13 @@ async function loadJourneyData() {
     if (!response.ok) {
         throw new Error('journey-data.json の読み込みに失敗しました');
     }
-    return await response.json();
+    const clone = response.clone();
+    try {
+        return await response.json();
+    } catch (err) {
+        const text = await clone.text();
+        throw new Error(`journey-data.json の JSON 解析に失敗しました: ${text}`);
+    }
 }
 
 document.addEventListener('DOMContentLoaded', async () => {


### PR DESCRIPTION
## Summary
- surface invalid JSON errors in `game10` using response cloning

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6856789868948325a4b3c3e6f99680e8