### PR TITLE
Fix game16 script path to js/app.js

### DIFF
--- a/game16/index.html
+++ b/game16/index.html
@@ -98,6 +98,6 @@
 
   <div id="toast" class="toast" role="status" aria-live="assertive"></div>
 
-  <script type="module" src="assets/js/app.js"></script>
+  <script type="module" src="js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix script tag in game16/index.html to load `js/app.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a97be7922c8325ad1546f0b96715c4