### PR TITLE
docs: update echo defaults for game27

### DIFF
--- a/game27/ADR.md
+++ b/game27/ADR.md
@@ -20,7 +20,7 @@
 
 ## ADR-003: Dual Timer System (RAF + setInterval) 
 **Date:** 2025-09-13  
-**Context:** Echo generation timing needs to be consistent (100ms) while drawing updates need smooth 60fps.  
+**Context:** Echo generation timing needs to be consistent (70ms) while drawing updates need smooth 60fps.
 **Decision:** Use requestAnimationFrame for drawing loop and separate setInterval for echo snapshots.  
 **Rationale:** RAF provides optimal frame pacing for smooth drawing. setInterval ensures consistent echo timing independent of frame rate. Dual system prevents echo timing drift during performance variations.  
 **Consequences:** Slightly more complex scheduler implementation. Echo timing may lag briefly during heavy performance drops, but this is acceptable vs. timing drift.

--- a/game27/DRAWING.md
+++ b/game27/DRAWING.md
@@ -32,12 +32,12 @@ For echo at depth k:
 ### Echo Timing
 | Parameter | Default | Range | Unit | Effect |
 |-----------|---------|-------|------|--------|
-| echoIntervalMs | 100 | 30–200 | ms | How often new echoes are created |
+| echoIntervalMs | 70 | 30–200 | ms | How often new echoes are created |
 
 ### Echo Quantity  
 | Parameter | Default | Range | Unit | Effect |
 |-----------|---------|-------|------|--------|
-| echoCountMax | 36 | 10–80 | count | Maximum simultaneous echoes |
+| echoCountMax | 80 | 10–200 | count | Maximum simultaneous echoes |
 
 ### Spatial Transform
 | Parameter | Default | Range | Unit | Effect |
@@ -76,8 +76,8 @@ For echo at depth k:
 
 ### Depth-Soft (Default)
 ```
-echoIntervalMs: 100
-echoCountMax: 36
+echoIntervalMs: 70
+echoCountMax: 80
 shiftX: -8, shiftY: -5
 scalePerEcho: 0.965
 alphaPerEcho: 0.93

--- a/game27/OVERVIEW.md
+++ b/game27/OVERVIEW.md
@@ -7,7 +7,7 @@
 - **Design Principle**: One-way dependencies, renderer abstraction, performance-first fallback
 
 ## Core Concept
-The app captures user strokes every 0.1s, creates "echo snapshots" that gradually fade towards the left-back direction (-X, -Y, +Z visual effect), with automatic size/opacity/blur reduction to simulate depth.
+The app captures user strokes every 70ms, creating "echo snapshots" that gradually fade towards the left-back direction (-X, -Y, +Z visual effect), with automatic size/opacity/blur reduction to simulate depth.
 
 ## Module Responsibilities
 
@@ -56,7 +56,7 @@ App (coordinator)
 ## Data Flow
 1. **Input**: Pointer events → normalized Points → StrokeManager
 2. **Drawing**: Active stroke updated in real-time via RAF
-3. **Echo Generation**: Every 0.1s, current stroke snapshot → EchoManager queue
+3. **Echo Generation**: Every 70ms, current stroke snapshot → EchoManager queue
 4. **Rendering**: Clear → Draw echoes (back-to-front) → Draw active stroke
 5. **Performance**: Monitor frame time → Governor adjusts settings if needed
 

--- a/game27/PERF.md
+++ b/game27/PERF.md
@@ -191,16 +191,16 @@ When enabled, displays:
 ### Console Logging
 Performance events are logged with timestamps for debugging:
 ```
-[09:13:45.123] Performance fallback Stage 2: Echo count reduced to 28
+[09:13:45.123] Performance fallback Stage 2: Echo count reduced to 72
 [09:13:50.456] Echo render time: 12.3ms (target: <8ms)
-[09:14:02.789] Performance recovery Stage 2→1: Echo count restored to 36
+[09:14:02.789] Performance recovery Stage 2→1: Echo count restored to 80
 ```
 
 ### Export Performance Data
 Debug builds can export performance data as CSV for analysis:
 ```
 timestamp,fps,frameMs,echoRenderMs,echoCount,stage,memoryMB
-1694598825123,58.2,17.2,6.1,36,0,45.2
-1694598825139,56.8,17.6,6.8,36,0,45.3
+1694598825123,58.2,17.2,6.1,80,0,45.2
+1694598825139,56.8,17.6,6.8,80,0,45.3
 ...
 ```

--- a/game27/TEST.md
+++ b/game27/TEST.md
@@ -25,11 +25,11 @@
 ### Echo Generation Tests
 | Test Case | Scenario | Expected Behavior | Pass Criteria |
 |-----------|----------|-------------------|---------------|
-| Echo Timing | Draw for 1 second | ~10 echoes generated (100ms interval) | 9-11 echoes present |
+| Echo Timing | Draw for 1 second | ~14 echoes generated (70ms interval) | 13-15 echoes present |
 | Echo Positioning | Single stroke | Echoes fade toward left-back | Each echo offset by (-8,-5) × k |
 | Echo Scaling | Various strokes | Size decreases with depth | Each echo 96.5% of previous |
 | Echo Alpha | Continuous drawing | Opacity fades correctly | Each echo 93% opacity of previous |
-| Max Echo Count | Long drawing session | Count capped at 36 | Never exceeds echoCountMax |
+| Max Echo Count | Long drawing session | Count capped at 80 | Never exceeds echoCountMax |
 
 ### Rendering Quality Tests  
 | Test Case | Scenario | Expected Behavior | Pass Criteria |
@@ -127,7 +127,7 @@
 
 ### Functional Requirements  
 - [ ] Drawing works smoothly with mouse, touch, and Apple Pencil
-- [ ] Echo generation maintains 100ms ±10ms timing accuracy
+- [ ] Echo generation maintains 70ms ±10ms timing accuracy
 - [ ] All four preset configurations produce visually distinct results
 - [ ] Settings changes apply immediately without requiring restart
 - [ ] Canvas clears completely with clear button


### PR DESCRIPTION
## Summary
- document new default echo timing of 70 ms
- raise max echo count default to 80 and extend range to 200
- sync tests and design docs with updated echo parameters

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b2e31e6883258112696337734d3a