### PR TITLE
feat(game23): unify light background color

### DIFF
--- a/game23/main.js
+++ b/game23/main.js
@@ -83,7 +83,8 @@ function initGame() {
     width: gameWidth,
     height: gameHeight * 2, // スクロール可能
     parent: 'game-container',
-    backgroundColor: '#00000000', // CSS背景と調和させる
+    // 明るい背景色でCSSの --bg と調和させる
+    backgroundColor: 0xf9fbff,
     scene: { preload, create }
   };
   new Phaser.Game(config);
@@ -97,7 +98,8 @@ function preload() {
 
 function create() {
   const scene = this;
-  scene.cameras.main.setBackgroundColor('#00000000');
+  // ゲーム全体の背景色を統一
+  scene.cameras.main.setBackgroundColor(0xf9fbff);
 
   const img = new Image();
   img.onload = function () {


### PR DESCRIPTION
## Summary
- use light 0xf9fbff background in Phaser config to match CSS theme
- set camera background to same color for consistent game visuals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa65494458832591f5aa5f4b6a04dc