### PR TITLE
Persist manifest in state for game21

### DIFF
--- a/game21/app.js
+++ b/game21/app.js
@@ -110,8 +110,8 @@ async function fetchJson(url, quiet = false, cache = 'no-cache') {
 
 async function loadManifest(cache) {
   try {
-    manifest = await fetchJson('data/manifest.json', true, cache);
-    return manifest;
+    state.manifest = await fetchJson('data/manifest.json', true, cache);
+    return state.manifest;
   } catch {
     return null; // 無ければレガシーへ
   }


### PR DESCRIPTION
## Summary
- Store manifest JSON in shared state when loading packs.
- Replace implicit manifest variable with `state.manifest` for clarity.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2e5a33048325b0d38ed3a9990c0c