### PR TITLE
Fix game24 laser animation startup

### DIFF
--- a/game24/app.js
+++ b/game24/app.js
@@ -84,11 +84,10 @@ class MultiLaserBilliards {
         
         // 初期描画
         this.drawStaticElements();
-        
+
         // アニメーションループ
         this.lastTime = performance.now();
-        this.animationId = null;
-        this.animate();
+        this.animationId = requestAnimationFrame(time => this.animate(time));
     }
     
     initializeLasers() {
@@ -722,7 +721,7 @@ class MultiLaserBilliards {
         }
     }
     
-    animate(currentTime) {
+    animate(currentTime = performance.now()) {
         const deltaTime = currentTime - this.lastTime;
         this.lastTime = currentTime;
         


### PR DESCRIPTION
## Summary
- start the game24 animation loop via `requestAnimationFrame`
- allow `animate` method to use `performance.now()` when no timestamp provided

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*
- `node --check game24/app.js`
- `node test.js` *(fails: Failed to launch the browser process)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb07bed108325a1a58644f947f978