### PR TITLE
Enable scene buttons after quotes load

### DIFF
--- a/game21/app.js
+++ b/game21/app.js
@@ -197,6 +197,7 @@ async function bootstrap(lang = 'ja') {
       for (const q of converted) byId.set(q.id, q);
     }
     buildQueues(allQuotes);
+    quotesLoaded = true;
     console.log(`Loaded ${allQuotes.length} quotes.`);
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- Set `quotesLoaded` flag after queues are built so scene buttons become active once quotes load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b316103a688325a99d559f0dc4b82d