### PR TITLE
Fix countdown and continue stage

### DIFF
--- a/game12/js/gameStates.js
+++ b/game12/js/gameStates.js
@@ -1,6 +1,6 @@
 // js/gameStates.js
 
-import { GAME_STATES, MESSAGES } from './constants.js';
+import { GAME_STATES, MESSAGES, STAGE_CLEARED_DELAY, RESET_DELAY } from './constants.js';
 import { gameEventEmitter } from './eventEmitter.js';
 
 /**
@@ -184,11 +184,13 @@ export class StageClearedState extends GameState {
     enter() {
         console.log("Entering StageClearedState");
         gameEventEmitter.emit('gameStateChanged', GAME_STATES.STAGE_CLEARED);
+        gameEventEmitter.emit('showSequenceNumbers', this.game.currentSequence);
         // UIはPlayerTurnStateのものを引き継ぎつつ、メッセージは更新済み
-        // 一定時間後にReadyStateに戻るか、次のステージへ
+        // 一定時間後に次のステージを自動で開始
         setTimeout(() => {
-            this.game.changeState(new ReadyState(this.game));
-        }, MESSAGES.STAGE_CLEARED_DELAY);
+            gameEventEmitter.emit('clearSequenceNumbers');
+            this.game.startGame();
+        }, STAGE_CLEARED_DELAY);
     }
 }
 
@@ -199,10 +201,12 @@ export class GameOverState extends GameState {
     enter() {
         console.log("Entering GameOverState");
         gameEventEmitter.emit('gameStateChanged', GAME_STATES.GAME_OVER);
+        gameEventEmitter.emit('showSequenceNumbers', this.game.currentSequence);
         // UIはPlayerTurnStateのものを引き継ぎつつ、メッセージは更新済み
-        // 一定時間後にReadyStateに戻る
+        // 一定時間後にトップページへ戻る
         setTimeout(() => {
+            gameEventEmitter.emit('clearSequenceNumbers');
             this.game.changeState(new ReadyState(this.game));
-        }, MESSAGES.RESET_DELAY); // RESET_DELAY を利用
+        }, RESET_DELAY);
     }
 }

--- a/game12/js/main.js
+++ b/game12/js/main.js
@@ -104,6 +104,7 @@ class GameController {
         }
         this.countdownActive = true;
         this.countdownTimer = COUNTDOWN_TIME;
+        gameEventEmitter.emit('clearSequenceNumbers');
 
         // 現在のステージに応じてシーケンスの長さを決定
         const currentStage = this.mode === GAME_MODES.ONCE ? this.stageOnce : this.stageRepeat;
@@ -159,6 +160,7 @@ class GameController {
         if (this.currentState instanceof PlayingSequenceState) {
             return; // ゲーム中はリセット不可
         }
+        gameEventEmitter.emit('clearSequenceNumbers');
         this.stageOnce = 1;
         this.stageRepeat = 1;
         localStorage.setItem('memoryGame_stageOnce', this.stageOnce.toString());

--- a/game12/js/uiManager.js
+++ b/game12/js/uiManager.js
@@ -82,6 +82,8 @@ export class UIManager {
         gameEventEmitter.on('updateRankingList', (ranking) => this.updateRankingList(ranking));
         gameEventEmitter.on('setDifficultySelection', (difficulty) => this.setDifficultySelection(difficulty));
         gameEventEmitter.on('stageClearedAnimation', () => this.playStageClearedAnimation());
+        gameEventEmitter.on('showSequenceNumbers', (sequence) => this.showSequenceNumbers(sequence));
+        gameEventEmitter.on('clearSequenceNumbers', () => this.clearSequenceNumbers());
     }
 
     showTopPage(message) {
@@ -143,19 +145,30 @@ export class UIManager {
         this.countdownOverlay.classList.remove('hidden');
         let count = COUNTDOWN_TIME;
         this.countdownNumberSpan.textContent = count.toString();
-        
+        this.restartCountdownAnimation();
+
         const countdownInterval = setInterval(() => {
             count--;
             if (count > 0) {
                 this.countdownNumberSpan.textContent = count.toString();
+                this.restartCountdownAnimation();
             } else if (count === 0) {
                 this.countdownNumberSpan.textContent = 'すたーと！';
+                this.restartCountdownAnimation();
             } else {
                 clearInterval(countdownInterval);
                 this.countdownOverlay.classList.add('hidden');
                 gameEventEmitter.emit('countdownFinished'); // カウントダウン終了を通知
             }
         }, 1000);
+    }
+
+    // アニメーションをリセットして再生
+    restartCountdownAnimation() {
+        this.countdownNumberSpan.classList.remove('countdown-number');
+        // reflow to restart animation
+        void this.countdownNumberSpan.offsetWidth;
+        this.countdownNumberSpan.classList.add('countdown-number');
     }
 
     stopCountdown() {
@@ -180,6 +193,23 @@ export class UIManager {
         } else {
             this.replayButton.classList.add('hidden');
         }
+    }
+
+    // 正解シーケンスの番号を各マスに表示
+    showSequenceNumbers(sequence) {
+        sequence.forEach((cellIndex, order) => {
+            const cell = this.gridContainer.querySelector(`.gridItem[data-index="${cellIndex}"]`);
+            if (cell) {
+                cell.textContent = (order + 1).toString();
+            }
+        });
+    }
+
+    // マスの番号表示をクリア
+    clearSequenceNumbers() {
+        this.gridContainer.querySelectorAll('.gridItem').forEach(cell => {
+            cell.textContent = '';
+        });
     }
 
     // ランキングリストを更新


### PR DESCRIPTION
## Summary
- restart countdown animation for each number
- show and clear sequence numbers
- continue to next stage after success
- return to top page only on failure
- reset stage delay constants

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884f4f535e883259f128f28e6af415e