### PR TITLE
Fix ES module loading for game10 map

### DIFF
--- a/game10/app.js
+++ b/game10/app.js
@@ -558,20 +558,6 @@ function showError(message) {
     }, 5000);
 }
 
-async function loadConfig() {
-    const response = await fetch('./config.json');
-    if (!response.ok) {
-        throw new Error('config.json の読み込みに失敗しました');
-    }
-    const clone = response.clone();
-    try {
-        return await response.json();
-    } catch (err) {
-        const text = await clone.text();
-        throw new Error(`config.json の JSON 解析に失敗しました: ${text}`);
-    }
-}
-
 export function initializeApp(config, data) {
     if (config && config.appTitle) {
         document.title = config.appTitle;

--- a/game10/index.html
+++ b/game10/index.html
@@ -80,7 +80,7 @@
     </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-    <script src="app.js"></script>
+    <script type="module" src="app.js"></script>
     <script>
       fetch('config.json')
         .then(r => r.json())


### PR DESCRIPTION
## Summary
- remove duplicate `loadConfig` definition
- load `app.js` as a module so `export` syntax works

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6858278f45888325a2d67683df65a532