### PR TITLE
Move line width control to color section

### DIFF
--- a/game24/index.html
+++ b/game24/index.html
@@ -117,9 +117,6 @@
       <div class="row"><label>ステップ（扇の開き）</label><div class="val"><span id="stepVal">1</span></div></div>
       <input type="range" id="fanStep" min="1" max="400" step="1" value="1"/>
 
-      <div class="row"><label>線の太さ</label><div class="val"><span id="lwVal">0.65</span>px</div></div>
-      <input type="range" id="lw" min="0.2" max="2.0" step="0.05" value="0.65"/>
-
       <div class="cols">
         <div class="row"><label class="toggle"><input type="checkbox" id="solo"> ソロモード</label><div class="val"></div></div>
         <div class="row"><label class="toggle"><input type="checkbox" id="skipSame"> 同一辺への接続を避ける</label><div class="val"></div></div>
@@ -167,6 +164,8 @@
         <div>
           <div class="row"><label>不透明度</label><div class="val"><span id="alphaVal">0.65</span></div></div>
           <input type="range" id="alpha" min="0.05" max="1" step="0.05" value="0.65"/>
+          <div class="row"><label>線の太さ</label><div class="val"><span id="lwVal">0.65</span>px</div></div>
+          <input type="range" id="lw" min="0.2" max="2.0" step="0.05" value="0.65"/>
         </div>
         <div class="row"><label class="toggle"><input type="checkbox" id="glow" checked> 軽いグロー</label><div class="val"></div></div>
       </div>


### PR DESCRIPTION
## Summary
- Move line width slider from pattern parameters to color and drawing section.
- Group line width with opacity and other drawing settings.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dd90c1dc8325b06724175e932caf