### PR TITLE
feat(game26): add directional grid flow controls

### DIFF
--- a/game26/index.html
+++ b/game26/index.html
@@ -120,8 +120,16 @@
       <input type="range" id="trailFade" min="0.02" max="0.30" step="0.01" value="0.09" />
     </div>
     <div class="row">
-      <label>グリッド流速: <span id="gFlowVal">0.50</span></label>
-      <input type="range" id="gridFlow" min="0" max="3" step="0.05" value="0.50" />
+      <label>グリッドX流速: <span id="gFlowXVal">0.50</span></label>
+      <input type="range" id="gridFlowX" min="0" max="3" step="0.05" value="0.50" />
+    </div>
+    <div class="row">
+      <label>グリッドY流速: <span id="gFlowYVal">0.50</span></label>
+      <input type="range" id="gridFlowY" min="0" max="3" step="0.05" value="0.50" />
+    </div>
+    <div class="row">
+      <label>グリッド基準角度: <span id="gBaseAngleVal">0</span>°</label>
+      <input type="range" id="gridBaseAngle" min="-180" max="180" step="1" value="0" />
     </div>
     <div class="row">
       <label>グリッド角速度: <span id="gAngleVal">0</span>°/s</label>
@@ -255,7 +263,7 @@
     colorPhaseAmt:0.60,
     mixWeight:{rotate:0.5,pulse:0.3,orbit:0.2},
     noiseAmp:0.12, noiseFreq:0.80, noiseFlow:0.50,
-    gridFlow:0.50, gridAngle:0, gridScaleVar:0.00,
+    gridFlowX:0.50, gridFlowY:0.50, gridBaseAngle:0, gridAngle:0, gridScaleVar:0.00,
     crossover:true, coAmp:0.60,
     parallax:true, zSpread:0.70,
     cells:[], fps:0, totalPaths:0, safety:'OK',
@@ -327,8 +335,9 @@ function drawShape(ctx,shape,s){ switch(shape){
     const width=rect.width, height=rect.height;
     const base=Math.min(width,height)/state.gridX;
     const spacing=base*(1+Math.sin(t)*state.gridScaleVar);
-    const offset=(t*state.gridFlow*base)%spacing;
-    const angle=t*state.gridAngle*Math.PI/180;
+    const offsetX=(t*state.gridFlowX*base)%spacing;
+    const offsetY=(t*state.gridFlowY*base)%spacing;
+    const angle=(state.gridBaseAngle + t*state.gridAngle)*Math.PI/180;
     ctxBG.save();
     ctxBG.translate(width/2,height/2);
     ctxBG.rotate(angle);
@@ -336,8 +345,8 @@ function drawShape(ctx,shape,s){ switch(shape){
     ctxBG.strokeStyle=rgba(state.colors[0],0.15);
     ctxBG.lineWidth=1;
     ctxBG.beginPath();
-    for(let x=-spacing+offset; x<width+spacing; x+=spacing){ ctxBG.moveTo(x,0); ctxBG.lineTo(x,height); }
-    for(let y=-spacing+offset; y<height+spacing; y+=spacing){ ctxBG.moveTo(0,y); ctxBG.lineTo(width,y); }
+    for(let x=-spacing+offsetX; x<width+spacing; x+=spacing){ ctxBG.moveTo(x,0); ctxBG.lineTo(x,height); }
+    for(let y=-spacing+offsetY; y<height+spacing; y+=spacing){ ctxBG.moveTo(0,y); ctxBG.lineTo(width,y); }
     ctxBG.stroke();
     ctxBG.restore();
   }
@@ -474,7 +483,9 @@ function drawShape(ctx,shape,s){ switch(shape){
     $('noiseAmp').value=state.noiseAmp; $('nzAmpVal').textContent=state.noiseAmp.toFixed(2);
     $('noiseFreq').value=state.noiseFreq; $('nzFreqVal').textContent=state.noiseFreq.toFixed(2);
     $('noiseFlow').value=state.noiseFlow; $('nzFlowVal').textContent=state.noiseFlow.toFixed(2);
-    $('gridFlow').value=state.gridFlow; $('gFlowVal').textContent=state.gridFlow.toFixed(2);
+    $('gridFlowX').value=state.gridFlowX; $('gFlowXVal').textContent=state.gridFlowX.toFixed(2);
+    $('gridFlowY').value=state.gridFlowY; $('gFlowYVal').textContent=state.gridFlowY.toFixed(2);
+    $('gridBaseAngle').value=state.gridBaseAngle; $('gBaseAngleVal').textContent=state.gridBaseAngle.toFixed(0);
     $('gridAngle').value=state.gridAngle; $('gAngleVal').textContent=state.gridAngle.toFixed(0);
     $('gridScaleVar').value=state.gridScaleVar; $('gScaleVarVal').textContent=state.gridScaleVar.toFixed(2);
     $('phaseColor').value=state.colorPhaseAmt; $('phaseColVal').textContent=state.colorPhaseAmt.toFixed(2);
@@ -524,7 +535,9 @@ function drawShape(ctx,shape,s){ switch(shape){
   $('noiseAmp').oninput=e=>{ state.noiseAmp=parseFloat(e.target.value); $('nzAmpVal').textContent=state.noiseAmp.toFixed(2); };
   $('noiseFreq').oninput=e=>{ state.noiseFreq=parseFloat(e.target.value); $('nzFreqVal').textContent=state.noiseFreq.toFixed(2); };
   $('noiseFlow').oninput=e=>{ state.noiseFlow=parseFloat(e.target.value); $('nzFlowVal').textContent=state.noiseFlow.toFixed(2); };
-  $('gridFlow').oninput=e=>{ state.gridFlow=parseFloat(e.target.value); $('gFlowVal').textContent=state.gridFlow.toFixed(2); scheduleURLSync(); };
+  $('gridFlowX').oninput=e=>{ state.gridFlowX=parseFloat(e.target.value); $('gFlowXVal').textContent=state.gridFlowX.toFixed(2); scheduleURLSync(); };
+  $('gridFlowY').oninput=e=>{ state.gridFlowY=parseFloat(e.target.value); $('gFlowYVal').textContent=state.gridFlowY.toFixed(2); scheduleURLSync(); };
+  $('gridBaseAngle').oninput=e=>{ state.gridBaseAngle=parseFloat(e.target.value); $('gBaseAngleVal').textContent=state.gridBaseAngle.toFixed(0); scheduleURLSync(); };
   $('gridAngle').oninput=e=>{ state.gridAngle=parseFloat(e.target.value); $('gAngleVal').textContent=state.gridAngle.toFixed(0); scheduleURLSync(); };
   $('gridScaleVar').oninput=e=>{ state.gridScaleVar=parseFloat(e.target.value); $('gScaleVarVal').textContent=state.gridScaleVar.toFixed(2); scheduleURLSync(); };
   $('phaseColor').oninput=e=>{ state.colorPhaseAmt=parseFloat(e.target.value); $('phaseColVal').textContent=state.colorPhaseAmt.toFixed(2); };
@@ -546,7 +559,8 @@ function drawShape(ctx,shape,s){ switch(shape){
     q.set('cm',state.colorMode); q.set('h',state.hue); q.set('s',state.sat); q.set('b',state.bri);
     q.set('nzA',state.noiseAmp.toFixed(2)); q.set('nzF',state.noiseFreq.toFixed(2)); q.set('nzW',state.noiseFlow.toFixed(2));
     q.set('colP',state.colorPhaseAmt.toFixed(2));
-    q.set('gF',state.gridFlow.toFixed(2)); q.set('gA',state.gridAngle.toFixed(1)); q.set('gS',state.gridScaleVar.toFixed(2));
+    q.set('gFx',state.gridFlowX.toFixed(2)); q.set('gFy',state.gridFlowY.toFixed(2));
+    q.set('gBA',state.gridBaseAngle.toFixed(1)); q.set('gA',state.gridAngle.toFixed(1)); q.set('gS',state.gridScaleVar.toFixed(2));
     q.set('wR',state.mixWeight.rotate.toFixed(2)); q.set('wP',state.mixWeight.pulse.toFixed(2)); q.set('wO',state.mixWeight.orbit.toFixed(2));
     q.set('co',state.crossover?1:0); q.set('coA',state.coAmp.toFixed(2)); q.set('px',state.parallax?1:0); q.set('zS',state.zSpread.toFixed(2));
     // Auto-Mod（共有は最小限）
@@ -565,7 +579,9 @@ function drawShape(ctx,shape,s){ switch(shape){
     state.sat=clamp(getNum('s',state.sat,v=>parseInt(v,10)),0,100); state.bri=clamp(getNum('b',state.bri,v=>parseInt(v,10)),0,100);
     state.noiseAmp=clamp(getNum('nzA',state.noiseAmp),0,0.40); state.noiseFreq=clamp(getNum('nzF',state.noiseFreq),0.10,2.00); state.noiseFlow=clamp(getNum('nzW',state.noiseFlow),0,2.00);
     state.colorPhaseAmt=clamp(getNum('colP',state.colorPhaseAmt),0,1.50);
-    state.gridFlow=clamp(getNum('gF',state.gridFlow),0,3); state.gridAngle=clamp(getNum('gA',state.gridAngle),-180,180); state.gridScaleVar=clamp(getNum('gS',state.gridScaleVar),0,1);
+    state.gridFlowX=clamp(getNum('gFx',state.gridFlowX),0,3); state.gridFlowY=clamp(getNum('gFy',state.gridFlowY),0,3);
+    state.gridBaseAngle=clamp(getNum('gBA',state.gridBaseAngle),-180,180);
+    state.gridAngle=clamp(getNum('gA',state.gridAngle),-180,180); state.gridScaleVar=clamp(getNum('gS',state.gridScaleVar),0,1);
     state.mixWeight.rotate=clamp(getNum('wR',state.mixWeight.rotate),0,1); state.mixWeight.pulse=clamp(getNum('wP',state.mixWeight.pulse),0,1); state.mixWeight.orbit=clamp(getNum('wO',state.mixWeight.orbit),0,1);
     state.crossover=getNum('co',state.crossover?1:0,v=>parseInt(v,10))===1; state.coAmp=clamp(getNum('coA',state.coAmp),0,2.00);
     state.parallax=getNum('px',state.parallax?1:0,v=>parseInt(v,10))===1; state.zSpread=clamp(getNum('zS',state.zSpread),0,1.00);


### PR DESCRIPTION
## Summary
- add gridFlowX, gridFlowY, and gridBaseAngle to state
- expose directional grid flow sliders and base angle control
- update grid rendering and URL serialization for new parameters

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc419f3b7483258d4e5935e651e3d3