### PR TITLE
fix: brighten jigsaw canvas

### DIFF
--- a/game23/js/GameManager.js
+++ b/game23/js/GameManager.js
@@ -41,6 +41,7 @@ export class GameManager {
       type: Phaser.AUTO,
       width: this.config.gameWidth,
       height: this.config.gameHeight,
+      backgroundColor: 0xffffff,
       parent: "game-container",
       scene: { preload: () => this.preload(), create: () => this.create() }
     };


### PR DESCRIPTION
## Summary
- set Phaser game background to white so puzzle pieces are visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cf0816c083259166c9a080540a96