### PR TITLE
Remove placeholder source URLs in game21 packs

### DIFF
--- a/game21/data/packs/enriched_quotes_core.json
+++ b/game21/data/packs/enriched_quotes_core.json
@@ -18,7 +18,7 @@
       "period": "Pre-Qin",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【371840679220454†L14-L17】",
+      "source_url": null,
       "explanation": "どんなに長い旅も一歩から始まるんだよ。今日も最初の一歩を踏み出そうね。"
     },
     {
@@ -39,7 +39,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "secondary",
-      "source_url": "【203293225791624†L152-L155】",
+      "source_url": null,
       "explanation": "食べ物にはその人の心や暮らしが表れているんだよ。新しい料理を味わって、その土地の人を知ろうね。"
     },
     {
@@ -60,7 +60,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【764620169306781†L132-L136】",
+      "source_url": null,
       "explanation": "旅をすると色々な人や文化を知って、心が広くなるよ。新しい場所で世界を知ろうね。"
     },
     {
@@ -81,7 +81,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【1421691728257†L398-L405】",
+      "source_url": null,
       "explanation": "旅の途中で道に迷っても、それはただの寄り道かもしれない。新しい発見があるかもしれないよ。"
     },
     {
@@ -102,7 +102,7 @@
       "period": "Edo period",
       "verification_status": "verified",
       "source_type": "secondary",
-      "source_url": "【306389301861155†L112-L129】",
+      "source_url": null,
       "explanation": "旅は一緒に行く仲間がいると楽しいよ。そして世の中はお互い助け合うことが大事なんだ。"
     },
     {
@@ -123,7 +123,7 @@
       "period": "1st century",
       "verification_status": "verified",
       "source_type": "secondary",
-      "source_url": "【616865087248851†L14-L48】",
+      "source_url": null,
       "explanation": "何度聞くよりも一度見てみる方がよくわかるんだよ。旅先での体験を大事にしようね。"
     },
     {
@@ -144,7 +144,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【295917037166768†L492-L495】",
+      "source_url": null,
       "explanation": "道中の出来事や旅そのものが人生なんだよ。遠くまで行くこと自体を楽しもうね。"
     },
     {
@@ -165,7 +165,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【130595950914006†L473-L479】",
+      "source_url": null,
       "explanation": "新しい発見は遠くへ行くことだけじゃなく、物の見方を変えることで生まれるんだよ。"
     },
     {
@@ -186,7 +186,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【806828661375599†L168-L171】",
+      "source_url": null,
       "explanation": "自然の中を歩いていると、想像以上の喜びや学びを得られるよ。山や森の教えを大切にしようね。"
     },
     {
@@ -207,7 +207,7 @@
       "period": "Pre-Qin",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【442886402494276†L648-L651】",
+      "source_url": null,
       "explanation": "良い旅人は予定にとらわれず、到着にこだわらないんだ。旅の途中を楽しもうね。"
     },
     {
@@ -228,7 +228,7 @@
       "period": "17th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【113771269056992†L108-L110】",
+      "source_url": null,
       "explanation": "旅は若い人には勉強になり、年を重ねると経験になるんだ。どんな年齢でも旅で学べるよ。"
     },
     {
@@ -249,7 +249,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【711772629834030†L265-L268】",
+      "source_url": null,
       "explanation": "どれだけ探検しても、最後には出発地点に戻ってその場所を初めて知ることになるんだ。旅の終わりも新しい発見なんだよ。"
     },
     {
@@ -270,7 +270,7 @@
       "period": "Ancient",
       "verification_status": "verified",
       "source_type": "secondary",
-      "source_url": "【995976010028647†L128-L136】",
+      "source_url": null,
       "explanation": "新しい場所に行ったら、その土地のやり方や文化に合わせることが大切だよ。郷に入れば郷に従えだね。"
     },
     {
@@ -291,7 +291,7 @@
       "period": "Medieval",
       "verification_status": "attributed",
       "source_type": "tertiary",
-      "source_url": "【15670316585927†L45-L53】",
+      "source_url": null,
       "explanation": "旅は最初、言葉を失うほどの驚きをくれるけれど、やがてその体験を語る物語に変わるんだよ。"
     },
     {
@@ -312,7 +312,7 @@
       "period": "Renaissance",
       "verification_status": "attributed",
       "source_type": "tertiary",
-      "source_url": "【716603372023852†L28-L31】",
+      "source_url": null,
       "explanation": "旅は若い人を成長させてくれるんだよ。新しい経験を積んで自分を大きくしていこうね。"
     },
     {
@@ -333,7 +333,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "tertiary",
-      "source_url": "【296573078105478†L18-L27】",
+      "source_url": null,
       "explanation": "世界そのものが一番の見ものなんだよ。広い世界を自分の目で見てみよう。"
     },
     {
@@ -417,7 +417,7 @@
       "period": "Unknown",
       "verification_status": "misattributed",
       "source_type": "tertiary",
-      "source_url": "【913021686751179†L53-L58】",
+      "source_url": null,
       "explanation": "目的地に着くことよりも、そこへ行くまでの過程を楽しもうという意味なんだよ。"
     },
     {
@@ -438,7 +438,7 @@
       "period": "Late Antiquity",
       "verification_status": "misattributed",
       "source_type": "tertiary",
-      "source_url": "【660888613515789†L59-L63】",
+      "source_url": null,
       "explanation": "旅をすると新しいページをめくるように世界が広がるんだよ。今日も新しいページを読んでみようね。"
     },
     {
@@ -480,7 +480,7 @@
       "period": "Ancient",
       "verification_status": "verified",
       "source_type": "tertiary",
-      "source_url": "【995976010028647†L128-L136】",
+      "source_url": null,
       "explanation": "新しい土地に行ったら、その土地の習慣や食文化に合わせることが大事だよ。挑戦してみようね！"
     },
     {

--- a/game21/data/packs/enriched_quotes_literature.json
+++ b/game21/data/packs/enriched_quotes_literature.json
@@ -18,7 +18,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【764620169306781†L132-L136】",
+      "source_url": null,
       "explanation": "旅をすると色々な人や文化を知って、心が広くなるよ。新しい場所で世界を知ろうね。"
     },
     {
@@ -39,7 +39,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【499568826857919†L480-L629】",
+      "source_url": null,
       "explanation": "目的地に着くことより、希望を持って旅を続けることが大切だよ。努力する過程を楽しもうね。"
     },
     {
@@ -60,7 +60,7 @@
       "period": "17th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【499568826857919†L480-L629】",
+      "source_url": null,
       "explanation": "旅をするときは、良い仲間がいると道のりが短く感じるんだよ。一緒に楽しもうね。"
     },
     {
@@ -81,7 +81,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【499568826857919†L480-L629】",
+      "source_url": null,
       "explanation": "長旅にはお気に入りの本や日記があると退屈しないね。移動時間も楽しもう。"
     },
     {
@@ -102,7 +102,7 @@
       "period": "18th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【499568826857919†L480-L629】",
+      "source_url": null,
       "explanation": "旅に出ると、現実の景色が想像を超えて教えてくれるよ。ありのままを見る大切さを学ぼうね。"
     },
     {
@@ -123,7 +123,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【499568826857919†L480-L629】",
+      "source_url": null,
       "explanation": "一人旅は自由で速く進めるけれど、時には仲間が恋しくなることもあるよね。"
     },
     {
@@ -144,7 +144,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【595943370508367†L332-L343】",
+      "source_url": null,
       "explanation": "遠い場所への旅は、学びや成長のチャンスに満ちているよ。好奇心を持って旅に出ようね。"
     },
     {
@@ -165,7 +165,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【806828661375599†L168-L171】",
+      "source_url": null,
       "explanation": "自然の中を歩いていると、思いがけない発見や癒しを得られるよ。たくさんの恵みを感じてね。"
     },
     {
@@ -186,7 +186,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【568963501037513†L207-L210】",
+      "source_url": null,
       "explanation": "遠くへ行くだけが旅ではないよ。同じ場所でも見方を変えれば新しい発見があるんだ。"
     },
     {
@@ -207,7 +207,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【568963501037513†L217-L221】",
+      "source_url": null,
       "explanation": "どこへ行っても自分自身からは逃げられない。旅は自分を見つめる時間にもなるんだよ。"
     },
     {
@@ -228,7 +228,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【568963501037513†L278-L282】",
+      "source_url": null,
       "explanation": "旅は単に場所の移動だけでなく、時間や社会的な関係も含む複合的な経験なんだ。"
     },
     {
@@ -249,7 +249,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【568963501037513†L310-L313】",
+      "source_url": null,
       "explanation": "新しい場所を探すだけでなく、物の見方を変えることで新しい発見があるんだよ。"
     },
     {
@@ -270,7 +270,7 @@
       "period": "16th century",
       "verification_status": "attributed",
       "source_type": "secondary",
-      "source_url": "【716603372023852†L28-L32】",
+      "source_url": null,
       "explanation": "若いうちに旅をすることは人格や経験を豊かにしてくれるよ。旅からたくさん学ぼうね。"
     },
     {
@@ -291,7 +291,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【144942522159149†L165-L170】",
+      "source_url": null,
       "explanation": "荷物が多いと旅が大変になるよ。身軽でいることが旅を楽しむコツなんだ。"
     },
     {
@@ -312,7 +312,7 @@
       "period": "17th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【144942522159149†L170-L172】",
+      "source_url": null,
       "explanation": "旅の終わり時を心得ている人ほど、満足のいく旅ができるんだ。帰るタイミングも大切だよ。"
     },
     {
@@ -333,7 +333,7 @@
       "period": "1st century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【144942522159149†L211-L213】",
+      "source_url": null,
       "explanation": "場所や状況を変えることで、気持ちがリフレッシュするんだよ。時には旅に出てみようね。"
     },
     {
@@ -354,7 +354,7 @@
       "period": "17th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【144942522159149†L275-L276】",
+      "source_url": null,
       "explanation": "若い頃の旅は学びとなり、年を重ねてからの旅は豊かな経験になるよ。人生の各段階で旅の意味は変わるんだ。"
     },
     {
@@ -375,7 +375,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【144942522159149†L279-L280】",
+      "source_url": null,
       "explanation": "旅先で異なる文化や考えに触れると、寛容な心が育つよ。人々の違いを受け入れよう。"
     },
     {
@@ -396,7 +396,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【387288569602602†L2661-L2666】",
+      "source_url": null,
       "explanation": "旅をすることは生きることそのものだよ。旅の風景は、自分自身を映し出しているんだ。"
     },
     {
@@ -417,7 +417,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "secondary",
-      "source_url": "【112281917475103†L4716-L4719】",
+      "source_url": null,
       "explanation": "旅人はただ観光地を巡る人ではなく、深く土地や人と関わる人なんだよ。旅の本質を考えてみようね。"
     },
     {
@@ -438,7 +438,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【624630485548305†L159-L170】",
+      "source_url": null,
       "explanation": "一見短い旅でも、心に深く残って元の自分に戻れなくなることがあるんだ。旅の影響は大きいね。"
     },
     {
@@ -459,7 +459,7 @@
       "period": "Pre-Qin",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【624630485548305†L159-L170】",
+      "source_url": null,
       "explanation": "長い旅も最初の一歩から始まるよ。まずは勇気を持って踏み出してみようね。"
     },
     {
@@ -480,7 +480,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【624630485548305†L159-L170】",
+      "source_url": null,
       "explanation": "旅の目的は人それぞれ。迷うために旅をする人もいれば、自分を見つけるために旅をする人もいるんだ。"
     },
     {
@@ -501,7 +501,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【624630485548305†L159-L170】",
+      "source_url": null,
       "explanation": "探検の旅は終わらない方が楽しいよ。好奇心を持っていつまでも新しい場所を探し続けようね。"
     },
     {
@@ -522,7 +522,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【624630485548305†L159-L170】",
+      "source_url": null,
       "explanation": "旅をしないと他国への偏見が増えてしまうよ。実際に旅をして他の文化を知ろうね。"
     }
   ]

--- a/game21/data/packs/travel-quotes-001.json
+++ b/game21/data/packs/travel-quotes-001.json
@@ -18,7 +18,7 @@
       "period": "Pre-Qin",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【371840679220454†L14-L17】",
+      "source_url": null,
       "explanation": "どんなに長い旅も一歩から始まるんだよ。今日も最初の一歩を踏み出そうね。"
     },
     {
@@ -39,7 +39,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "secondary",
-      "source_url": "【203293225791624†L152-L155】",
+      "source_url": null,
       "explanation": "食べ物にはその人の心や暮らしが表れているんだよ。新しい料理を味わって、その土地の人を知ろうね。"
     },
     {
@@ -60,7 +60,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【764620169306781†L132-L136】",
+      "source_url": null,
       "explanation": "旅をすると色々な人や文化を知って、心が広くなるよ。新しい場所で世界を知ろうね。"
     },
     {
@@ -81,7 +81,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【1421691728257†L398-L405】",
+      "source_url": null,
       "explanation": "旅の途中で道に迷っても、それはただの寄り道かもしれない。新しい発見があるかもしれないよ。"
     },
     {
@@ -102,7 +102,7 @@
       "period": "Edo period",
       "verification_status": "verified",
       "source_type": "secondary",
-      "source_url": "【306389301861155†L112-L129】",
+      "source_url": null,
       "explanation": "旅は一緒に行く仲間がいると楽しいよ。そして世の中はお互い助け合うことが大事なんだ。"
     },
     {
@@ -123,7 +123,7 @@
       "period": "1st century",
       "verification_status": "verified",
       "source_type": "secondary",
-      "source_url": "【616865087248851†L14-L48】",
+      "source_url": null,
       "explanation": "何度聞くよりも一度見てみる方がよくわかるんだよ。旅先での体験を大事にしようね。"
     },
     {
@@ -144,7 +144,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【295917037166768†L492-L495】",
+      "source_url": null,
       "explanation": "道中の出来事や旅そのものが人生なんだよ。遠くまで行くこと自体を楽しもうね。"
     },
     {
@@ -165,7 +165,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【130595950914006†L473-L479】",
+      "source_url": null,
       "explanation": "新しい発見は遠くへ行くことだけじゃなく、物の見方を変えることで生まれるんだよ。"
     },
     {
@@ -186,7 +186,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【806828661375599†L168-L171】",
+      "source_url": null,
       "explanation": "自然の中を歩いていると、想像以上の喜びや学びを得られるよ。山や森の教えを大切にしようね。"
     },
     {
@@ -207,7 +207,7 @@
       "period": "Pre-Qin",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【442886402494276†L648-L651】",
+      "source_url": null,
       "explanation": "良い旅人は予定にとらわれず、到着にこだわらないんだ。旅の途中を楽しもうね。"
     },
     {
@@ -228,7 +228,7 @@
       "period": "17th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【113771269056992†L108-L110】",
+      "source_url": null,
       "explanation": "旅は若い人には勉強になり、年を重ねると経験になるんだ。どんな年齢でも旅で学べるよ。"
     },
     {
@@ -249,7 +249,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【711772629834030†L265-L268】",
+      "source_url": null,
       "explanation": "どれだけ探検しても、最後には出発地点に戻ってその場所を初めて知ることになるんだ。旅の終わりも新しい発見なんだよ。"
     },
     {
@@ -270,7 +270,7 @@
       "period": "Ancient",
       "verification_status": "verified",
       "source_type": "secondary",
-      "source_url": "【995976010028647†L128-L136】",
+      "source_url": null,
       "explanation": "新しい場所に行ったら、その土地のやり方や文化に合わせることが大切だよ。郷に入れば郷に従えだね。"
     },
     {
@@ -291,7 +291,7 @@
       "period": "Medieval",
       "verification_status": "attributed",
       "source_type": "tertiary",
-      "source_url": "【15670316585927†L45-L53】",
+      "source_url": null,
       "explanation": "旅は最初、言葉を失うほどの驚きをくれるけれど、やがてその体験を語る物語に変わるんだよ。"
     },
     {
@@ -312,7 +312,7 @@
       "period": "Renaissance",
       "verification_status": "attributed",
       "source_type": "tertiary",
-      "source_url": "【716603372023852†L28-L31】",
+      "source_url": null,
       "explanation": "旅は若い人を成長させてくれるんだよ。新しい経験を積んで自分を大きくしていこうね。"
     },
     {
@@ -333,7 +333,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "tertiary",
-      "source_url": "【296573078105478†L18-L27】",
+      "source_url": null,
       "explanation": "世界そのものが一番の見ものなんだよ。広い世界を自分の目で見てみよう。"
     },
     {
@@ -417,7 +417,7 @@
       "period": "Unknown",
       "verification_status": "misattributed",
       "source_type": "tertiary",
-      "source_url": "【913021686751179†L53-L58】",
+      "source_url": null,
       "explanation": "目的地に着くことよりも、そこへ行くまでの過程を楽しもうという意味なんだよ。"
     },
     {
@@ -438,7 +438,7 @@
       "period": "Late Antiquity",
       "verification_status": "misattributed",
       "source_type": "tertiary",
-      "source_url": "【660888613515789†L59-L63】",
+      "source_url": null,
       "explanation": "旅をすると新しいページをめくるように世界が広がるんだよ。今日も新しいページを読んでみようね。"
     },
     {
@@ -480,7 +480,7 @@
       "period": "Ancient",
       "verification_status": "verified",
       "source_type": "tertiary",
-      "source_url": "【995976010028647†L128-L136】",
+      "source_url": null,
       "explanation": "新しい土地に行ったら、その土地の習慣や食文化に合わせることが大事だよ。挑戦してみようね！"
     },
     {
@@ -1068,7 +1068,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【764620169306781†L132-L136】",
+      "source_url": null,
       "explanation": "旅をすると色々な人や文化を知って、心が広くなるよ。新しい場所で世界を知ろうね。"
     },
     {
@@ -1089,7 +1089,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【499568826857919†L480-L629】",
+      "source_url": null,
       "explanation": "目的地に着くことより、希望を持って旅を続けることが大切だよ。努力する過程を楽しもうね。"
     },
     {
@@ -1110,7 +1110,7 @@
       "period": "17th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【499568826857919†L480-L629】",
+      "source_url": null,
       "explanation": "旅をするときは、良い仲間がいると道のりが短く感じるんだよ。一緒に楽しもうね。"
     },
     {
@@ -1131,7 +1131,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【499568826857919†L480-L629】",
+      "source_url": null,
       "explanation": "長旅にはお気に入りの本や日記があると退屈しないね。移動時間も楽しもう。"
     },
     {
@@ -1152,7 +1152,7 @@
       "period": "18th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【499568826857919†L480-L629】",
+      "source_url": null,
       "explanation": "旅に出ると、現実の景色が想像を超えて教えてくれるよ。ありのままを見る大切さを学ぼうね。"
     },
     {
@@ -1173,7 +1173,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【499568826857919†L480-L629】",
+      "source_url": null,
       "explanation": "一人旅は自由で速く進めるけれど、時には仲間が恋しくなることもあるよね。"
     },
     {
@@ -1194,7 +1194,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【595943370508367†L332-L343】",
+      "source_url": null,
       "explanation": "遠い場所への旅は、学びや成長のチャンスに満ちているよ。好奇心を持って旅に出ようね。"
     },
     {
@@ -1215,7 +1215,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【806828661375599†L168-L171】",
+      "source_url": null,
       "explanation": "自然の中を歩いていると、思いがけない発見や癒しを得られるよ。たくさんの恵みを感じてね。"
     },
     {
@@ -1236,7 +1236,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【568963501037513†L207-L210】",
+      "source_url": null,
       "explanation": "遠くへ行くだけが旅ではないよ。同じ場所でも見方を変えれば新しい発見があるんだ。"
     },
     {
@@ -1257,7 +1257,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【568963501037513†L217-L221】",
+      "source_url": null,
       "explanation": "どこへ行っても自分自身からは逃げられない。旅は自分を見つめる時間にもなるんだよ。"
     },
     {
@@ -1278,7 +1278,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【568963501037513†L278-L282】",
+      "source_url": null,
       "explanation": "旅は単に場所の移動だけでなく、時間や社会的な関係も含む複合的な経験なんだ。"
     },
     {
@@ -1299,7 +1299,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【568963501037513†L310-L313】",
+      "source_url": null,
       "explanation": "新しい場所を探すだけでなく、物の見方を変えることで新しい発見があるんだよ。"
     },
     {
@@ -1320,7 +1320,7 @@
       "period": "16th century",
       "verification_status": "attributed",
       "source_type": "secondary",
-      "source_url": "【716603372023852†L28-L32】",
+      "source_url": null,
       "explanation": "若いうちに旅をすることは人格や経験を豊かにしてくれるよ。旅からたくさん学ぼうね。"
     },
     {
@@ -1341,7 +1341,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【144942522159149†L165-L170】",
+      "source_url": null,
       "explanation": "荷物が多いと旅が大変になるよ。身軽でいることが旅を楽しむコツなんだ。"
     },
     {
@@ -1362,7 +1362,7 @@
       "period": "17th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【144942522159149†L170-L172】",
+      "source_url": null,
       "explanation": "旅の終わり時を心得ている人ほど、満足のいく旅ができるんだ。帰るタイミングも大切だよ。"
     },
     {
@@ -1383,7 +1383,7 @@
       "period": "1st century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【144942522159149†L211-L213】",
+      "source_url": null,
       "explanation": "場所や状況を変えることで、気持ちがリフレッシュするんだよ。時には旅に出てみようね。"
     },
     {
@@ -1404,7 +1404,7 @@
       "period": "17th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【144942522159149†L275-L276】",
+      "source_url": null,
       "explanation": "若い頃の旅は学びとなり、年を重ねてからの旅は豊かな経験になるよ。人生の各段階で旅の意味は変わるんだ。"
     },
     {
@@ -1425,7 +1425,7 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【144942522159149†L279-L280】",
+      "source_url": null,
       "explanation": "旅先で異なる文化や考えに触れると、寛容な心が育つよ。人々の違いを受け入れよう。"
     },
     {
@@ -1446,7 +1446,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【387288569602602†L2661-L2666】",
+      "source_url": null,
       "explanation": "旅をすることは生きることそのものだよ。旅の風景は、自分自身を映し出しているんだ。"
     },
     {
@@ -1467,7 +1467,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "secondary",
-      "source_url": "【112281917475103†L4716-L4719】",
+      "source_url": null,
       "explanation": "旅人はただ観光地を巡る人ではなく、深く土地や人と関わる人なんだよ。旅の本質を考えてみようね。"
     },
     {
@@ -1488,7 +1488,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【624630485548305†L159-L170】",
+      "source_url": null,
       "explanation": "一見短い旅でも、心に深く残って元の自分に戻れなくなることがあるんだ。旅の影響は大きいね。"
     },
     {
@@ -1509,7 +1509,7 @@
       "period": "Pre-Qin",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【624630485548305†L159-L170】",
+      "source_url": null,
       "explanation": "長い旅も最初の一歩から始まるよ。まずは勇気を持って踏み出してみようね。"
     },
     {
@@ -1530,7 +1530,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【624630485548305†L159-L170】",
+      "source_url": null,
       "explanation": "旅の目的は人それぞれ。迷うために旅をする人もいれば、自分を見つけるために旅をする人もいるんだ。"
     },
     {
@@ -1551,7 +1551,7 @@
       "period": "20th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【624630485548305†L159-L170】",
+      "source_url": null,
       "explanation": "探検の旅は終わらない方が楽しいよ。好奇心を持っていつまでも新しい場所を探し続けようね。"
     },
     {
@@ -1572,10 +1572,10 @@
       "period": "19th century",
       "verification_status": "verified",
       "source_type": "primary",
-      "source_url": "【624630485548305†L159-L170】",
+      "source_url": null,
       "explanation": "旅をしないと他国への偏見が増えてしまうよ。実際に旅をして他の文化を知ろうね。"
     },
-   {
+    {
       "id": "en-literature-0026",
       "scene": "出発前・旅の準備",
       "category": "出発・準備",


### PR DESCRIPTION
## Summary
- replace placeholder `source_url` values containing temporary markers with `null` in game21 pack data

## Testing
- `jq empty game21/data/packs/enriched_quotes_core.json`
- `jq empty game21/data/packs/enriched_quotes_literature.json`
- `jq empty game21/data/packs/travel-quotes-001.json`


------
https://chatgpt.com/codex/tasks/task_e_68bc2126fcc08325b01cb68532e2514f