### PR TITLE
feat(game21): add prominent random button and move UI controls

### DIFF
--- a/game21/index.html
+++ b/game21/index.html
@@ -11,21 +11,10 @@
   <div class="app-container">
     <header class="app-header">
       <h1>✈️ 旅の言葉 🗾</h1>
-
-      <!-- 追加：表示モード＆RTLトグル（任意で非表示にしてもOK） -->
-      <div class="controls" aria-label="表示設定">
-        <label>表示:
-          <select id="langSelect" class="form-control">
-            <option value="both" selected>原文＋日本語</option>
-            <option value="original">原文のみ</option>
-            <option value="ja">日本語のみ</option>
-          </select>
-        </label>
-        <button id="toggleRtl" class="btn btn--outline btn--sm" type="button" aria-pressed="false" aria-label="右から左の表記切替">RTL</button>
-      </div>
     </header>
 
     <main class="main-content">
+      <button class="btn btn--scene btn--random" data-category="all" disabled><span class="button-icon">🎲</span>ランダム</button>
       <article class="quote-card hidden" id="quoteCard" aria-live="polite">
         <div class="quote-scene" id="quoteScene"></div>
 
@@ -67,9 +56,20 @@
         <button class="btn btn--scene" data-category="帰る時" disabled><span class="button-icon">🏠</span>帰る時</button>
         <button class="btn btn--scene" data-category="家族時間" disabled><span class="button-icon">👨‍👩‍👧‍👦</span>家族時間</button>
         <button class="btn btn--scene" data-category="自然体験" disabled><span class="button-icon">🌿</span>自然体験</button>
-        <button class="btn btn--scene btn--all" data-category="all" disabled><span class="button-icon">🎲</span>おまかせ</button>
       </div>
     </main>
+    <footer class="app-footer">
+      <div class="controls" aria-label="表示設定">
+        <label>表示:
+          <select id="langSelect" class="form-control">
+            <option value="both" selected>原文＋日本語</option>
+            <option value="original">原文のみ</option>
+            <option value="ja">日本語のみ</option>
+          </select>
+        </label>
+        <button id="toggleRtl" class="btn btn--outline btn--sm" type="button" aria-pressed="false" aria-label="右から左の表記切替">RTL</button>
+      </div>
+    </footer>
   </div>
 
   <script type="module" src="app.js"></script>

--- a/game21/style.css
+++ b/game21/style.css
@@ -800,6 +800,11 @@ body::before {
   gap: var(--space-32);
 }
 
+.app-footer {
+  text-align: center;
+  margin-top: var(--space-32);
+}
+
 .quote-card {
   display: block;
   background: var(--color-surface);
@@ -901,6 +906,16 @@ body::before {
   overflow: hidden;
   min-height: 80px;
   cursor: pointer;
+}
+
+.btn--random {
+  width: 100%;
+  max-width: 600px;
+  font-size: var(--font-size-lg);
+}
+
+.btn--random .button-icon {
+  font-size: var(--font-size-3xl);
 }
 
 .btn--scene::before {


### PR DESCRIPTION
## Summary
- Rename "おまかせ" to "ランダム" and move it above the quote card
- Relocate language and RTL controls to a footer section
- Style the new random button to span the card width

## Testing
- `npm test` (fails: ENOENT package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bc32062be483258e1467d0d12708f7