### PR TITLE
Update game21 pack hashes and add README

### DIFF
--- a/game21/data/README.md
+++ b/game21/data/README.md
@@ -1,0 +1,20 @@
+# Data pack hash maintenance
+
+The `manifest.json` file lists each pack along with a SHA‑256 hash to
+protect against tampering. Whenever a file in `packs/` changes or a new
+pack is added, regenerate the hashes and update the manifest.
+
+## Regenerate hashes
+
+From this directory run:
+
+```bash
+sha256sum packs/*.json
+```
+
+Copy each digest and replace the matching `hash` entry in
+`manifest.json` using the `sha256-<hex>` format.
+
+Commit both the modified pack files and `manifest.json` so the hashes
+stay in sync.
+

--- a/game21/data/manifest.json
+++ b/game21/data/manifest.json
@@ -7,7 +7,7 @@
       "lang_code": "multi",
       "category": "mixed",
       "count": 100,
-      "hash": "sha256-xxxxxxxx"
+      "hash": "sha256-5faacb125ae88731b1900cc9388bfbb80eb944ebf5bcbc05900bf9e45e3e3580"
     },
     {
       "id": "ja-core",
@@ -15,7 +15,7 @@
       "lang_code": "ja",
       "category": "core",
       "count": 25,
-      "hash": "sha256-xxxxxxxx"
+      "hash": "sha256-43298997a518b134a5e3ece4fa198a1f7021476f2dec6db7b95b0666c007158c"
     },
     {
       "id": "enriched-core",
@@ -23,7 +23,7 @@
       "lang_code": "multi",
       "category": "core",
       "count": 30,
-      "hash": "sha256-xxxxxxxx"
+      "hash": "sha256-8632cb9be979106d612edb557b32afd60b37b0a523c4a667d7d4ef5b3ef19aed"
     },
     {
       "id": "enriched-classics",
@@ -31,7 +31,7 @@
       "lang_code": "multi",
       "category": "classics",
       "count": 20,
-      "hash": "sha256-xxxxxxxx"
+      "hash": "sha256-f04143d3dcde215fcefd64298e6f7b22758a2c51d08a725bc9427ca249746265"
     },
     {
       "id": "enriched-literature",
@@ -39,7 +39,7 @@
       "lang_code": "multi",
       "category": "literature",
       "count": 25,
-      "hash": "sha256-xxxxxxxx"
+      "hash": "sha256-5f330ff176a2689c52698e1ed39bb4a63e0a8f85bf15098d6134956d170ef76e"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- compute SHA-256 for each file in `game21/data/packs` and store values in `manifest.json`
- document the hash generation process in a new `game21/data/README.md`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc21280c4c83258036e358fdacce73