### PR TITLE
Handle null blob when exporting canvas

### DIFF
--- a/game24/app.js
+++ b/game24/app.js
@@ -139,12 +139,16 @@ mountPresetGallery(document.getElementById("preset-gallery"), (name) => {
 document.getElementById("btn-save").addEventListener("click", async () => {
   const scale = Number(document.getElementById("save-scale").value || 2);
   const transparent = document.getElementById("save-transparent").checked;
-  const blob = await exportPNG(pixi.app, store.getState(), scale, transparent);
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url; a.download = "itokake.png"; a.click();
-  URL.revokeObjectURL(url);
-  toast("PNGを書き出しました");
+  try {
+    const blob = await exportPNG(pixi.app, store.getState(), scale, transparent);
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url; a.download = "itokake.png"; a.click();
+    URL.revokeObjectURL(url);
+    toast("PNGを書き出しました");
+  } catch (err) {
+    alert("PNGの書き出しに失敗しました: " + (err && err.message ? err.message : err));
+  }
 });
 document.getElementById("btn-share").addEventListener("click", async () => {
   try { await navigator.clipboard.writeText(location.href); toast("共有リンクをコピーしました"); }

--- a/game24/modules/export.js
+++ b/game24/modules/export.js
@@ -39,6 +39,7 @@ export async function exportPNG(app, state, scale=2, transparent=false) {
   app.renderer.render(root, { renderTexture: rt, clear: true });
   const cvs = app.renderer.extract.canvas(rt);
   const blob = await new Promise(res => cvs.toBlob(b => res(b), "image/png"));
+  if (!blob) throw new Error("Canvas toBlob() returned null");
   rt.destroy(true);
   root.destroy({ children:true });
   return blob;


### PR DESCRIPTION
## Summary
- Guard against `canvas.toBlob()` returning null in PNG export
- Alert users when save operation fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aac969afb88325843e3b1ecff1b09d