### PR TITLE
Remove unused button animation from game23

### DIFF
--- a/game23/js/Effects.js
+++ b/game23/js/Effects.js
@@ -16,10 +16,6 @@ export class Effects {
     this.sounds.clear?.play({ volume: 0.7 });
   }
 
-  animateButton(button) {
-    button.style.animation = 'pulse-glow 2s ease-in-out infinite';
-  }
-
   createNotification(message, type = 'info') {
     const notification = document.createElement('div');
     notification.className = `notification ${type} animate__animated animate__bounceInDown`;


### PR DESCRIPTION
## Summary
- remove unused animateButton from game23 Effects
- ensure no remaining pulse-glow animation references

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d251540c83259489c8ccf40b2380