### PR TITLE
Fix match reference fallback

### DIFF
--- a/game11/app.js
+++ b/game11/app.js
@@ -278,9 +278,10 @@ function generateMatchGameQuestion() {
 
   // 参照アイテムを表示
   const refEl = document.getElementById('match-reference');
-  refEl.textContent = referenceItem.emoji;
+  const refContent = referenceItem.emoji || referenceItem.name;
+  refEl.textContent = refContent;
   refEl.setAttribute('aria-label', referenceItem.name);
-  adjustTextItem(refEl, referenceItem.emoji);
+  adjustTextItem(refEl, refContent);
 
   const matchGrid = document.getElementById('match-grid');
   matchGrid.innerHTML = '';


### PR DESCRIPTION
## Summary
- ensure match game reference shows a name when emoji is unavailable

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68582a3569f483258e5288f13ecafe5d