### PR TITLE
Verify pack hashes before loading

### DIFF
--- a/game21/app.js
+++ b/game21/app.js
@@ -147,12 +147,31 @@ async function loadManifest() {
 }
 
 async function loadPack(relPath) {
-  const data = await fetchJson(`data/${relPath}`, true);
-  const quotes = Array.isArray(data) ? data : data.quotes;
-  for (const q of quotes) {
-    byId.set(q.id, q);
+  const url = `data/${relPath}`;
+  try {
+    const r = await fetch(url, { cache: 'force-cache' });
+    if (!r.ok) throw new Error(`${url} ${r.status}`);
+    const buf = await r.arrayBuffer();
+    const packInfo = manifest?.packs?.find(p => p.path === relPath || p.file === relPath);
+    if (packInfo?.hash) {
+      const digest = await crypto.subtle.digest('SHA-256', buf);
+      const hashHex = Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
+      const fullHash = `sha256-${hashHex}`;
+      if (fullHash !== packInfo.hash) {
+        alert('データの整合性が確認できませんでした');
+        throw new Error(`Hash mismatch for ${relPath}`);
+      }
+    }
+    const data = JSON.parse(new TextDecoder().decode(buf));
+    const quotes = Array.isArray(data) ? data : data.quotes;
+    for (const q of quotes) {
+      byId.set(q.id, q);
+    }
+    allQuotes.push(...quotes);
+  } catch (err) {
+    console.error(err);
+    throw err;
   }
-  allQuotes.push(...quotes);
 }
 
 function legacyToNewSchema(legacy) {


### PR DESCRIPTION
## Summary
- Compute SHA-256 digest of each pack after fetching
- Validate digests against manifest hash and abort on mismatch

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc26eedba88325a46719ae32b4195c