### PR TITLE
Remove unused pulsing marker

### DIFF
--- a/game10/app.js
+++ b/game10/app.js
@@ -9,7 +9,6 @@ class BashoJourneyMap {
         this.map = null;
         this.tileLayer = null; // タイルレイヤーを保持する変数を追加
         this.markers = [];
-        this.currentMarker = null;
         this.journeyPath = null;
         this.autoAdjustEnabled = true; // デフォルトは自動調整ON
         this.currentMapStyle = 'modern'; // デフォルトは現代地図
@@ -89,6 +88,8 @@ class BashoJourneyMap {
 
             this.markers.push(marker);
         });
+
+        this.updateMarkerStyles();
     }
 
     drawJourneyPath() {
@@ -536,22 +537,8 @@ class BashoJourneyMap {
 
     updateMap() {
         const location = this.journeyData.journeyData[this.currentIndex];
-        
-        // 現在位置マーカーを更新
-        if (this.currentMarker) {
-            this.map.removeLayer(this.currentMarker);
-        }
-        
-        // 現在位置を示す特別なマーカーを作成
-        const currentIcon = L.divIcon({
-            className: 'custom-marker current-marker pulse',
-            html: `<span>${this.currentIndex + 1}</span>`,
-            iconSize: [32, 32]
-        });
-        
-        this.currentMarker = L.marker([location.lat, location.lng], {
-            icon: currentIcon
-        }).addTo(this.map);
+
+        this.updateMarkerStyles();
         
         // 自動調整が有効な場合、地図の中心と縮尺を移動
         if (this.autoAdjustEnabled) {
@@ -566,6 +553,19 @@ class BashoJourneyMap {
                 duration: 1
             });
         }
+    }
+
+    updateMarkerStyles() {
+        this.markers.forEach((marker, index) => {
+            const el = marker.getElement();
+            if (el) {
+                if (index === this.currentIndex) {
+                    el.classList.add('current-marker');
+                } else {
+                    el.classList.remove('current-marker');
+                }
+            }
+        });
     }
 
     updateTimeline() {

--- a/game10/scss/_layout.scss
+++ b/game10/scss/_layout.scss
@@ -134,19 +134,12 @@
   to { opacity: 1; transform: translateY(0); }
 }
 
-@keyframes pulse {
-  0% { transform: scale(1); opacity: 1; }
-  50% { transform: scale(1.3); opacity: 0.7; }
-  100% { transform: scale(1); opacity: 1; }
-}
 
 .fade-in {
   animation: fadeIn 0.8s ease-in-out;
 }
 
-.pulse {
-  animation: pulse 1.5s infinite;
-}
+
 
 /* 地点切り替え時のトランジション */
 .location-details {

--- a/game10/style.css
+++ b/game10/style.css
@@ -682,27 +682,10 @@ select.form-control {
     transform: translateY(0);
   }
 }
-@keyframes pulse {
-  0% {
-    transform: scale(1);
-    opacity: 1;
-  }
-  50% {
-    transform: scale(1.3);
-    opacity: 0.7;
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
 .fade-in {
   animation: fadeIn 0.8s ease-in-out;
 }
 
-.pulse {
-  animation: pulse 1.5s infinite;
-}
 
 /* 地点切り替え時のトランジション */
 .location-details {


### PR DESCRIPTION
## Summary
- refactor marker selection logic in app.js
- highlight active map marker using `current-marker` class
- remove unused pulsing marker styles from SCSS and CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68580cbcfd9c83259dd4aa662ac7d68d