### PR TITLE
feat: simplify controls with easy mode

### DIFF
--- a/game24/index.html
+++ b/game24/index.html
@@ -101,7 +101,7 @@
       <div class="row"><label class="toggle"><input type="checkbox" id="showPins"> ピンを表示</label><div class="val"></div></div>
     </div>
 
-    <div class="group">
+    <div class="group advanced">
       <h2>パターン（周回インデックス）</h2>
       <p class="desc">ピンを長方形の外周に並べ、<em>i</em>番ピンから <em>(i × 乗数 + オフセット)</em> 番へ線を結びます。扇出しは「本数」と「ステップ」で制御。</p>
       <div class="row"><label>乗数 (multiplier)</label><div class="val"><span id="mulVal">2.000</span></div></div>
@@ -138,7 +138,7 @@
       </div>
     </div>
 
-    <div class="group">
+    <div class="group advanced">
       <h2>色と描画</h2>
       <div class="row"><label>色モード</label>
         <select id="colorMode" class="btn">
@@ -251,12 +251,52 @@
     t: 0,
   };
 
+  const saved = {};
+  const easyDefaults = {
+    mul: 2,
+    offset: 0,
+    fan: 1,
+    fanStep: 1,
+    colorMode: 'solid',
+    hue: 200,
+    span: 180,
+    sat: 85,
+    lit: 65,
+    alpha: 0.65,
+    lw: 0.65,
+    glow: true,
+    animate: false,
+    speed: 0.06,
+    solo: false,
+    selected: 0,
+    skipSame: false,
+  };
+
   // Utility: map value
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 function lerp(a,b,t){return a+(b-a)*t}
 
   function applyMode(){
     const simple = ui.easy.checked;
+    document.querySelectorAll('.advanced').forEach(el => {
+      el.style.display = simple ? 'none' : '';
+    });
+    if(simple){
+      for(const k in easyDefaults){
+        const el = ui[k];
+        if(!el) continue;
+        saved[k] = el.type === 'checkbox' ? el.checked : el.value;
+        if(el.type === 'checkbox') el.checked = easyDefaults[k];
+        else el.value = easyDefaults[k];
+      }
+    } else {
+      for(const k in saved){
+        const el = ui[k];
+        if(!el) continue;
+        if(el.type === 'checkbox') el.checked = saved[k];
+        else el.value = saved[k];
+      }
+    }
     if(simple){
       ui.resX.min = ui.resY.min = 100;
       ui.resX.max = ui.resY.max = 2000;
@@ -278,6 +318,7 @@ function lerp(a,b,t){return a+(b-a)*t}
     ui.resYVal.textContent = ui.resY.value;
     ui.nxVal.textContent = ui.pinsX.value;
     ui.nyVal.textContent = ui.pinsY.value;
+    ui.animate.dispatchEvent(new Event('change'));
   }
 
   function sizeCanvas(){


### PR DESCRIPTION
## Summary
- Hide advanced parameter groups when easy mode is enabled
- Restore user settings when easy mode is disabled and apply sensible defaults

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e32b4e208325bd47ecf5e2b76b6e