### PR TITLE
feat: add bootstrap retry

### DIFF
--- a/game21/app.js
+++ b/game21/app.js
@@ -198,10 +198,29 @@ async function bootstrap(lang = 'ja') {
     }
     buildQueues(allQuotes);
     console.log(`Loaded ${allQuotes.length} quotes.`);
+    quotesLoaded = true;
+    sceneButtons.forEach(btn => btn.disabled = false);
+    return true;
   } catch (err) {
     console.error(err);
-    alert('データを読み込めませんでした');
     sceneButtons.forEach(btn => btn.disabled = true);
+    quotesLoaded = false;
+    let errorEl = document.getElementById('loadError');
+    if (!errorEl) {
+      errorEl = document.createElement('div');
+      errorEl.id = 'loadError';
+      errorEl.innerHTML = `
+        <p>データを読み込めませんでした</p>
+        <button id="retryBootstrap" class="btn btn--outline" type="button">再読み込み</button>
+      `;
+      document.body.appendChild(errorEl);
+      const retryBtn = document.getElementById('retryBootstrap');
+      retryBtn.addEventListener('click', async () => {
+        const success = await bootstrap(lang);
+        if (success) errorEl.remove();
+      });
+    }
+    return false;
   }
 
 }


### PR DESCRIPTION
## Summary
- show inline error with retry button when bootstrap fails
- rerun bootstrap on retry and remove error on success
- re-enable scene selection buttons after successful bootstrap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b31612263c832582fe8c502b952006