### PR TITLE
Allow configurable preview position in game23

### DIFF
--- a/game23/index.html
+++ b/game23/index.html
@@ -32,6 +32,17 @@
       </select>
     </label>
 
+    <label for="preview-position" class="tile-button">
+      みほんのいちをえらんでね
+      <div id="preview-position-display" class="piece-count-display">した</div>
+      <select id="preview-position" aria-label="見本画像の配置を選ぶ">
+        <option value="bottom">した</option>
+        <option value="right">みぎ</option>
+        <option value="left">ひだり</option>
+        <option value="top">うえ</option>
+      </select>
+    </label>
+
     <label for="upload-image" class="tile-button">
       がぞうをいれる
       <input type="file" id="upload-image" accept="image/png, image/jpeg" aria-label="画像を選ぶ">


### PR DESCRIPTION
## Summary
- allow choosing reference image position
- update puzzle layout logic accordingly

## Testing
- `node --check game23/main.js`

------
https://chatgpt.com/codex/tasks/task_e_68abd42f25288325af7a65040df36a45