### PR TITLE
fix: avoid double jump on touch devices

### DIFF
--- a/game16/js/app.js
+++ b/game16/js/app.js
@@ -185,15 +185,11 @@ class Game{
 
   _bindInputs(){
     const onPress = ()=> this.jump();
-    document.addEventListener('touchstart', (e)=>{
+    document.addEventListener('pointerdown', (e)=>{
+      if(e.pointerType==='mouse' && e.button!==0) return;
       if(e.target.closest('#startBtn')) return;
       if(e.target.tagName==='INPUT' || e.target.tagName==='BUTTON') return;
-      onPress();
-    }, {passive:true});
-    document.addEventListener('mousedown', (e)=>{
-      if(e.button!==0) return;
-      if(e.target.closest('#startBtn')) return;
-      if(e.target.tagName==='INPUT' || e.target.tagName==='BUTTON') return;
+      if(e.pointerType==='touch') e.preventDefault();
       onPress();
     });
     document.addEventListener('keydown', (e)=>{


### PR DESCRIPTION
## Summary
- Replace separate touch and mouse handlers with a single `pointerdown` listener
- Prevent duplicate `mousedown` events from triggering extra jumps

## Testing
- `node /tmp/test_pointerdown.js`


------
https://chatgpt.com/codex/tasks/task_e_68a97f834ee48325835a57fb653783b6