### PR TITLE
Add aria labels for emojis

### DIFF
--- a/game11/app.js
+++ b/game11/app.js
@@ -169,7 +169,9 @@ function generateSeasonQuizQuestion() {
   
   gameState.currentQuestionData = randomItem;
   
-  document.getElementById('season-quiz-item').textContent = randomItem.emoji;
+  const quizItemEl = document.getElementById('season-quiz-item');
+  quizItemEl.textContent = randomItem.emoji;
+  quizItemEl.setAttribute('aria-label', randomItem.name);
   document.getElementById('season-quiz-name').textContent = randomItem.name;
 }
 
@@ -204,7 +206,9 @@ function generateNameQuizQuestion() {
   
   gameState.currentQuestionData = correctItem;
   
-  document.getElementById('name-quiz-icon').textContent = correctItem.emoji;
+  const nameIconEl = document.getElementById('name-quiz-icon');
+  nameIconEl.textContent = correctItem.emoji;
+  nameIconEl.setAttribute('aria-label', correctItem.name);
   
   // カテゴリを決定
   const categories = ['もの', 'はな', 'くだもの', 'ぎょうじ'];
@@ -278,6 +282,7 @@ function generateMatchGameQuestion() {
     const card = document.createElement('div');
     card.className = 'match-card';
     card.textContent = item.emoji;
+    card.setAttribute('aria-label', item.name);
     card.dataset.item = JSON.stringify(item);
     card.addEventListener('click', function() {
       selectMatchCard(this, item);
@@ -362,6 +367,7 @@ function generateOrderGameQuestion() {
     const item = document.createElement('div');
     item.className = 'order-item';
     item.textContent = season.emoji;
+    item.setAttribute('aria-label', season.name);
     item.dataset.season = JSON.stringify(season);
     item.addEventListener('click', function() {
       selectOrderItem(this, season);
@@ -420,7 +426,9 @@ function generateTestQuestion() {
   const questionTypes = ['season', 'name'];
   const questionType = questionTypes[Math.floor(Math.random() * questionTypes.length)];
   
-  document.getElementById('test-question-item').textContent = correctItem.emoji;
+  const testItemEl = document.getElementById('test-question-item');
+  testItemEl.textContent = correctItem.emoji;
+  testItemEl.setAttribute('aria-label', correctItem.name);
   
   const optionsContainer = document.getElementById('test-options-container');
   optionsContainer.innerHTML = '';
@@ -496,6 +504,7 @@ function showExplanation(isCorrect) {
   // 解説内容の表示
   const item = gameState.currentQuestionData;
   explanationIcon.textContent = item.emoji;
+  explanationIcon.setAttribute('aria-label', item.name);
   explanationName.textContent = item.name;
   explanationSeason.textContent = `季節：${item.season}`;
   explanationDescription.textContent = item.description;


### PR DESCRIPTION
## Summary
- add `aria-label` attributes to dynamic emoji elements in game 11

## Testing
- `node --check game11/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68580d9fb0c48325affbcbc5fc1e84f9