### PR TITLE
Fix loadPack to store quotes in state and log totals

### DIFF
--- a/game21/app.js
+++ b/game21/app.js
@@ -121,8 +121,14 @@ async function loadPack(relPath, cache) {
   const data = await fetchJson(`data/${relPath}`, true, cache);
   const quotes = Array.isArray(data) ? data : data.quotes;
   for (const q of quotes) {
-    byId.set(q.id, q);
+    if (state.byId.has(q.id)) {
+      console.warn(`Duplicate quote id detected: ${q.id}`);
+      continue;
+    }
+    state.byId.set(q.id, q);
+    state.allQuotes.push(q);
   }
+  console.log(`Loaded ${quotes.length} quotes from ${relPath}. Total quotes: ${state.allQuotes.length}`);
 }
 
 function legacyToNewSchema(legacy) {


### PR DESCRIPTION
## Summary
- Ensure `loadPack` fills `state.byId` and `state.allQuotes`
- Warn on duplicate quote IDs and log cumulative quote totals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2e5e3ff4832593c348d13a49ad17