### PR TITLE
feat(game27): support gradient and rainbow strokes

### DIFF
--- a/game27/index.html
+++ b/game27/index.html
@@ -45,6 +45,22 @@
                         <input type="color" id="strokeColor" class="color-input" value="#00ff88">
                     </div>
                     <div class="form-group">
+                        <label class="form-label">色モード</label>
+                        <select id="colorMode" class="form-control">
+                            <option value="solid" selected>単色</option>
+                            <option value="gradient">グラデーション</option>
+                            <option value="rainbow">レインボー</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">グラデーション終点色</label>
+                        <input type="color" id="gradientEndColor" class="color-input" value="#ff0088">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">色相シフト: <span id="hueShiftValue">30</span>°</label>
+                        <input type="range" id="hueShift" class="form-control" min="0" max="360" value="30" step="1">
+                    </div>
+                    <div class="form-group">
                         <label class="form-label">ブラシサイズ: <span id="strokeWidthValue">3</span>px</label>
                         <input type="range" id="strokeWidth" class="form-control" min="1" max="10" value="3" step="0.5">
                     </div>

--- a/game27/style.css
+++ b/game27/style.css
@@ -820,6 +820,8 @@ select.form-control {
 .settings-content {
   max-height: calc(100vh - 120px);
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
   padding: 0;
   transition: all var(--duration-normal) var(--ease-standard);
 }
@@ -879,6 +881,11 @@ select.form-control {
 .color-input::-webkit-color-swatch {
   border: none;
   border-radius: calc(var(--radius-base) - 2px);
+}
+
+/* Color effect controls */
+#hueShift {
+  accent-color: var(--color-teal-300);
 }
 
 /* Range Inputs */


### PR DESCRIPTION
## Summary
- add color mode selector with gradient and rainbow options
- implement color interpolation and hue shift algorithms
- style hue shift control
- limit global touchmove prevention to canvas to allow mobile scrolling
- enable touch-friendly scroll behavior on settings panel

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check game27/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c59f9f42e08325a96087d0cf7b0a98