### PR TITLE
Handle missing elements in game23 UIManager.showScreen

### DIFF
--- a/game23/js/UIManager.js
+++ b/game23/js/UIManager.js
@@ -7,6 +7,7 @@ export class UIManager {
   showScreen(screenId) {
     this.screens.forEach(id => {
       const el = document.getElementById(id);
+      if (!el) return;
       if (id === screenId) {
         el.classList.remove("hidden");
       } else {


### PR DESCRIPTION
## Summary
- Prevent UIManager.showScreen from manipulating `classList` on missing elements.

## Testing
- `node --input-type=module <<'NODE'\nimport { UIManager } from './game23/js/UIManager.js';\n\n...\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_68a9d253f3988325a795969f752f0852