### PR TITLE
Ensure remaining piece counter updates when game starts

### DIFF
--- a/game23/js/GameManager.js
+++ b/game23/js/GameManager.js
@@ -31,6 +31,7 @@ export class GameManager {
   startGame() {
     if (!this.gameState.selectedImage) return;
     this.gameState.remainingPieces = this.gameState.rows * this.gameState.cols;
+    this.uiManager.updateRemainingPieces(this.gameState.remainingPieces);
     this.uiManager.showScreen("game-screen");
     this.initPhaserGame();
   }


### PR DESCRIPTION
## Summary
- update GameManager to refresh remaining piece counter before showing the game screen so the total is correct immediately

## Testing
- `node --input-type=module <script>`


------
https://chatgpt.com/codex/tasks/task_e_68a9d257919483258314db0617e5fa40