### PR TITLE
feat(game23): move background color palette

### DIFF
--- a/game23/index.html
+++ b/game23/index.html
@@ -13,6 +13,9 @@
 
 <!-- スタート画面 -->
 <div id="start-screen">
+  <div id="color-picker">
+    <input type="color" id="bg-color" value="#8E24AA" title="うしろのいろをえらんでね">
+  </div>
   <h1>きょうのジグソーパズル</h1>
   <div class="button-container">
     <label for="piece-count" class="tile-button">
@@ -22,11 +25,6 @@
         <option value="4x5">20ピース（4×5）</option>
         <option value="6x8">48ピース（6×8）</option>
       </select>
-    </label>
-
-    <label for="bg-color" class="tile-button">
-      うしろのいろをえらんでね
-      <input type="color" id="bg-color" value="#8E24AA">
     </label>
 
     <label for="upload-image" class="tile-button">

--- a/game23/style.css
+++ b/game23/style.css
@@ -16,6 +16,10 @@ body {
   padding: 50px;
 }
 
+#start-screen {
+  position: relative;
+}
+
 #game-screen {
   text-align: center;
 }
@@ -116,6 +120,19 @@ body {
   top: 10px;
   right: 10px;
   z-index: 1000;
+}
+
+#color-picker {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+#color-picker input[type="color"] {
+  width: 40px;
+  height: 40px;
+  border: none;
+  padding: 0;
 }
 
 #retry-button {


### PR DESCRIPTION
## Summary
- show background color picker as a small palette in the top right instead of a main menu item
- style color picker and start screen container for absolute positioning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c08b17f083258b92d7f70dc9065f