### PR TITLE
Fix top-page reset for game12

### DIFF
--- a/game12/js/main.js
+++ b/game12/js/main.js
@@ -61,7 +61,8 @@ class GameController {
         gameEventEmitter.on('replayButtonClicked', () => this.replaySequence());
         gameEventEmitter.on('resetButtonClicked', () => this.resetGame());
         gameEventEmitter.on('nextButtonClicked', () => this.startGame());
-        gameEventEmitter.on('backButtonClicked', () => this.changeState(new ReadyState(this)));
+        // トップページに戻る際はステージをリセット
+        gameEventEmitter.on('backButtonClicked', () => this.resetGame());
         gameEventEmitter.on('resetRankingButtonClicked', () => this.rankingManager.resetRanking());
         gameEventEmitter.on('difficultyChanged', (difficulty) => this.setDifficulty(difficulty));
         gameEventEmitter.on('gridCellClicked', (index) => {

--- a/game12/js/uiManager.js
+++ b/game12/js/uiManager.js
@@ -101,6 +101,8 @@ export class UIManager {
         }
         this.setNextButtonVisible(false);
         this.setBackButtonVisible(false);
+        // トップページではボタンを再度有効にする
+        this.setControlsEnabled(true);
     }
 
     hideTopPage() {


### PR DESCRIPTION
## Summary
- reset stage when using back button in game12
- re-enable top page buttons when returning

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884fb24fa108325870c9016e883aad5