### PR TITLE
Support random quote selection for all categories

### DIFF
--- a/game21/app.js
+++ b/game21/app.js
@@ -332,7 +332,9 @@ function showNextQuote() {
   if (!currentCategory) {
     return;
   }
-  const randomQuote = getRandomQuoteByCategory(currentCategory);
+  const randomQuote = currentCategory === 'all'
+    ? getRandomQuoteAll()
+    : getRandomQuoteByCategory(currentCategory);
   if (randomQuote) {
     displayQuote(randomQuote);
   }


### PR DESCRIPTION
## Summary
- Allow `showNextQuote` to fetch from all quotes when the "おまかせ" category is selected
- Keep existing behavior for specific categories

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e8bd08ac8325a3bfbd851d1c2de2