### PR TITLE
Add color cycling and glow options to game26

### DIFF
--- a/game26/index.html
+++ b/game26/index.html
@@ -107,6 +107,21 @@
       <label>線色3:</label><input type="color" id="color3" value="#ff66cc" />
     </div>
     <div class="row">
+      <label>色モード:</label>
+      <select id="colorMode">
+        <option value="manual">Manual</option>
+        <option value="cycle">Cycle</option>
+        <option value="red">Red Only</option>
+        <option value="gray">Grayscale</option>
+        <option value="neon">Neon Glow</option>
+      </select>
+    </div>
+    <div class="row" id="hsbRow">
+      <label>Hue:</label><input type="range" id="hue" min="0" max="360" value="0" />
+      <label>S:</label><input type="range" id="sat" min="0" max="100" value="100" />
+      <label>B:</label><input type="range" id="bri" min="0" max="100" value="100" />
+    </div>
+    <div class="row">
       <label>残像フェード</label>
       <input type="range" id="trailFade" min="0.02" max="0.30" step="0.01" value="0.09" />
     </div>
@@ -230,6 +245,7 @@
     seed:12345, rng:mulberry32(12345),
     trail:true, trailFade:0.09, bgColor:'#000000',
     colors:['#ffffff','#66ccff','#ff66cc'],
+    colorMode:'manual', hue:0, sat:100, bri:100, hueSpeed:30,
     colorPhaseAmt:0.60,
     mixWeight:{rotate:0.5,pulse:0.3,orbit:0.2},
     noiseAmp:0.12, noiseFreq:0.80, noiseFlow:0.50,
@@ -345,6 +361,8 @@
     const rect=stage.getBoundingClientRect(), width=rect.width, height=rect.height;
     const cellW=width/state.gridX, cellH=height/state.gridY, cellMin=Math.min(cellW,cellH);
     const base=cellMin*0.36, nFreq=state.noiseFreq, zt=t*state.noiseFlow;
+    const drawColors = computeColors(now/1000);
+    const glow = state.colorMode==='neon'?20:8;
 
     for(const c of state.cells){
       const z01 = state.parallax ? clamp( (c.z * state.zSpread) + (1 - state.zSpread)*0.5 , 0, 1 ) : 0.5;
@@ -367,7 +385,7 @@
       const alphaPar= state.parallax ? lerp(0.65,1.00,z01) : 1.0;
 
       for(let ci=0; ci<3; ci++){
-        const color=state.colors[ci]||'#fff';
+        const color=drawColors[ci]||'#fff';
         const phaseShift=state.colorPhaseAmt*(ci-1);
         const tt=localT+phaseShift;
 
@@ -377,7 +395,8 @@
         else if(c.motion==='pulse') scale*=(0.80+0.20*Math.sin(tt*2.0));
         else if(c.motion==='orbit'){ const r=c.orbitR*scalePar; offx=Math.cos(tt*1.2)*r; offy=Math.sin(tt*1.2)*r; }
         ctxFG.translate(offx,offy); ctxFG.rotate(rot);
-        ctxFG.lineWidth=state.lineWidth*linePar; ctxFG.globalAlpha=alphaPar; ctxFG.strokeStyle=color;
+        ctxFG.lineWidth=state.lineWidth*linePar; ctxFG.globalAlpha=alphaPar;
+        ctxFG.strokeStyle=color; ctxFG.shadowBlur=glow; ctxFG.shadowColor=color;
         drawShape(ctxFG,c.shape,base*scale);
         ctxFG.restore();
       }
@@ -391,6 +410,20 @@
   }
 
   function rgba(hex,a){ const h=hex.replace('#',''); const r=parseInt(h.slice(0,2),16), g=parseInt(h.slice(2,4),16), b=parseInt(h.slice(4,6),16); return `rgba(${r},${g},${b},${a})`; }
+  function hsb2hex(h,s,b){ s/=100; b/=100; const k=n=>(n+h/60)%6; const f=n=>b-b*s*Math.max(Math.min(k(n),4-k(n),1),0); const r=Math.round(255*f(5)),g=Math.round(255*f(3)),bl=Math.round(255*f(1)); return '#'+[r,g,bl].map(x=>x.toString(16).padStart(2,'0')).join(''); }
+  function computeColors(time){
+    if(state.colorMode==='cycle'){
+      const base=(state.hue + time*state.hueSpeed)%360;
+      return [0,1,2].map(i=>hsb2hex((base+i*120)%360,state.sat,state.bri));
+    }else if(state.colorMode==='red'){
+      return ['#ff0000','#aa0000','#ff5555'];
+    }else if(state.colorMode==='gray'){
+      return ['#ffffff','#999999','#555555'];
+    }else if(state.colorMode==='neon'){
+      return ['#ff00f5','#39ff14','#00e5ff'];
+    }
+    return state.colors;
+  }
 
   // ===== UI wiring =====
   const $ = id=>document.getElementById(id);
@@ -402,6 +435,7 @@
     $('seed').value=state.seed; $('toggleTrail').textContent=state.trail?'✨ 残像: ON':'✨ 残像: OFF';
     $('trailFade').value=state.trailFade; $('bgColor').value=state.bgColor;
     $('color1').value=state.colors[0]; $('color2').value=state.colors[1]; $('color3').value=state.colors[2];
+    $('colorMode').value=state.colorMode; $('hue').value=state.hue; $('sat').value=state.sat; $('bri').value=state.bri; $('hsbRow').style.display=state.colorMode==='cycle'?'flex':'none';
     $('shape').value=state.shape; $('motion').value=state.motion;
     $('noiseAmp').value=state.noiseAmp; $('nzAmpVal').textContent=state.noiseAmp.toFixed(2);
     $('noiseFreq').value=state.noiseFreq; $('nzFreqVal').textContent=state.noiseFreq.toFixed(2);
@@ -442,6 +476,10 @@
   $('color1').oninput=e=>{ state.colors[0]=e.target.value; scheduleURLSync(); };
   $('color2').oninput=e=>{ state.colors[1]=e.target.value; scheduleURLSync(); };
   $('color3').oninput=e=>{ state.colors[2]=e.target.value; scheduleURLSync(); };
+  $('colorMode').oninput=e=>{ state.colorMode=e.target.value; updateUIFromState(); scheduleURLSync(); };
+  $('hue').oninput=e=>{ state.hue=parseInt(e.target.value,10); scheduleURLSync(); };
+  $('sat').oninput=e=>{ state.sat=parseInt(e.target.value,10); scheduleURLSync(); };
+  $('bri').oninput=e=>{ state.bri=parseInt(e.target.value,10); scheduleURLSync(); };
   $('trailFade').oninput=e=>{ state.trailFade=parseFloat(e.target.value); scheduleURLSync(); };
   $('shape').oninput=e=>{ state.shape=e.target.value; rebuildLayout(); scheduleURLSync(); };
   $('motion').oninput=e=>{ state.motion=e.target.value; rebuildLayout(); scheduleURLSync(); };
@@ -465,6 +503,7 @@
     q.set('seed',state.seed); q.set('shape',state.shape); q.set('motion',state.motion);
     q.set('trail',state.trail?1:0); q.set('tf',state.trailFade.toFixed(2));
     q.set('bg',state.bgColor.replace('#','')); q.set('c1',state.colors[0].replace('#','')); q.set('c2',state.colors[1].replace('#','')); q.set('c3',state.colors[2].replace('#',''));
+    q.set('cm',state.colorMode); q.set('h',state.hue); q.set('s',state.sat); q.set('b',state.bri);
     q.set('nzA',state.noiseAmp.toFixed(2)); q.set('nzF',state.noiseFreq.toFixed(2)); q.set('nzW',state.noiseFlow.toFixed(2));
     q.set('colP',state.colorPhaseAmt.toFixed(2));
     q.set('wR',state.mixWeight.rotate.toFixed(2)); q.set('wP',state.mixWeight.pulse.toFixed(2)); q.set('wO',state.mixWeight.orbit.toFixed(2));
@@ -481,6 +520,8 @@
     state.seed=getNum('seed',state.seed,v=>parseInt(v,10)); state.shape=getStr('shape',state.shape); state.motion=getStr('motion',state.motion);
     state.trail=getNum('trail',state.trail?1:0,v=>parseInt(v,10))===1; state.trailFade=clamp(getNum('tf',state.trailFade),0.02,0.30);
     state.bgColor=getHex('bg',state.bgColor); state.colors[0]=getHex('c1',state.colors[0]); state.colors[1]=getHex('c2',state.colors[1]); state.colors[2]=getHex('c3',state.colors[2]);
+    state.colorMode=getStr('cm',state.colorMode); state.hue=clamp(getNum('h',state.hue,v=>parseInt(v,10)),0,360);
+    state.sat=clamp(getNum('s',state.sat,v=>parseInt(v,10)),0,100); state.bri=clamp(getNum('b',state.bri,v=>parseInt(v,10)),0,100);
     state.noiseAmp=clamp(getNum('nzA',state.noiseAmp),0,0.40); state.noiseFreq=clamp(getNum('nzF',state.noiseFreq),0.10,2.00); state.noiseFlow=clamp(getNum('nzW',state.noiseFlow),0,2.00);
     state.colorPhaseAmt=clamp(getNum('colP',state.colorPhaseAmt),0,1.50);
     state.mixWeight.rotate=clamp(getNum('wR',state.mixWeight.rotate),0,1); state.mixWeight.pulse=clamp(getNum('wP',state.mixWeight.pulse),0,1); state.mixWeight.orbit=clamp(getNum('wO',state.mixWeight.orbit),0,1);


### PR DESCRIPTION
## Summary
- add color mode dropdown and HSB sliders for dynamic palettes
- support automatic color cycling and theme presets including red, grayscale, and neon
- draw shapes with canvas shadow blur and color-based glow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc363ba358832584aa16776abbc674