### PR TITLE
chore: remove html comment from game16 styles

### DIFF
--- a/game16/assets/css/styles.css
+++ b/game16/assets/css/styles.css
@@ -1,4 +1,3 @@
-<!-- ===== FILE: assets/css/styles.css ===== -->
 :root{
   --bg:#0f1222;          /* deep navy */
   --panel:#171a2f;       /* panel dark */


### PR DESCRIPTION
## Summary
- start game16 CSS with `:root` by removing HTML comment header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a97f78d5a48325a76ddb1e7b826024