### PR TITLE
Add subtle outline to puzzle pieces

### DIFF
--- a/game23/main.js
+++ b/game23/main.js
@@ -177,6 +177,9 @@ function create() {
           pieceWidth / scale, pieceHeight / scale,
           0, 0, pieceWidth, pieceHeight
         );
+        cctx.strokeStyle = 'rgba(0,0,0,0.2)';
+        cctx.lineWidth = 0.5;          // 極細ライン
+        cctx.strokeRect(0, 0, pieceWidth, pieceHeight);
         canvasTexture.refresh();
 
         const piece = scene.add.image(0, 0, pieceTextureKey);


### PR DESCRIPTION
## Summary
- Draw semi-transparent stroke around each puzzle piece to improve visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa654b005c83258684ee02daa669a0