### PR TITLE
fix: update travel quotes pack count

### DIFF
--- a/game21/data/manifest.json
+++ b/game21/data/manifest.json
@@ -6,7 +6,7 @@
       "file": "travel-quotes-001.json",
       "lang_code": "multi",
       "category": "mixed",
-      "count": 100,
+      "count": 102,
       "hash": "sha256-xxxxxxxx"
     },
     {


### PR DESCRIPTION
## Summary
- update manifest count for travel quotes pack to 102
- verify manifest counts against pack data

## Testing
- `node - <<'NODE'
const fs=require('fs');
const manifest=JSON.parse(fs.readFileSync('game21/data/manifest.json','utf8'));
let mismatches=[];
for(const pack of manifest.packs){
  const data=JSON.parse(fs.readFileSync(`game21/data/packs/${pack.file}`,'utf8'));
  const actual=(data.quotes||data).length;
  if(actual!==pack.count){mismatches.push(`${pack.id}: expected ${pack.count}, got ${actual}`);} else {
    console.log(`Pack ${pack.id} count matches (${actual})`);
  }
}
if(mismatches.length){
  console.error('Mismatches found:',mismatches.join('\n'));
  process.exit(1);
}
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68bc21250e6083258aeb93a2d7618675