### PR TITLE
Fix overflow for text-based quiz items

### DIFF
--- a/game11/app.js
+++ b/game11/app.js
@@ -173,6 +173,7 @@ function generateSeasonQuizQuestion() {
   const quizItemEl = document.getElementById('season-quiz-item');
   quizItemEl.textContent = randomItem.emoji;
   quizItemEl.setAttribute('aria-label', randomItem.name);
+  adjustTextItem(quizItemEl, randomItem.emoji);
   document.getElementById('season-quiz-name').textContent = randomItem.name;
 }
 
@@ -210,6 +211,7 @@ function generateNameQuizQuestion() {
   const nameIconEl = document.getElementById('name-quiz-icon');
   nameIconEl.textContent = correctItem.emoji;
   nameIconEl.setAttribute('aria-label', correctItem.name);
+  adjustTextItem(nameIconEl, correctItem.emoji);
   
   // カテゴリを決定
   const categories = ['もの', 'はな', 'くだもの', 'ぎょうじ'];
@@ -430,6 +432,7 @@ function generateTestQuestion() {
   const testItemEl = document.getElementById('test-question-item');
   testItemEl.textContent = correctItem.emoji;
   testItemEl.setAttribute('aria-label', correctItem.name);
+  adjustTextItem(testItemEl, correctItem.emoji);
   
   const optionsContainer = document.getElementById('test-options-container');
   optionsContainer.innerHTML = '';
@@ -506,6 +509,7 @@ function showExplanation(isCorrect) {
   const item = gameState.currentQuestionData;
   explanationIcon.textContent = item.emoji;
   explanationIcon.setAttribute('aria-label', item.name);
+  adjustTextItem(explanationIcon, item.emoji);
   explanationName.textContent = item.name;
   explanationSeason.textContent = `季節：${item.season}`;
   explanationDescription.textContent = item.description;
@@ -672,5 +676,14 @@ function loadProgress() {
     }
   } catch (e) {
     console.warn('Failed to load progress:', e);
+  }
+}
+
+// 問題表示用アイコンのテキスト量に応じてクラスを付与
+function adjustTextItem(element, content) {
+  if (content && content.length > 2) {
+    element.classList.add('text-item');
+  } else {
+    element.classList.remove('text-item');
   }
 }

--- a/game11/style.css
+++ b/game11/style.css
@@ -949,6 +949,16 @@ body {
   background-color: rgba(255, 255, 255, 0.8);
   border-radius: 50%;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  text-align: center;
+  word-break: break-word;
+  overflow: hidden;
+  padding: 4px;
+}
+
+/* 文字が複数の場合にサイズを調整 */
+.quiz-item.text-item {
+  font-size: 2.5rem;
+  line-height: 1.2;
 }
 
 .large-emoji {
@@ -1190,6 +1200,15 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  text-align: center;
+  word-break: break-word;
+  overflow: hidden;
+  padding: 4px;
+}
+
+.explanation-icon.text-item {
+  font-size: 2.5rem;
+  line-height: 1.2;
 }
 
 .explanation-text {


### PR DESCRIPTION
## Summary
- avoid overflow when quiz icons contain multiple characters
- adjust explanation icon for long text
- add helper to resize icons based on text length

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68581f8da2388325b9dcd427e424a2fd