### PR TITLE
game24: introduce controls container before presets

### DIFF
--- a/game24/app.js
+++ b/game24/app.js
@@ -15,7 +15,6 @@ const initial = loadFromHash() ?? defaultState;
 const store = createStore(initial);
 
 const stageEl = document.getElementById("stage");
-const panelEl = document.getElementById("panel");
 const tipsEl = document.getElementById("tips");
 const badge = document.getElementById("badge-over");
 
@@ -126,7 +125,7 @@ store.subscribe((state) => {
 });
 
 // UI
-const pane = initPanel(panelEl, store, {
+const pane = initPanel(document.getElementById("controls"), store, {
   onRandomColors: () => store.replaceState(randomColorsOnly(store.getState())),
   onRandomAll: () => store.replaceState(randomAll(store.getState())),
   onPreset: (presetState) => store.replaceState(presetState),

--- a/game24/index.html
+++ b/game24/index.html
@@ -19,7 +19,7 @@
     </main>
     <aside id="panel" aria-label="コントロールパネル">
       <div id="badge-over">高負荷モード：アニメOFFで表示中</div>
-      <!-- Tweakpane mounts here -->
+      <div id="controls"></div>
       <div id="preset-gallery"></div>
       <div class="savebar">
         <label>倍率

--- a/game24/styles/main.css
+++ b/game24/styles/main.css
@@ -65,6 +65,10 @@ body { background: var(--bg); color: var(--text);
 }
 #badge-over.show { display: block; }
 
+#controls {
+  margin-bottom: 12px;
+}
+
 .preset-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
## Summary
- add a dedicated `#controls` element after the over-budget badge so controls appear before the preset gallery
- mount the panel using `document.getElementById("controls")` instead of the entire panel element
- give `#controls` bottom margin to separate it from following sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aac76e23e883258d74f20622e99304