### PR TITLE
refactor: modularize quotes game utilities

### DIFF
--- a/game21/app.js
+++ b/game21/app.js
@@ -1,3 +1,6 @@
+import state from './state.js';
+import { shuffle, inferDirFromLang, toggleBadges, nextIdFrom } from './utils.js';
+
 let quotesLoaded = false;
 
 // ====================== 基本DOM参照 ======================
@@ -21,39 +24,10 @@ const langSelect = document.getElementById('langSelect');
 const toggleRtlBtn = document.getElementById('toggleRtl');
 
 // ====================== 状態管理 ======================
-let currentCategory = null;
-let allQuotes = [];         // 統合配列（packs or legacy）
-let byId = new Map();       // id -> quote
-let manifest = null;
-
-const queues = {            // 事前シャッフル＋ポインタ
-  all: { ids: [], cursor: 0 },
-  byCategory: new Map()     // category -> { ids: [], cursor: 0 }
-};
-
-// ====================== ユーティリティ ======================
-function shuffle(arr) { // Fisher–Yates
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = (Math.random() * (i + 1)) | 0;
-    [arr[i], arr[j]] = [arr[j], arr[i]];
-  }
-}
-
-function inferDirFromLang(lang) {
-  return /^(ar|he|fa|ur)(-|$)/.test(lang || '') ? 'rtl' : 'auto';
-}
-
-function toggleBadges(status) {
-  badgeVerification.hidden = badgeAttributed.hidden = badgeMisattr.hidden = true;
-  if (status === 'verified') badgeVerification.hidden = false;
-  else if (status === 'misattributed') badgeMisattr.hidden = false;
-  else badgeAttributed.hidden = false; // attributed/unknown
-}
-
 function buildQueues(quotes) {
   const idsAll = quotes.map(q => q.id);
   shuffle(idsAll);
-  queues.all = { ids: idsAll, cursor: 0 };
+  state.queues.all = { ids: idsAll, cursor: 0 };
   const buckets = new Map();
   for (const q of quotes) {
     if (!buckets.has(q.category)) buckets.set(q.category, []);
@@ -61,15 +35,8 @@ function buildQueues(quotes) {
   }
   for (const [cat, arr] of buckets.entries()) {
     shuffle(arr);
-    queues.byCategory.set(cat, { ids: arr, cursor: 0 });
+    state.queues.byCategory.set(cat, { ids: arr, cursor: 0 });
   }
-}
-
-function nextIdFrom(queue) {
-  if (!queue || queue.ids.length === 0) return null;
-  const id = queue.ids[queue.cursor++];
-  if (queue.cursor >= queue.ids.length) queue.cursor = 0; // 使い切ったらループ
-  return id;
 }
 
 // ====================== レンダリング ======================
@@ -113,7 +80,11 @@ function renderQuote(q, mode = (langSelect?.value || 'both')) {
   }
 
   // 検証バッジ
-  toggleBadges(q.verification_status || 'unknown');
+  toggleBadges(q.verification_status || 'unknown', {
+    badgeVerification,
+    badgeAttributed,
+    badgeMisattr,
+  });
 
   // 説明
   quoteExplanation.textContent = q.explanation || '';
@@ -139,8 +110,8 @@ async function fetchJson(url, quiet = false) {
 
 async function loadManifest() {
   try {
-    manifest = await fetchJson('data/manifest.json', true);
-    return manifest;
+    state.manifest = await fetchJson('data/manifest.json', true);
+    return state.manifest;
   } catch {
     return null; // 無ければレガシーへ
   }
@@ -150,9 +121,9 @@ async function loadPack(relPath) {
   const data = await fetchJson(`data/${relPath}`, true);
   const quotes = Array.isArray(data) ? data : data.quotes;
   for (const q of quotes) {
-    byId.set(q.id, q);
+    state.byId.set(q.id, q);
   }
-  allQuotes.push(...quotes);
+  state.allQuotes.push(...quotes);
 }
 
 function legacyToNewSchema(legacy) {
@@ -203,14 +174,14 @@ async function bootstrap(lang = 'ja') {
       // フォールバック：従来 quotes.json を読む
       const legacy = await fetchJson('./quotes.json', true);
       const converted = legacyToNewSchema(legacy);
-      allQuotes = converted;
-      for (const q of converted) byId.set(q.id, q);
+      state.allQuotes = converted;
+      for (const q of converted) state.byId.set(q.id, q);
       loadedAny = converted.length > 0;
     }
     if (!loadedAny) throw new Error('No packs loaded');
-    buildQueues(allQuotes);
+    buildQueues(state.allQuotes);
     quotesLoaded = true;
-    console.log(`Loaded ${allQuotes.length} quotes.`);
+    console.log(`Loaded ${state.allQuotes.length} quotes.`);
     sceneButtons.forEach(btn => btn.disabled = false);
     return true;
   } catch (err) {
@@ -239,14 +210,14 @@ async function bootstrap(lang = 'ja') {
 
 // ====================== 取得＆表示 ======================
 function pickNextQuote() {
-  if (!currentCategory) return null;
-  if (currentCategory === 'all') {
-    const id = nextIdFrom(queues.all);
-    return byId.get(id);
+  if (!state.currentCategory) return null;
+  if (state.currentCategory === 'all') {
+    const id = nextIdFrom(state.queues.all);
+    return state.byId.get(id);
   } else {
-    const bucket = queues.byCategory.get(currentCategory);
+    const bucket = state.queues.byCategory.get(state.currentCategory);
     const id = nextIdFrom(bucket || { ids: [], cursor: 0 });
-    return byId.get(id);
+    return state.byId.get(id);
   }
 }
 
@@ -267,7 +238,7 @@ sceneButtons.forEach(btn => {
       alert('読み込み中です…');
       return;
     }
-    currentCategory = btn.getAttribute('data-category');
+    state.currentCategory = btn.getAttribute('data-category');
     pulseButton(btn);
     setTimeout(showNextQuote, 150);
   });

--- a/game21/index.html
+++ b/game21/index.html
@@ -72,6 +72,6 @@
     </main>
   </div>
 
-  <script src="app.js" defer></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/game21/state.js
+++ b/game21/state.js
@@ -1,0 +1,12 @@
+const state = {
+  currentCategory: null,
+  allQuotes: [],
+  byId: new Map(),
+  manifest: null,
+  queues: {
+    all: { ids: [], cursor: 0 },
+    byCategory: new Map(),
+  },
+};
+
+export default state;

--- a/game21/utils.js
+++ b/game21/utils.js
@@ -1,0 +1,24 @@
+export function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = (Math.random() * (i + 1)) | 0;
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+
+export function inferDirFromLang(lang) {
+  return /^(ar|he|fa|ur)(-|$)/.test(lang || '') ? 'rtl' : 'auto';
+}
+
+export function toggleBadges(status, { badgeVerification, badgeAttributed, badgeMisattr }) {
+  badgeVerification.hidden = badgeAttributed.hidden = badgeMisattr.hidden = true;
+  if (status === 'verified') badgeVerification.hidden = false;
+  else if (status === 'misattributed') badgeMisattr.hidden = false;
+  else badgeAttributed.hidden = false; // attributed/unknown
+}
+
+export function nextIdFrom(queue) {
+  if (!queue || queue.ids.length === 0) return null;
+  const id = queue.ids[queue.cursor++];
+  if (queue.cursor >= queue.ids.length) queue.cursor = 0;
+  return id;
+}


### PR DESCRIPTION
## Summary
- extract shuffle, direction, badge toggling, and queue helpers into `utils.js`
- encapsulate quotes data and category state in shared `state.js`
- load quotes game script as an ES module from `index.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc26f37ce88325b8e4902a8be288fb