### PR TITLE
Fix: ignore category button clicks in game21

### DIFF
--- a/game21/app.js
+++ b/game21/app.js
@@ -396,6 +396,7 @@ document.addEventListener('touchend', e => {
 document.addEventListener('click', e => {
   const x = e.clientX;
   const width = window.innerWidth;
+  if (e.target.closest('.btn--scene')) return;
   if (x < edgeOffset || x > width - edgeOffset) {
     showNextQuote();
   }


### PR DESCRIPTION
## Summary
- prevent document-level quote advancement when clicking scene buttons

## Testing
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b2eb49f8908325b432a9165e637f5c