### PR TITLE
Improve image upload validation and error handling in game23

### DIFF
--- a/game23/main.js
+++ b/game23/main.js
@@ -27,16 +27,26 @@ document.getElementById('piece-count').addEventListener('change', function (e) {
 
 document.getElementById('upload-image').addEventListener('change', function (e) {
   const file = e.target.files[0];
+  const startButton = document.getElementById('start-button');
   if (file && file.size <= 5 * 1024 * 1024) {
-    const reader = new FileReader();
-    reader.onload = function (event) {
-      selectedImage = event.target.result;
-      document.getElementById('start-button').disabled = false;
-    };
-    reader.readAsDataURL(file);
+    if (file.type === 'image/jpeg' || file.type === 'image/png') {
+      const reader = new FileReader();
+      reader.onload = function (event) {
+        selectedImage = event.target.result;
+        startButton.disabled = false;
+      };
+      reader.onerror = function () {
+        alert('画像の読み込みに失敗しました');
+        startButton.disabled = true;
+      };
+      reader.readAsDataURL(file);
+    } else {
+      alert('PNGまたはJPG形式の画像を選択してください。');
+      startButton.disabled = true;
+    }
   } else {
     alert('5MB以下のPNGまたはJPG画像を選択してください。');
-    document.getElementById('start-button').disabled = true;
+    startButton.disabled = true;
   }
 });
 


### PR DESCRIPTION
## Summary
- alert when image file fails to load and disable start button
- enforce PNG/JPEG upload types, disabling start button for other formats

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bd9ee6e08325a5750ba13cc46aa0