### PR TITLE
Add dedicated calibration input handling

### DIFF
--- a/game16/js/app.js
+++ b/game16/js/app.js
@@ -141,6 +141,7 @@ class Game{
     this.hitWindowMsMap = { easy: 120, normal: 80, hard: 55 };
     this.hitWindowMs = this.hitWindowMsMap[this.difficulty];
     this.latencyMs = this.audio.latencyCompMs; // positive means user taps late
+    this.calibrating = false;
 
     // learning stats
     this.statsEnabled = true;
@@ -272,6 +273,7 @@ class Game{
   }
 
   jump(){
+    if(this.calibrating) return;
     if(!this.started || this.paused) return;
     const now = performance.now();
     const nearest = this.metro.nearestBeatTimeMs(now);
@@ -375,16 +377,18 @@ class Game{
   }
 
   async calibrate(){
+    if(this.calibrating) return;
     if(!this.audio.ctx){ await this.audio.ensure(); }
     const bpm = parseInt(document.getElementById('bpm').value,10);
     this.metro.setBpm(bpm);
     const N = 12;
     const samples = [];
     showToast('キャリブレーション：リズムに合わせて12回タップしてください');
+    this.calibrating = true;
     this.metro.start();
     this.started = true; this.paused = false;
 
-    const onTap = (e)=>{
+    const onTap = ()=>{
       const now = performance.now();
       const nearest = this.metro.nearestBeatTimeMs(now);
       samples.push(now - nearest);
@@ -397,9 +401,9 @@ class Game{
     };
     const onTapCap = (e)=>{
       if(e.target.tagName==='INPUT' || e.target.tagName==='BUTTON') return;
-      onTap(e);
+      onTap();
     };
-    const onKey = (e)=>{ if(e.code==='Space'||e.code==='Enter'){ e.preventDefault(); onTap(e);} };
+    const onKey = (e)=>{ if(e.code==='Space'||e.code==='Enter'){ e.preventDefault(); onTap();} };
     document.addEventListener('touchstart', onTapCap, {passive:true});
     document.addEventListener('mousedown', onTap);
     document.addEventListener('keydown', onKey);
@@ -410,6 +414,12 @@ class Game{
       localStorage.setItem(LS.LATENCY, String(this.latencyMs));
       const dropped = samples.length - kept;
       showToast(`補正: ${value.toFixed(0)}ms（中央値${kept>0?`・外れ値${dropped}件除外`:''}）を適用しました`);
+      this.calibrating = false;
+      this.metro.stop();
+      this.started = false;
+      this.reset();
+      document.getElementById('combo').textContent = '0';
+      document.getElementById('judge').textContent = '-';
     };
   }
 }


### PR DESCRIPTION
## Summary
- prevent normal gameplay during calibration by gating jump and combo logic
- add calibration-specific input handling and reset game state when complete

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a97f84a00c8325989654d802f0650d