### PR TITLE
Improve dark mode quote card text visibility in game21

### DIFF
--- a/game21/style.css
+++ b/game21/style.css
@@ -1063,3 +1063,15 @@ body::before {
   text-align: center;
   margin-bottom: var(--space-8);
 }
+
+@media (prefers-color-scheme: dark) {
+  .quote-text,
+  .quote-original {
+    color: var(--color-text);
+  }
+}
+
+[data-color-scheme="dark"] .quote-text,
+[data-color-scheme="dark"] .quote-original {
+  color: var(--color-text);
+}


### PR DESCRIPTION
## Summary
- improve readability of quote cards in dark mode by using the standard text color

## Testing
- `npm test` (fails: ENOENT no package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bc66275a088325a28ea4e638b2142a