### PR TITLE
refactor: move inline styles to stylesheet for game21

### DIFF
--- a/game21/index.html
+++ b/game21/index.html
@@ -13,9 +13,9 @@
       <h1>✈️ 旅の言葉 🗾</h1>
 
       <!-- 追加：表示モード＆RTLトグル（任意で非表示にしてもOK） -->
-      <div class="controls" aria-label="表示設定" style="display:flex;gap:12px;justify-content:center;margin-top:8px;">
+      <div class="controls" aria-label="表示設定">
         <label>表示:
-          <select id="langSelect" class="form-control" style="max-width:160px;">
+          <select id="langSelect" class="form-control">
             <option value="both" selected>原文＋日本語</option>
             <option value="original">原文のみ</option>
             <option value="ja">日本語のみ</option>
@@ -30,7 +30,7 @@
         <div class="quote-scene" id="quoteScene"></div>
 
         <!-- 追加：検証バッジ -->
-        <div class="quote-badges" style="text-align:center;margin-bottom:8px;">
+        <div class="quote-badges">
           <span class="badge" id="badgeVerification" hidden>Verified</span>
           <span class="badge badge--warn" id="badgeAttributed" hidden>Attributed</span>
           <span class="badge badge--alert" id="badgeMisattr" hidden>Misattributed</span>
@@ -46,7 +46,7 @@
         <div class="quote-author" id="quoteAuthor"></div>
 
         <!-- 追加：出典など -->
-        <div class="quote-source" style="text-align:center;margin-bottom:8px;">
+        <div class="quote-source">
           <span id="quoteWork"></span>
           <span id="quotePeriod"></span>
           <a id="quoteSourceUrl" href="#" target="_blank" rel="noopener" hidden>出典リンク</a>

--- a/game21/style.css
+++ b/game21/style.css
@@ -1030,3 +1030,21 @@ body::before {
   color: var(--color-text-secondary);
   margin-bottom: var(--space-8);
 }
+
+/* Layout controls and badge containers */
+.controls {
+  display: flex;
+  gap: var(--space-12);
+  justify-content: center;
+  margin-top: var(--space-8);
+}
+
+#langSelect {
+  max-width: 160px;
+}
+
+.quote-badges,
+.quote-source {
+  text-align: center;
+  margin-bottom: var(--space-8);
+}


### PR DESCRIPTION
## Summary
- move layout and badge container styles from `index.html` to `style.css`
- keep `index.html` free of inline style attributes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc26f23ce08325b2941a5a6b10b244