### PR TITLE
Add blend mode selection to game24

### DIFF
--- a/game24/modules/presets.js
+++ b/game24/modules/presets.js
@@ -15,15 +15,15 @@ export const presets = {
   "やさしい虹": {
     ...defaultState,
     N: 48,
-    layers: [ { k: 17, width: 1.2, alpha: 1.0, color: { type:"gradient", from:"#FFD76A", to:"#2F6BFF"} } ],
+    layers: [ { k: 17, width: 1.2, alpha: 1.0, color: { type:"gradient", from:"#FFD76A", to:"#2F6BFF"}, blend:"normal" } ],
     bg: "#111111"
   },
   "光の花": {
     ...defaultState,
     N: 96,
     layers: [
-      { k: 31, width: 0.8, alpha: 1.0, color: { type:"solid", value:"#FF66CC"} },
-      { k: 25, width: 0.5, alpha: 0.9, color: { type:"solid", value:"#66FFCC"} }
+      { k: 31, width: 0.8, alpha: 1.0, color: { type:"solid", value:"#FF66CC"}, blend:"normal" },
+      { k: 25, width: 0.5, alpha: 0.9, color: { type:"solid", value:"#66FFCC"}, blend:"normal" }
     ],
     bg: "#0F0F12"
   },
@@ -36,13 +36,13 @@ export const presets = {
   "幾何校章": {
     ...defaultState,
     N: 60,
-    layers: [ { k: 12, width: 2.0, alpha: 1.0, color: { type:"solid", value:"#F2F2F2"} } ],
+    layers: [ { k: 12, width: 2.0, alpha: 1.0, color: { type:"solid", value:"#F2F2F2"}, blend:"normal" } ],
     bg: "#202020"
   },
   "深海ブルー": {
     ...defaultState,
     N: 64,
-    layers: [ { k: 21, width: 1.0, alpha: 1.0, color: { type:"gradient", from:"#0AA9FF", to:"#022C43"} } ],
+    layers: [ { k: 21, width: 1.0, alpha: 1.0, color: { type:"gradient", from:"#0AA9FF", to:"#022C43"}, blend:"normal" } ],
     bg: "#000000"
   }
 };

--- a/game24/modules/render.js
+++ b/game24/modules/render.js
@@ -30,12 +30,14 @@ export function createPixiApp(container) {
 
 export function buildLayer(pins, seq, spec) {
   const g = new PIXI.Graphics();
+  g.blendMode = PIXI.BLEND_MODES[spec.blend?.toUpperCase?.() || "NORMAL"];
   return { g, pins, seq, style: spec, tMax: 1 };
 }
 
 export function drawLayer(rt, animated) {
   const { g, pins, seq, style, tMax } = rt;
   g.clear();
+  g.blendMode = PIXI.BLEND_MODES[style.blend?.toUpperCase?.() || "NORMAL"];
   const width = style.width;
   const L = Math.min(tMax, seq.length - 1);
   if (L <= 0) return;

--- a/game24/modules/ui.js
+++ b/game24/modules/ui.js
@@ -21,10 +21,20 @@ export function initPanel(container, store, handlers) {
     fLayers.children.forEach(c => fLayers.remove(c));
     const st = store.getState();
     st.layers.forEach((layer, idx) => {
-      const fd = fLayers.addFolder({ title: `Layer ${idx+1}` });
-      const ctrlK = fd.addInput(layer, "k", { label: "歩幅 k", min: 1, max: Math.max(1, st.N-1), step: 1 });
-      const ctrlW = fd.addInput(layer, "width", { label: "線幅", min: 0.3, max: 6.0, step: 0.1 });
-      const ctrlA = fd.addInput(layer, "alpha", { label: "透明度", min: 0.1, max: 1.0, step: 0.05 });
+        const fd = fLayers.addFolder({ title: `Layer ${idx+1}` });
+        const ctrlK = fd.addInput(layer, "k", { label: "歩幅 k", min: 1, max: Math.max(1, st.N-1), step: 1 });
+        const ctrlW = fd.addInput(layer, "width", { label: "線幅", min: 0.3, max: 6.0, step: 0.1 });
+        const ctrlA = fd.addInput(layer, "alpha", { label: "透明度", min: 0.1, max: 1.0, step: 0.05 });
+        const ctrlB = fd.addInput(layer, "blend", {
+          label: "ブレンド",
+          options: {
+            通常: "normal",
+            加算: "add",
+            乗算: "multiply",
+            スクリーン: "screen",
+            ライト: "lighter",
+          },
+        });
       // 色：簡易（単色/グラデ/パレットを直接JSON編集する代わりに3ボタン）
       const grp = fd.addFolder({ title: "色" });
       grp.addButton({ title: "単色: 白" }).on("click", ()=> patch(idx, { color: { type:"solid", value:"#F2F2F2" } }));
@@ -32,9 +42,10 @@ export function initPanel(container, store, handlers) {
       grp.addButton({ title: "パレット: Aurora" }).on("click", ()=> patch(idx, { color: { type:"palette", name:"aurora" } }));
       fd.addButton({ title: "削除" }).on("click", () => removeLayer(idx));
 
-      ctrlK.on("change", ev => patch(idx, { k: ev.value }));
-      ctrlW.on("change", ev => patch(idx, { width: ev.value }));
-      ctrlA.on("change", ev => patch(idx, { alpha: ev.value }));
+        ctrlK.on("change", ev => patch(idx, { k: ev.value }));
+        ctrlW.on("change", ev => patch(idx, { width: ev.value }));
+        ctrlA.on("change", ev => patch(idx, { alpha: ev.value }));
+        ctrlB.on("change", ev => patch(idx, { blend: ev.value }));
     });
     fLayers.addButton({ title: "＋ 追加" }).on("click", addLayer);
   }
@@ -46,7 +57,7 @@ export function initPanel(container, store, handlers) {
   function addLayer() {
     const st = store.getState();
     if (st.layers.length >= 3) return;
-    const base = st.layers[st.layers.length-1] ?? { k:17, width:1.2, alpha:1.0, color:{ type:"gradient", from:"#FFD76A", to:"#2F6BFF"} };
+      const base = st.layers[st.layers.length-1] ?? { k:17, width:1.2, alpha:1.0, color:{ type:"gradient", from:"#FFD76A", to:"#2F6BFF"}, blend:"normal" };
     const layer = { ...base, k: Math.min(st.N-1, base.k + 4) };
     store.setState({ layers: [...st.layers, layer] });
   }


### PR DESCRIPTION
## Summary
- use `style.blend` to set `PIXI.BLEND_MODES` during layer build and draw
- add UI control to choose blend mode per layer
- ensure presets define a blend mode for each layer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aac7708fac83258b45dc0cb523c043