### PR TITLE
feat: make game15 grid responsive

### DIFF
--- a/game15/style.css
+++ b/game15/style.css
@@ -818,13 +818,14 @@ select.form-control {
 .grid {
     display: grid;
     grid-template-columns: repeat(10, 1fr);
+    grid-template-rows: repeat(10, 1fr);
     gap: 1px;
     background-color: var(--color-border);
     border: 2px solid var(--color-border);
     border-radius: var(--radius-base);
     padding: 1px;
-    width: 350px;
-    height: 350px;
+    width: min(90vmin, 350px);
+    aspect-ratio: 1 / 1;
 }
 
 .grid-cell {
@@ -834,7 +835,9 @@ select.form-control {
     justify-content: center;
     cursor: pointer;
     transition: all var(--duration-fast) var(--ease-standard);
-    font-size: var(--font-size-md);
+    aspect-ratio: 1 / 1;
+    line-height: 1;
+    font-size: calc((min(90vmin, 350px) / 10) * 0.8);
     border-radius: var(--radius-sm);
     user-select: none;
 }
@@ -982,12 +985,7 @@ select.form-control {
     .app-container {
         padding: var(--space-12);
     }
-    
-    .grid {
-        width: 320px;
-        height: 320px;
-    }
-    
+
     .app-header h1 {
         font-size: var(--font-size-xl);
     }
@@ -1002,7 +1000,6 @@ select.form-control {
 
     .upper-section {
         height: 40vh;
-        max-height: 400px;
     }
 
     .lower-section {
@@ -1011,18 +1008,8 @@ select.form-control {
 }
 
 @media (max-width: 480px) {
-    .grid {
-        width: 280px;
-        height: 280px;
-    }
-    
-    .grid-cell {
-        font-size: var(--font-size-sm);
-    }
-    
     .upper-section {
         height: 35vh;
-        max-height: 350px;
     }
     
     .lower-section {


### PR DESCRIPTION
## Summary
- expand game15 grid to define rows and remove fixed width/height
- size grid with responsive square container
- keep cells square with dynamic font sizing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9799310448325aa692a1cff992a9b