### PR TITLE
Add all-category quote selection button

### DIFF
--- a/game21/app.js
+++ b/game21/app.js
@@ -212,8 +212,11 @@ const quoteText = document.getElementById('quoteText');
 const quoteAuthor = document.getElementById('quoteAuthor');
 const quoteExplanation = document.getElementById('quoteExplanation');
 
+let currentCategory = null;
+
 // カテゴリ別の使用済み名言のインデックスを追跡
 let usedQuotesByCategory = {};
+let usedQuotesAll = [];
 
 // 指定されたカテゴリからランダムな名言を取得する関数
 function getRandomQuoteByCategory(category) {
@@ -252,7 +255,35 @@ function getRandomQuoteByCategory(category) {
     quote.quote === selectedQuote.quote && quote.author === selectedQuote.author
   );
   usedQuotesByCategory[category].push(originalIndex);
-  
+
+  return selectedQuote;
+}
+
+// 全てのカテゴリからランダムな名言を取得する関数
+function getRandomQuoteAll() {
+  if (quotesData.quotes.length === 0) {
+    return null;
+  }
+
+  // 全ての名言を使い切った場合はリセット
+  if (usedQuotesAll.length >= quotesData.quotes.length) {
+    usedQuotesAll = [];
+  }
+
+  // 未使用の名言を取得
+  let availableQuotes = quotesData.quotes.filter((quote, index) => {
+    return !usedQuotesAll.includes(index);
+  });
+
+  const randomIndex = Math.floor(Math.random() * availableQuotes.length);
+  const selectedQuote = availableQuotes[randomIndex];
+
+  // 使用済みリストに追加
+  const originalIndex = quotesData.quotes.findIndex(q =>
+    q.quote === selectedQuote.quote && q.author === selectedQuote.author
+  );
+  usedQuotesAll.push(originalIndex);
+
   return selectedQuote;
 }
 
@@ -290,13 +321,19 @@ function pulseButton(button) {
 sceneButtons.forEach(button => {
   button.addEventListener('click', () => {
     const category = button.getAttribute('data-category');
-    
+    currentCategory = category;
+
     // ボタンアニメーション
     pulseButton(button);
-    
+
     // 少し遅延してから名言を表示
     setTimeout(() => {
-      const randomQuote = getRandomQuoteByCategory(category);
+      let randomQuote;
+      if (category === 'all') {
+        randomQuote = getRandomQuoteAll();
+      } else {
+        randomQuote = getRandomQuoteByCategory(category);
+      }
       if (randomQuote) {
         displayQuote(randomQuote);
       }

--- a/game21/index.html
+++ b/game21/index.html
@@ -70,6 +70,11 @@
                     <span class="button-icon">🌿</span>
                     自然体験
                 </button>
+
+                <button class="btn btn--scene btn--all" data-category="all">
+                    <span class="button-icon">🎲</span>
+                    おまかせ
+                </button>
             </div>
         </main>
     </div>


### PR DESCRIPTION
## Summary
- Add "おまかせ" button to display random quotes from all categories
- Track current category and previously used quotes across entire dataset
- Support random quote retrieval across all categories via new helper

## Testing
- `node --check game21/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e2cc1fe48325b5829cc95d2ef252