### PR TITLE
Fix countdown and replay button

### DIFF
--- a/game12/js/gameStates.js
+++ b/game12/js/gameStates.js
@@ -142,7 +142,9 @@ export class PlayerTurnState extends GameState {
         gameEventEmitter.emit('gameStateChanged', GAME_STATES.PLAYER_TURN);
         gameEventEmitter.emit('setMessage', MESSAGES.YOUR_TURN[Math.floor(Math.random() * MESSAGES.YOUR_TURN.length)]);
         gameEventEmitter.emit('setReplayButtonVisible', true); // もう一度ボタンを表示
-        gameEventEmitter.emit('setControlsEnabled', true, ['modeButton', 'resetButton', 'replayButton']); // モード、リセット、リプレイボタンは有効
+        // まずすべてのボタンを有効化した後、必要なもの以外は無効化
+        gameEventEmitter.emit('setControlsEnabled', true);
+        gameEventEmitter.emit('setControlsEnabled', false, ['modeButton', 'resetButton', 'replayButton']); // モード、リセット、リプレイボタンのみ有効
     }
 
     exit() {

--- a/game12/js/uiManager.js
+++ b/game12/js/uiManager.js
@@ -165,9 +165,6 @@ export class UIManager {
             if (count > 0) {
                 this.countdownNumberSpan.textContent = count.toString();
                 this.restartCountdownAnimation();
-            } else if (count === 0) {
-                this.countdownNumberSpan.textContent = 'すたーと！';
-                this.restartCountdownAnimation();
             } else {
                 clearInterval(countdownInterval);
                 this.countdownOverlay.classList.add('hidden');


### PR DESCRIPTION
## Summary
- remove "すたーと!" from countdown so the game starts directly
- enable the replay button when it's shown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688593338c98832593d7e05c651fcdcd