### PR TITLE
Fix puzzle piece interactivity after placement

### DIFF
--- a/game23/js/GameManager.js
+++ b/game23/js/GameManager.js
@@ -92,6 +92,8 @@ export class GameManager {
       if (dist < this.config.snapDistance) {
         gameObject.x = gameObject.correctX;
         gameObject.y = gameObject.correctY;
+        gameObject.disableInteractive();
+        scene.input.setDraggable(gameObject, false);
         this.effects.playPlaceSound();
         this.uiManager.updateRemainingPieces(--this.gameState.remainingPieces);
         if (this.gameState.remainingPieces === 0) this.handleClear(scene);


### PR DESCRIPTION
## Summary
- Disable interaction and dragging for puzzle pieces once snapped into place

## Testing
- `node --check game23/js/GameManager.js && echo "syntax ok"`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d25a277c8325a25d15a018b1f3f6