### PR TITLE
Move multiplier animation controls near multiplier slider

### DIFF
--- a/game24/index.html
+++ b/game24/index.html
@@ -103,6 +103,10 @@
       <div class="row"><label>乗数 (multiplier)</label><div class="val"><span id="mulVal">2.000</span></div></div>
       <input type="range" id="mul" min="0" max="20" step="0.001" value="2"/>
 
+      <div class="row"><label class="toggle"><input type="checkbox" id="animate"> 乗数をアニメーション</label><div class="val"></div></div>
+      <div class="row"><label>速度</label><div class="val"><span id="speedVal">0.06</span></div></div>
+      <input type="range" id="speed" min="0.005" max="0.2" step="0.005" value="0.06"/>
+
       <div class="cols">
         <div>
           <div class="row"><label>オフセット</label><div class="val"><span id="offVal">0</span></div></div>
@@ -174,9 +178,6 @@
         <button class="btn primary" id="redraw">再描画</button>
         <button class="btn" id="save">PNG保存</button>
       </div>
-      <div class="row"><label class="toggle"><input type="checkbox" id="animate"> 乗数をアニメーション</label><div class="val"></div></div>
-      <div class="row"><label>速度</label><div class="val"><span id="speedVal">0.06</span></div></div>
-      <input type="range" id="speed" min="0.005" max="0.2" step="0.005" value="0.06"/>
     </div>
 
     <div class="group">


### PR DESCRIPTION
## Summary
- Reposition `#animate` checkbox and `#speed` slider to the Pattern group right after the multiplier control.
- Remove animation controls from the Color & Drawing section to keep related settings together.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dd8fad60832585c55ed0ce60d0fa