### PR TITLE
Add fullscreen mode to game24

### DIFF
--- a/game24/index.html
+++ b/game24/index.html
@@ -29,6 +29,7 @@
                         <button id="playPauseBtn" class="btn btn--primary">再生</button>
                         <button id="resetBtn" class="btn btn--secondary">リセット</button>
                         <button id="snapshotBtn" class="btn btn--outline">スナップショット</button>
+                        <button id="fullscreenBtn" class="btn btn--outline" aria-pressed="false">全画面</button>
                     </div>
                 </div>
 

--- a/game24/style.css
+++ b/game24/style.css
@@ -856,6 +856,12 @@ select.form-control {
   justify-content: center;
 }
 
+#fullscreenBtn[aria-pressed="true"] {
+  background: var(--color-primary);
+  color: var(--color-btn-primary-text);
+  border-color: var(--color-primary);
+}
+
 .controls-container {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
@@ -1158,6 +1164,33 @@ input[type="range"]:focus {
 
 .laser-counter.highlight {
   animation: laserCountHighlight 0.8s ease-out;
+}
+
+/* Fullscreen mode adjustments */
+body.fullscreen-active {
+  overflow: hidden;
+  background: var(--color-black);
+}
+
+.container.is-fullscreen {
+  max-width: none;
+  width: 100vw;
+  height: 100vh;
+  padding-right: var(--space-16);
+  padding-left: var(--space-16);
+}
+
+.container.is-fullscreen .main-content {
+  height: calc(100vh - 120px);
+  min-height: 0;
+}
+
+.container.is-fullscreen .control-panel {
+  overflow-y: auto;
+}
+
+.container.is-fullscreen .canvas-container {
+  padding: var(--space-16);
 }
 
 @keyframes aspectHighlight {


### PR DESCRIPTION
## Summary
- add a fullscreen toggle control to the laser billiards interface
- update canvas resizing logic and fullscreen state management in the app script
- adjust styles for the fullscreen layout and button state

## Testing
- not run (frontend change only)

------
https://chatgpt.com/codex/tasks/task_e_68c933f4e5ac832583e410af49682adb