### PR TITLE
Align depth-soft preset with default settings in game27

### DIFF
--- a/game27/app.js
+++ b/game27/app.js
@@ -22,16 +22,16 @@ class EchoDrawingApp {
         
         this.presets = {
             'depth-soft': {
-                echoIntervalMs: 100,
-                echoCountMax: 36,
-                shiftX: -8,
-                shiftY: -5,
-                scalePerEcho: 0.965,
-                alphaPerEcho: 0.93,
-                blurPerEcho: 0.2,
-                colorDecay: 'light',
-                colorMode: 'solid',
-                gradientEndColor: '#ff0088',
+                echoIntervalMs: 70,
+                echoCountMax: 80,
+                shiftX: -1,
+                shiftY: -2,
+                scalePerEcho: 0.99,
+                alphaPerEcho: 0.98,
+                blurPerEcho: 0,
+                colorDecay: 'off',
+                colorMode: 'gradient',
+                gradientEndColor: '#ff0078',
                 hueShift: 30
             },
             'film-echo': {


### PR DESCRIPTION
## Summary
- Sync `depth-soft` preset with baseline configuration (80 echoes, gradient colors, no color decay)
- Reviewed remaining presets and confirmed consistency with specs

## Testing
- `node --check game27/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7b3ebaf9c832599e1ff2001f0bed3