### PR TITLE
Add Nunito Google Font to game23

### DIFF
--- a/game23/index.html
+++ b/game23/index.html
@@ -5,6 +5,8 @@
   <title>きょうのジグソーパズル ✨ Special Edition</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap" rel="stylesheet">
+
   <!-- Tailwind & Phaser -->
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/phaser/3.55.2/phaser.min.js"></script>


### PR DESCRIPTION
## Summary
- include Nunito Google Font in game23 puzzle's HTML head to enable custom typography

## Testing
- `curl -L 'https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap' | head`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d264edcc8325986c974e14790c8e