### PR TITLE
Add background color picker to game23

### DIFF
--- a/game23/index.html
+++ b/game23/index.html
@@ -5,7 +5,7 @@
   <title>こどもむけジグソーパズルゲーム</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- CSSの読み込み -->
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="style.css">
   <!-- Phaser.jsの読み込み（CDN） -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/phaser/3.55.2/phaser.min.js"></script>
 </head>
@@ -22,6 +22,11 @@
         <option value="4x5">20ピース（4×5）</option>
         <option value="6x8">48ピース（6×8）</option>
       </select>
+    </label>
+
+    <label for="bg-color" class="tile-button">
+      うしろのいろをえらんでね
+      <input type="color" id="bg-color" value="#8E24AA">
     </label>
 
     <label for="upload-image" class="tile-button">

--- a/game23/main.js
+++ b/game23/main.js
@@ -10,6 +10,8 @@ let gameHeight = window.innerHeight - 200; // タイトルと余白分高さを�
 let imageKey = '';
 let imageCounter = 0;
 let completedImageURL = ''; // 完成画像のデータURLを保存
+let bgColor = '#8E24AA';
+document.documentElement.style.setProperty('--bg-color', bgColor);
 
 document.getElementById('piece-count').addEventListener('change', function (e) {
   const value = e.target.value;
@@ -40,6 +42,11 @@ document.getElementById('upload-image').addEventListener('change', function (e) 
   }
 });
 
+document.getElementById('bg-color').addEventListener('change', function (e) {
+  bgColor = e.target.value;
+  document.documentElement.style.setProperty('--bg-color', bgColor);
+});
+
 document.getElementById('start-button').addEventListener('click', function () {
   if (selectedImage) {
     document.getElementById('start-screen').style.display = 'none';
@@ -65,7 +72,7 @@ function initGame() {
     width: gameWidth,
     height: gameHeight * 2, // 高さを2倍に設定してスクロール可能に
     parent: 'game-container',
-    backgroundColor: '#8E24AA', // 背景色を紫色に設定
+    backgroundColor: bgColor, // 背景色を設定
     scene: {
       preload: preload,
       create: create
@@ -86,7 +93,7 @@ function create() {
   const scene = this;
 
   // シーン全体の背景色を設定
-  scene.cameras.main.setBackgroundColor('#8E24AA'); // 背景色を紫色に設定
+  scene.cameras.main.setBackgroundColor(bgColor); // 背景色を設定
 
   // 画像を新しいImageオブジェクトとしてロード
   const img = new Image();

--- a/game23/style.css
+++ b/game23/style.css
@@ -1,8 +1,12 @@
+:root {
+  --bg-color: #8E24AA;
+}
+
 body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 0;
-  background-color: #6A1B9A; /* 明るめのパープル */
+  background-color: var(--bg-color); /* 明るめのパープル */
   color: #FFFFFF; /* 白いテキスト */
   overflow: auto; /* 画面をスクロール可能にする */
 }
@@ -26,7 +30,7 @@ body {
   height: auto; /* 高さを自動調整 */
   overflow: visible; /* コンテンツが溢れた場合でも表示 */
   position: relative;
-  background-color: #8E24AA; /* 紫色に近いハロウィンカラー */
+  background-color: var(--bg-color); /* 紫色に近いハロウィンカラー */
 }
 
 /* ボタンコンテナのスタイル */


### PR DESCRIPTION
## Summary
- allow users to choose puzzle background color via color picker
- apply chosen color to body, game container and Phaser scene

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bd9123e883258e5faefcb9548e3e