### PR TITLE
Add async config loading to game10

### DIFF
--- a/game10/app.js
+++ b/game10/app.js
@@ -2,9 +2,10 @@
 
 // 旅程データは外部JSONから読み込む
 
-class BashoJourneyMap {
-    constructor(data) {
+export class BashoJourneyMap {
+    constructor(data, config = {}) {
         this.journeyData = data;
+        this.config = config;
         this.currentIndex = 0;
         this.map = null;
         this.tileLayer = null; // タイルレイヤーを保持する変数を追加
@@ -24,7 +25,8 @@ class BashoJourneyMap {
             this.setupUI();
             this.setupEventListeners();
             this.updateDisplay();
-            console.log('松尾芭蕉『奥の細道』地図が正常に初期化されました');
+            const title = this.config.appTitle || '松尾芭蕉\u300e奥の細道\u300f';
+            console.log(`${title} 地図が正常に初期化されました`);
         } catch (error) {
             console.error('初期化エラー:', error);
             this.showError('地図の初期化に失敗しました。');
@@ -122,10 +124,13 @@ class BashoJourneyMap {
         // タイトルと期間を設定
         const titleElement = document.getElementById('journey-title');
         const periodElement = document.getElementById('journey-period');
-        
-        if (titleElement) titleElement.textContent = this.journeyData.title || '松尾芭蕉『奥の細道』の旅路';
+
+        const journeyTitle = this.config.journeyTitle || this.journeyData.title || '松尾芭蕉『奥の細道』の旅路';
+        const journeyPeriod = this.config.journeyPeriod || this.journeyData.period || '1689年5月16日 - 8月21日（98日間）';
+
+        if (titleElement) titleElement.textContent = journeyTitle;
         if (periodElement) {
-            periodElement.textContent = this.journeyData.period || '1689年5月16日 - 8月21日（98日間）';
+            periodElement.textContent = journeyPeriod;
         }
 
         // タイムラインスライダーを設定
@@ -539,12 +544,33 @@ function showError(message) {
     }, 5000);
 }
 
+async function loadConfig() {
+    const response = await fetch('./config.json');
+    if (!response.ok) {
+        throw new Error('config.json の読み込みに失敗しました');
+    }
+    const clone = response.clone();
+    try {
+        return await response.json();
+    } catch (err) {
+        const text = await clone.text();
+        throw new Error(`config.json の JSON 解析に失敗しました: ${text}`);
+    }
+}
+
+export function initializeApp(config, data) {
+    if (config && config.appTitle) {
+        document.title = config.appTitle;
+    }
+    return new BashoJourneyMap(data, config);
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
     try {
-        const data = await loadJourneyData();
-        new BashoJourneyMap(data);
+        const [config, data] = await Promise.all([loadConfig(), loadJourneyData()]);
+        initializeApp(config, data);
     } catch (err) {
-        console.error('旅程データの取得に失敗しました', err);
+        console.error('設定または旅程データの取得に失敗しました', err);
         showError(err.message);
         // ページを再読み込みして再試行することを推奨
     }

--- a/game10/config.json
+++ b/game10/config.json
@@ -1,0 +1,5 @@
+{
+  "appTitle": "芭蕉の旅路マップ",
+  "journeyTitle": "松尾芭蕉『奥の細道』の旅路",
+  "journeyPeriod": "1689年5月16日 - 8月21日"
+}

--- a/game10/index.html
+++ b/game10/index.html
@@ -9,6 +9,10 @@
 </head>
 <body>
     <div class="container">
+        <header class="header">
+            <h1 id="journey-title"></h1>
+            <p id="journey-period"></p>
+        </header>
         <!-- 芭蕉プロフィール -->
         <section class="bio-section">
           <h2>芭蕉の略歴</h2>
@@ -76,6 +80,6 @@
     </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-    <script src="app.js"></script>
+    <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load config.json in addition to journey-data
- add initialization function for reuse
- display app title/period from config and update console message
- add header to HTML and switch to ES module

## Testing
- `node -c game10/app.js`

------
https://chatgpt.com/codex/tasks/task_e_685823344d408325bf91b59b65bb8809