### PR TITLE
Update game27 presets and default configuration

### DIFF
--- a/game27/app.js
+++ b/game27/app.js
@@ -21,7 +21,7 @@ class EchoDrawingApp {
         };
         
         this.presets = {
-            'depth-soft': {
+            'default': {
                 echoIntervalMs: 70,
                 echoCountMax: 80,
                 shiftX: -1,
@@ -32,33 +32,42 @@ class EchoDrawingApp {
                 colorDecay: 'off',
                 colorMode: 'gradient',
                 gradientEndColor: '#ff0078',
-                hueShift: 30
+                hueShift: 30,
+                strokeColor: '#00c8ff',
+                strokeWidth: 3,
+                strokeAlpha: 0.75
             },
-            'film-echo': {
-                echoIntervalMs: 120,
-                echoCountMax: 24,
-                shiftX: -10,
-                shiftY: -6,
-                scalePerEcho: 0.95,
-                alphaPerEcho: 0.9,
-                blurPerEcho: 0.4,
-                colorDecay: 'strong',
-                colorMode: 'solid',
-                gradientEndColor: '#ff0088',
-                hueShift: 30
+            'rainbow': {
+                echoIntervalMs: 40,
+                echoCountMax: 200,
+                shiftX: 5,
+                shiftY: 0,
+                scalePerEcho: 0.99,
+                alphaPerEcho: 0.98,
+                blurPerEcho: 0,
+                colorDecay: 'off',
+                colorMode: 'rainbow',
+                gradientEndColor: '#ff0000',
+                hueShift: 3,
+                strokeColor: '#ff0000',
+                strokeWidth: 5,
+                strokeAlpha: 1
             },
             'wireframe-lite': {
-                echoIntervalMs: 80,
-                echoCountMax: 32,
-                shiftX: -5,
-                shiftY: -3,
-                scalePerEcho: 0.975,
-                alphaPerEcho: 0.95,
-                blurPerEcho: 0.0,
+                echoIntervalMs: 30,
+                echoCountMax: 20,
+                shiftX: 20,
+                shiftY: 1,
+                scalePerEcho: 0.9,
+                alphaPerEcho: 0.98,
+                blurPerEcho: 0,
                 colorDecay: 'off',
                 colorMode: 'solid',
-                gradientEndColor: '#ff0088',
-                hueShift: 30
+                gradientEndColor: '#000000',
+                hueShift: 30,
+                strokeColor: '#00ff64',
+                strokeWidth: 1,
+                strokeAlpha: 1
             }
         };
         
@@ -228,17 +237,21 @@ class EchoDrawingApp {
         
         Object.assign(this.settings, preset);
         this.echoManager.setMaxEchoes(this.settings.echoCountMax);
-        
+
         // Update UI controls
         Object.keys(preset).forEach(key => {
             const element = document.getElementById(this.getControlId(key));
             if (element) {
-                element.value = preset[key];
-                
+                let value = preset[key];
+                if (key === 'strokeAlpha') {
+                    value = preset[key] * 100;
+                }
+                element.value = value;
+
                 // Update display values
                 const valueDisplay = document.getElementById(this.getControlId(key) + 'Value');
                 if (valueDisplay) {
-                    valueDisplay.textContent = preset[key];
+                    valueDisplay.textContent = value;
                 }
             }
         });

--- a/game27/index.html
+++ b/game27/index.html
@@ -31,8 +31,8 @@
                 <div class="settings-section">
                     <h4>プリセット</h4>
                     <div class="preset-buttons">
-                        <button class="btn btn--secondary btn--sm preset-btn active" data-preset="depth-soft">深度ソフト</button>
-                        <button class="btn btn--secondary btn--sm preset-btn" data-preset="film-echo">フィルムエコー</button>
+                        <button class="btn btn--secondary btn--sm preset-btn active" data-preset="default">デフォルト</button>
+                        <button class="btn btn--secondary btn--sm preset-btn" data-preset="rainbow">レインボー</button>
                         <button class="btn btn--secondary btn--sm preset-btn" data-preset="wireframe-lite">ワイヤーフレーム</button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Rename and expand presets: new `default`, `rainbow`, and revised `wireframe-lite` with updated echo, color, and brush settings.
- Ensure applying presets updates all UI controls and echo limits, including stroke opacity handling.
- Adjust preset buttons in the interface to match new names.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c79adbc8d48325bf894714f085e6b8