### PR TITLE
Fix addition formula generation in game15

### DIFF
--- a/game15/app.js
+++ b/game15/app.js
@@ -101,7 +101,7 @@ class MultiplicationApp {
         multiplicationFormula.textContent = `${this.selectedRow} × ${this.selectedCol} = ${result}`;
         
         // 足し算式を生成
-        const additionTerms = Array(this.selectedRow).fill(this.selectedCol);
+        const additionTerms = Array(this.selectedCol).fill(this.selectedRow);
         const additionExpression = additionTerms.join(' + ');
         additionFormula.textContent = `${additionExpression} = ${result}`;
     }


### PR DESCRIPTION
## Summary
- Correct addition-term array in game15 to build row-based addition expressions

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node` (custom DOMless script)

------
https://chatgpt.com/codex/tasks/task_e_68a97d2cf54083259e5417e3841e47b0