### PR TITLE
refactor: drop unused pane variable

### DIFF
--- a/game24/app.js
+++ b/game24/app.js
@@ -125,7 +125,7 @@ store.subscribe((state) => {
 });
 
 // UI
-const pane = initPanel(document.getElementById("controls"), store, {
+initPanel(document.getElementById("controls"), store, {
   onRandomColors: () => store.replaceState(randomColorsOnly(store.getState())),
   onRandomAll: () => store.replaceState(randomAll(store.getState())),
   onPreset: (presetState) => store.replaceState(presetState),


### PR DESCRIPTION
## Summary
- remove unused `pane` variable when initializing controls in game24

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aac9669ed88325b0e7f518cca56400