### PR TITLE
Add documentation pages and help links for game24 parameters

### DIFF
--- a/game24/docs/animation.html
+++ b/game24/docs/animation.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Animation</title>
+<style>
+body{font-family:sans-serif;background:#0b0d10;color:#e6edf3;padding:20px}
+svg{background:#111;border:1px solid #333}
+a{color:#91caff}
+</style>
+</head>
+<body>
+<h1>Multiplier Animation</h1>
+<p>The <strong>Animate Multiplier</strong> checkbox makes the multiplier value oscillate automatically. The <strong>Speed</strong> slider controls how quickly it cycles.</p>
+<svg width="220" height="80">
+  <path d="M10 40 Q55 10 100 40 T190 40" stroke="#6ee7ff" stroke-width="2" fill="none" />
+  <circle cx="10" cy="40" r="4" fill="#f472b6">
+    <animate attributeName="cx" values="10;190;10" dur="2s" repeatCount="indefinite" />
+  </circle>
+</svg>
+<p>The dot moves along a wave to illustrate the cycling multiplier.</p>
+<p><a href="index.html">Documentation index</a> | <a href="../index.html">Back to game</a></p>
+</body>
+</html>

--- a/game24/docs/color.html
+++ b/game24/docs/color.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Color and Drawing</title>
+<style>
+body{font-family:sans-serif;background:#0b0d10;color:#e6edf3;padding:20px}
+svg{background:#111;border:1px solid #333}
+a{color:#91caff}
+</style>
+</head>
+<body>
+<h1>Color and Drawing</h1>
+<p>This section explains the appearance controls:</p>
+<ul>
+  <li><strong>Color Mode</strong> – choose between solid color or gradients.</li>
+  <li><strong>Hue Base / Span</strong> – define gradient hues.</li>
+  <li><strong>Saturation</strong> and <strong>Lightness</strong> – adjust HSL values.</li>
+  <li><strong>Opacity</strong> – overall transparency of lines.</li>
+  <li><strong>Line Width</strong> – thickness of the strings.</li>
+  <li><strong>Glow</strong> – adds a subtle blur for a glowing effect.</li>
+</ul>
+<svg width="220" height="120">
+  <line x1="10" y1="30" x2="210" y2="30" stroke="#6ee7ff" stroke-width="2" />
+  <line x1="10" y1="60" x2="210" y2="60" stroke="#6ee7ff" stroke-width="6" stroke-opacity="0.5" />
+  <line x1="10" y1="90" x2="210" y2="90" stroke="#6ee7ff" stroke-width="2" filter="url(#g)" />
+  <defs>
+    <filter id="g" x="-20" y="-20" width="240" height="160">
+      <feGaussianBlur stdDeviation="2" result="b" />
+      <feMerge>
+        <feMergeNode in="b" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+</svg>
+<p>Examples of different line widths, opacities and glow.</p>
+<p><a href="index.html">Documentation index</a> | <a href="../index.html">Back to game</a></p>
+</body>
+</html>

--- a/game24/docs/easy.html
+++ b/game24/docs/easy.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Easy Mode</title>
+<style>
+body{font-family:sans-serif;background:#0b0d10;color:#e6edf3;padding:20px}
+.example{margin-top:16px;display:flex;gap:20px}
+.example div{flex:1;text-align:center}
+.example svg{background:#111;border:1px solid #333}
+a{color:#91caff}
+</style>
+</head>
+<body>
+<h1>Easy Mode</h1>
+<p>The <strong>Easy Mode</strong> checkbox simplifies the controls by restricting ranges for resolution and pin counts. This helps when exploring without needing fine tuning.</p>
+<div class="example">
+  <div>
+    <svg width="120" height="80">
+      <rect x="10" y="10" width="100" height="60" fill="#222" stroke="#6ee7ff" />
+      <text x="60" y="45" fill="#fff" font-size="10" text-anchor="middle">Easy</text>
+    </svg>
+    <p>Limited ranges</p>
+  </div>
+  <div>
+    <svg width="120" height="80">
+      <rect x="5" y="5" width="110" height="70" fill="#222" stroke="#f472b6" />
+      <text x="60" y="45" fill="#fff" font-size="10" text-anchor="middle">Normal</text>
+    </svg>
+    <p>Full control</p>
+  </div>
+</div>
+<p><a href="index.html">Documentation index</a> | <a href="../index.html">Back to game</a></p>
+</body>
+</html>

--- a/game24/docs/fan.html
+++ b/game24/docs/fan.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Fan Settings</title>
+<style>
+body{font-family:sans-serif;background:#0b0d10;color:#e6edf3;padding:20px}
+svg{background:#111;border:1px solid #333}
+a{color:#91caff}
+</style>
+</head>
+<body>
+<h1>Fan Settings</h1>
+<p><strong>Lines per Pin</strong> and <strong>Fan Step</strong> control the small fan of lines that spread from each selected pin.</p>
+<svg width="200" height="140" viewBox="0 0 200 140">
+  <rect x="10" y="10" width="180" height="120" fill="#222" stroke="#6ee7ff" />
+  <circle cx="100" cy="70" r="3" fill="#f472b6" />
+  <line x1="100" y1="70" x2="180" y2="20" stroke="#a78bfa" />
+  <line x1="100" y1="70" x2="180" y2="70" stroke="#a78bfa" />
+  <line x1="100" y1="70" x2="180" y2="120" stroke="#a78bfa" />
+</svg>
+<p>Increasing the fan count or step spreads the lines wider.</p>
+<p><a href="index.html">Documentation index</a> | <a href="../index.html">Back to game</a></p>
+</body>
+</html>

--- a/game24/docs/index.html
+++ b/game24/docs/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Documentation</title>
+<style>
+body{font-family:sans-serif;background:#0b0d10;color:#e6edf3;padding:20px}
+ul{line-height:1.6}
+a{color:#91caff}
+</style>
+</head>
+<body>
+<h1>Parameter Reference</h1>
+<ul>
+  <li><a href="easy.html">Easy Mode</a></li>
+  <li><a href="resolution.html">Canvas Resolution</a></li>
+  <li><a href="pins.html">Pins and Margin</a></li>
+  <li><a href="multiplier.html">Multiplier</a></li>
+  <li><a href="animation.html">Multiplier Animation</a></li>
+  <li><a href="offset.html">Offset</a></li>
+  <li><a href="fan.html">Fan Settings</a></li>
+  <li><a href="solo.html">Solo Mode & Selection</a></li>
+  <li><a href="color.html">Color and Drawing</a></li>
+</ul>
+<p><a href="../index.html">Back to game</a></p>
+</body>
+</html>

--- a/game24/docs/multiplier.html
+++ b/game24/docs/multiplier.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Multiplier</title>
+<style>
+body{font-family:sans-serif;background:#0b0d10;color:#e6edf3;padding:20px}
+svg{background:#111;border:1px solid #333}
+a{color:#91caff}
+</style>
+</head>
+<body>
+<h1>Multiplier</h1>
+<p>The <strong>Multiplier</strong> value determines how far along the pin list to connect from each pin. For pin <em>i</em>, the line is drawn to pin <em>(i × multiplier + offset)</em>.</p>
+<svg width="200" height="140" viewBox="0 0 200 140">
+  <rect x="10" y="10" width="180" height="120" fill="#222" stroke="#6ee7ff" />
+  <circle cx="10" cy="10" r="3" fill="#f472b6" />
+  <circle cx="190" cy="10" r="3" fill="#f472b6" />
+  <circle cx="190" cy="130" r="3" fill="#f472b6" />
+  <circle cx="10" cy="130" r="3" fill="#f472b6" />
+  <line x1="10" y1="10" x2="190" y2="130" stroke="#a78bfa" />
+</svg>
+<p>Here a multiplier of 2 links the first pin to one halfway around the perimeter.</p>
+<p><a href="index.html">Documentation index</a> | <a href="../index.html">Back to game</a></p>
+</body>
+</html>

--- a/game24/docs/offset.html
+++ b/game24/docs/offset.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Offset</title>
+<style>
+body{font-family:sans-serif;background:#0b0d10;color:#e6edf3;padding:20px}
+svg{background:#111;border:1px solid #333}
+a{color:#91caff}
+</style>
+</head>
+<body>
+<h1>Offset</h1>
+<p>The <strong>Offset</strong> slider shifts the destination pin by a constant amount before applying the multiplier. This rotates the pattern around the perimeter.</p>
+<svg width="200" height="140" viewBox="0 0 200 140">
+  <rect x="10" y="10" width="180" height="120" fill="#222" stroke="#6ee7ff" />
+  <circle cx="10" cy="10" r="3" fill="#f472b6" />
+  <circle cx="190" cy="10" r="3" fill="#f472b6" />
+  <circle cx="190" cy="130" r="3" fill="#f472b6" />
+  <circle cx="10" cy="130" r="3" fill="#f472b6" />
+  <line x1="10" y1="10" x2="190" y2="10" stroke="#a78bfa" />
+</svg>
+<p>With a positive offset the first pin connects further along the perimeter.</p>
+<p><a href="index.html">Documentation index</a> | <a href="../index.html">Back to game</a></p>
+</body>
+</html>

--- a/game24/docs/pins.html
+++ b/game24/docs/pins.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Pins and Margin</title>
+<style>
+body{font-family:sans-serif;background:#0b0d10;color:#e6edf3;padding:20px}
+svg{background:#111;border:1px solid #333}
+a{color:#91caff}
+</style>
+</head>
+<body>
+<h1>Pins and Margin</h1>
+<p>This page covers the controls under <em>Board and Pins</em>:</p>
+<ul>
+  <li><strong>Pin Count X/Y</strong> – how many pins are placed along each side.</li>
+  <li><strong>Inner Margin</strong> – space from canvas edge to pins.</li>
+  <li><strong>Pin Radius</strong> – size of the pin markers.</li>
+  <li><strong>Show Pins</strong> – toggles pin visibility.</li>
+</ul>
+<svg width="200" height="140">
+  <rect x="20" y="20" width="160" height="100" fill="#222" stroke="#6ee7ff" />
+  <!-- pins -->
+  <circle cx="20" cy="20" r="4" fill="#f472b6" />
+  <circle cx="180" cy="20" r="4" fill="#f472b6" />
+  <circle cx="180" cy="120" r="4" fill="#f472b6" />
+  <circle cx="20" cy="120" r="4" fill="#f472b6" />
+</svg>
+<p>The diagram shows a margin pushing the pins inward from the canvas edges.</p>
+<p><a href="index.html">Documentation index</a> | <a href="../index.html">Back to game</a></p>
+</body>
+</html>

--- a/game24/docs/resolution.html
+++ b/game24/docs/resolution.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Canvas Resolution</title>
+<style>
+body{font-family:sans-serif;background:#0b0d10;color:#e6edf3;padding:20px}
+.example{margin-top:16px;display:flex;gap:20px}
+.example div{flex:1;text-align:center}
+.example svg{background:#111;border:1px solid #333}
+a{color:#91caff}
+</style>
+</head>
+<body>
+<h1>Canvas Resolution</h1>
+<p>The <strong>Canvas Width</strong> and <strong>Canvas Height</strong> sliders control the pixel resolution of the drawing area. Higher values produce sharper exports but require more processing.</p>
+<div class="example">
+  <div>
+    <svg width="120" height="80">
+      <rect x="10" y="10" width="100" height="60" fill="#222" stroke="#6ee7ff" stroke-width="1" />
+      <text x="60" y="45" fill="#fff" font-size="10" text-anchor="middle">1024×1024</text>
+    </svg>
+    <p>Default resolution</p>
+  </div>
+  <div>
+    <svg width="120" height="80">
+      <rect x="5" y="5" width="110" height="70" fill="#222" stroke="#6ee7ff" stroke-width="3" />
+      <text x="60" y="45" fill="#fff" font-size="10" text-anchor="middle">2048×2048</text>
+    </svg>
+    <p>High resolution</p>
+  </div>
+</div>
+<p><a href="index.html">Documentation index</a> | <a href="../index.html">Back to game</a></p>
+</body>
+</html>

--- a/game24/docs/solo.html
+++ b/game24/docs/solo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Solo Mode</title>
+<style>
+body{font-family:sans-serif;background:#0b0d10;color:#e6edf3;padding:20px}
+svg{background:#111;border:1px solid #333}
+a{color:#91caff}
+</style>
+</head>
+<body>
+<h1>Solo Mode and Pin Selection</h1>
+<p><strong>Solo Mode</strong> draws lines only from a selected pin. Use the <strong>Selected Pin</strong> slider or click a pin on the canvas. <strong>Skip Same Side</strong> avoids connecting to pins on the same edge.</p>
+<svg width="200" height="140" viewBox="0 0 200 140">
+  <rect x="10" y="10" width="180" height="120" fill="#222" stroke="#6ee7ff" />
+  <circle cx="10" cy="10" r="3" fill="#f472b6" />
+  <circle cx="190" cy="10" r="3" fill="#f472b6" />
+  <line x1="10" y1="10" x2="190" y2="10" stroke="#a78bfa" />
+</svg>
+<p>The highlighted pin is the origin when Solo Mode is active.</p>
+<p><a href="index.html">Documentation index</a> | <a href="../index.html">Back to game</a></p>
+</body>
+</html>

--- a/game24/index.html
+++ b/game24/index.html
@@ -47,6 +47,7 @@
 
     footer{grid-column:1/-1; text-align:center; color:#718096; font-size:12px; padding-top:8px}
     a{color:#91caff; text-decoration:none}
+    .help{margin-left:4px;color:#6ee7ff;font-weight:bold;cursor:help}
   </style>
 </head>
 <body>
@@ -67,69 +68,69 @@
     <div class="group">
       <h2>モード</h2>
       <p class="desc">操作を簡略化するモードです。</p>
-      <div class="row"><label class="toggle"><input type="checkbox" id="easy"> 簡単モード</label><div class="val"></div></div>
+      <div class="row"><label class="toggle"><input type="checkbox" id="easy"> 簡単モード <a class="help" href="docs/easy.html" target="_blank">?</a></label><div class="val"></div></div>
     </div>
     <div class="group">
       <h2>ボードとピン</h2>
-      <div class="row"><label>キャンバス幅</label><div class="val"><span id="resXVal">1024</span>px</div></div>
+      <div class="row"><label>キャンバス幅 <a class="help" href="docs/resolution.html" target="_blank">?</a></label><div class="val"><span id="resXVal">1024</span>px</div></div>
       <input type="range" id="resX" min="512" max="2048" step="64" value="1024"/>
-      <div class="row"><label>キャンバス高さ</label><div class="val"><span id="resYVal">1024</span>px</div></div>
+      <div class="row"><label>キャンバス高さ <a class="help" href="docs/resolution.html" target="_blank">?</a></label><div class="val"><span id="resYVal">1024</span>px</div></div>
       <input type="range" id="resY" min="512" max="2048" step="64" value="1024"/>
 
       <div class="cols">
         <div>
-          <div class="row"><label>上/下のピン数 (X)</label><div class="val"><span id="nxVal">120</span></div></div>
+          <div class="row"><label>上/下のピン数 (X) <a class="help" href="docs/pins.html" target="_blank">?</a></label><div class="val"><span id="nxVal">120</span></div></div>
           <input type="range" id="pinsX" min="4" max="400" step="1" value="120"/>
         </div>
         <div>
-          <div class="row"><label>左/右のピン数 (Y)</label><div class="val"><span id="nyVal">120</span></div></div>
+          <div class="row"><label>左/右のピン数 (Y) <a class="help" href="docs/pins.html" target="_blank">?</a></label><div class="val"><span id="nyVal">120</span></div></div>
           <input type="range" id="pinsY" min="4" max="400" step="1" value="120"/>
         </div>
       </div>
 
       <div class="cols">
         <div>
-          <div class="row"><label>内側マージン</label><div class="val"><span id="marginVal">28</span>px</div></div>
+          <div class="row"><label>内側マージン <a class="help" href="docs/pins.html" target="_blank">?</a></label><div class="val"><span id="marginVal">28</span>px</div></div>
           <input type="range" id="margin" min="0" max="120" step="2" value="28"/>
         </div>
         <div>
-          <div class="row"><label>ピン半径</label><div class="val"><span id="pinRVal">0</span>px</div></div>
+          <div class="row"><label>ピン半径 <a class="help" href="docs/pins.html" target="_blank">?</a></label><div class="val"><span id="pinRVal">0</span>px</div></div>
           <input type="range" id="pinR" min="0" max="4" step="1" value="0"/>
         </div>
       </div>
 
-      <div class="row"><label class="toggle"><input type="checkbox" id="showPins"> ピンを表示</label><div class="val"></div></div>
+      <div class="row"><label class="toggle"><input type="checkbox" id="showPins"> ピンを表示 <a class="help" href="docs/pins.html" target="_blank">?</a></label><div class="val"></div></div>
     </div>
 
     <div class="group">
       <h2>パターン（周回インデックス）</h2>
       <p class="desc">ピンを長方形の外周に並べ、<em>i</em>番ピンから <em>(i × 乗数 + オフセット)</em> 番へ線を結びます。扇出しは「本数」と「ステップ」で制御。</p>
-      <div class="row"><label>乗数 (multiplier)</label><div class="val"><span id="mulVal">2.000</span></div></div>
+      <div class="row"><label>乗数 (multiplier) <a class="help" href="docs/multiplier.html" target="_blank">?</a></label><div class="val"><span id="mulVal">2.000</span></div></div>
       <input type="range" id="mul" min="0" max="20" step="0.001" value="2"/>
 
-      <div class="row"><label class="toggle"><input type="checkbox" id="animate"> 乗数をアニメーション</label><div class="val"></div></div>
-      <div class="row"><label>速度</label><div class="val"><span id="speedVal">0.06</span></div></div>
+      <div class="row"><label class="toggle"><input type="checkbox" id="animate"> 乗数をアニメーション <a class="help" href="docs/animation.html" target="_blank">?</a></label><div class="val"></div></div>
+      <div class="row"><label>速度 <a class="help" href="docs/animation.html" target="_blank">?</a></label><div class="val"><span id="speedVal">0.06</span></div></div>
       <input type="range" id="speed" min="0.005" max="0.2" step="0.005" value="0.06"/>
 
       <div class="cols">
         <div>
-          <div class="row"><label>オフセット</label><div class="val"><span id="offVal">0</span></div></div>
+          <div class="row"><label>オフセット <a class="help" href="docs/offset.html" target="_blank">?</a></label><div class="val"><span id="offVal">0</span></div></div>
           <input type="range" id="offset" min="0" max="800" step="1" value="0"/>
         </div>
         <div>
-          <div class="row"><label>線の本数/ピン</label><div class="val"><span id="fanVal">1</span></div></div>
+          <div class="row"><label>線の本数/ピン <a class="help" href="docs/fan.html" target="_blank">?</a></label><div class="val"><span id="fanVal">1</span></div></div>
           <input type="range" id="fan" min="1" max="32" step="1" value="1"/>
         </div>
       </div>
 
-      <div class="row"><label>ステップ（扇の開き）</label><div class="val"><span id="stepVal">1</span></div></div>
+      <div class="row"><label>ステップ（扇の開き） <a class="help" href="docs/fan.html" target="_blank">?</a></label><div class="val"><span id="stepVal">1</span></div></div>
       <input type="range" id="fanStep" min="1" max="400" step="1" value="1"/>
 
       <div class="cols">
-        <div class="row"><label class="toggle"><input type="checkbox" id="solo"> ソロモード</label><div class="val"></div></div>
-        <div class="row"><label class="toggle"><input type="checkbox" id="skipSame"> 同一辺への接続を避ける</label><div class="val"></div></div>
+        <div class="row"><label class="toggle"><input type="checkbox" id="solo"> ソロモード <a class="help" href="docs/solo.html" target="_blank">?</a></label><div class="val"></div></div>
+        <div class="row"><label class="toggle"><input type="checkbox" id="skipSame"> 同一辺への接続を避ける <a class="help" href="docs/solo.html" target="_blank">?</a></label><div class="val"></div></div>
       </div>
-      <div class="row"><label>選択ピン（ソロ）</label><div class="val"><span id="selVal">0</span></div></div>
+      <div class="row"><label>選択ピン（ソロ） <a class="help" href="docs/solo.html" target="_blank">?</a></label><div class="val"><span id="selVal">0</span></div></div>
       <input type="range" id="selected" min="0" max="100" step="1" value="0"/>
 
       <div class="cols">
@@ -140,7 +141,7 @@
 
     <div class="group">
       <h2>色と描画</h2>
-      <div class="row"><label>色モード</label>
+      <div class="row"><label>色モード <a class="help" href="docs/color.html" target="_blank">?</a></label>
         <select id="colorMode" class="btn">
           <option value="solid">単色</option>
           <option value="start">開始ピン基準グラデ</option>
@@ -150,35 +151,35 @@
       </div>
       <div class="cols">
         <div>
-          <div class="row"><label>色相ベース</label><div class="val"><span id="hueVal">200</span>°</div></div>
+          <div class="row"><label>色相ベース <a class="help" href="docs/color.html" target="_blank">?</a></label><div class="val"><span id="hueVal">200</span>°</div></div>
           <input type="range" id="hue" min="0" max="360" step="1" value="200"/>
         </div>
         <div>
-          <div class="row"><label>色相スパン</label><div class="val"><span id="spanVal">180</span>°</div></div>
+          <div class="row"><label>色相スパン <a class="help" href="docs/color.html" target="_blank">?</a></label><div class="val"><span id="spanVal">180</span>°</div></div>
           <input type="range" id="span" min="0" max="360" step="1" value="180"/>
         </div>
       </div>
       <div class="cols">
         <div>
-          <div class="row"><label>彩度</label><div class="val"><span id="satVal">85</span>%</div></div>
+          <div class="row"><label>彩度 <a class="help" href="docs/color.html" target="_blank">?</a></label><div class="val"><span id="satVal">85</span>%</div></div>
           <input type="range" id="sat" min="0" max="100" step="1" value="85"/>
         </div>
         <div>
-          <div class="row"><label>明度</label><div class="val"><span id="litVal">65</span>%</div></div>
+          <div class="row"><label>明度 <a class="help" href="docs/color.html" target="_blank">?</a></label><div class="val"><span id="litVal">65</span>%</div></div>
           <input type="range" id="lit" min="0" max="100" step="1" value="65"/>
         </div>
       </div>
       <div class="cols">
         <div>
-          <div class="row"><label>不透明度</label><div class="val"><span id="alphaVal">0.65</span></div></div>
+          <div class="row"><label>不透明度 <a class="help" href="docs/color.html" target="_blank">?</a></label><div class="val"><span id="alphaVal">0.65</span></div></div>
           <input type="range" id="alpha" min="0.05" max="1" step="0.05" value="0.65"/>
-          <div class="row"><label>線の太さ</label><div class="val"><span id="lwVal">0.65</span>px</div></div>
+          <div class="row"><label>線の太さ <a class="help" href="docs/color.html" target="_blank">?</a></label><div class="val"><span id="lwVal">0.65</span>px</div></div>
           <input type="range" id="lw" min="0.2" max="2.0" step="0.05" value="0.65"/>
         </div>
-        <div class="row"><label class="toggle"><input type="checkbox" id="glow" checked> 軽いグロー</label><div class="val"></div></div>
+        <div class="row"><label class="toggle"><input type="checkbox" id="glow" checked> 軽いグロー <a class="help" href="docs/color.html" target="_blank">?</a></label><div class="val"></div></div>
       </div>
-      <div class="row"><label class="toggle"><input type="checkbox" id="animate"> 乗数をアニメーション</label><div class="val"></div></div>
-      <div class="row"><label>速度</label><div class="val"><span id="speedVal">0.06</span></div></div>
+      <div class="row"><label class="toggle"><input type="checkbox" id="animate"> 乗数をアニメーション <a class="help" href="docs/animation.html" target="_blank">?</a></label><div class="val"></div></div>
+      <div class="row"><label>速度 <a class="help" href="docs/animation.html" target="_blank">?</a></label><div class="val"><span id="speedVal">0.06</span></div></div>
       <input type="range" id="speed" min="0.005" max="0.2" step="0.005" value="0.06"/>
     </div>
 


### PR DESCRIPTION
## Summary
- add `docs/` reference pages for canvas resolution, multiplier, pins, animation, offset, fan settings, solo mode, color options and easy mode
- wire "?" help links for each control in `index.html`
- include docs index for easy navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e32e7f5c8325add1c1973344f8a9