### PR TITLE
Add motion presets and UI controls to game27

### DIFF
--- a/game27/app.js
+++ b/game27/app.js
@@ -31,14 +31,6 @@ class EchoDrawingApp {
             'default': {
                 echoIntervalMs: 70,
                 echoCountMax: 80,
-                shiftX: -1,
-                shiftY: -2,
-                shiftXMode: 'static',
-                shiftYMode: 'static',
-                shiftXOscAmplitude: 0,
-                shiftYOscAmplitude: 0,
-                shiftXOscFrequency: 1,
-                shiftYOscFrequency: 1,
                 scalePerEcho: 0.99,
                 alphaPerEcho: 0.98,
                 blurPerEcho: 0,
@@ -54,14 +46,6 @@ class EchoDrawingApp {
             'rainbow': {
                 echoIntervalMs: 40,
                 echoCountMax: 200,
-                shiftX: 5,
-                shiftY: 0,
-                shiftXMode: 'oscillate',
-                shiftYMode: 'oscillate',
-                shiftXOscAmplitude: 25,
-                shiftYOscAmplitude: 15,
-                shiftXOscFrequency: 0.6,
-                shiftYOscFrequency: 0.9,
                 scalePerEcho: 0.99,
                 alphaPerEcho: 0.98,
                 blurPerEcho: 0,
@@ -76,14 +60,6 @@ class EchoDrawingApp {
             'wireframe-lite': {
                 echoIntervalMs: 30,
                 echoCountMax: 20,
-                shiftX: 20,
-                shiftY: 1,
-                shiftXMode: 'static',
-                shiftYMode: 'static',
-                shiftXOscAmplitude: 0,
-                shiftYOscAmplitude: 0,
-                shiftXOscFrequency: 1,
-                shiftYOscFrequency: 1,
                 scalePerEcho: 0.9,
                 alphaPerEcho: 0.98,
                 blurPerEcho: 0,
@@ -96,6 +72,54 @@ class EchoDrawingApp {
                 strokeAlpha: 1
             }
         };
+
+        this.motionPresets = {
+            steady: {
+                shiftX: -1,
+                shiftY: -2,
+                shiftXMode: 'static',
+                shiftYMode: 'static',
+                shiftXOscAmplitude: 0,
+                shiftYOscAmplitude: 0,
+                shiftXOscFrequency: 1,
+                shiftYOscFrequency: 1
+            },
+            sway: {
+                shiftX: 0,
+                shiftY: 0,
+                shiftXMode: 'oscillate',
+                shiftYMode: 'oscillate',
+                shiftXOscAmplitude: 25,
+                shiftYOscAmplitude: 15,
+                shiftXOscFrequency: 0.6,
+                shiftYOscFrequency: 0.5
+            },
+            orbit: {
+                shiftX: 3,
+                shiftY: 3,
+                shiftXMode: 'oscillate',
+                shiftYMode: 'oscillate',
+                shiftXOscAmplitude: 35,
+                shiftYOscAmplitude: 35,
+                shiftXOscFrequency: 0.4,
+                shiftYOscFrequency: 0.4
+            }
+        };
+
+        this.activePreset = 'default';
+        this.activeMotionPreset = 'steady';
+        this.presetButtons = [];
+        this.motionPresetButtons = [];
+        this.shiftSettingKeys = [
+            'shiftX',
+            'shiftY',
+            'shiftXMode',
+            'shiftYMode',
+            'shiftXOscAmplitude',
+            'shiftYOscAmplitude',
+            'shiftXOscFrequency',
+            'shiftYOscFrequency'
+        ];
         
         this.strokeManager = new StrokeManager();
         this.echoManager = new EchoManager(this.settings.echoCountMax);
@@ -117,6 +141,8 @@ class EchoDrawingApp {
         this.setupSettings();
         this.startRenderLoop();
         this.startEchoTimer();
+
+        this.applyPreset(this.activePreset);
 
         document.querySelector('.app-container').classList.add('loaded');
     }
@@ -167,18 +193,15 @@ class EchoDrawingApp {
         document.getElementById('toggleSettings').addEventListener('click', () => {
             this.toggleSettingsPanel();
         });
+
+        this.bindPresetButtons();
+        this.bindMotionPresetButtons();
     }
-    
+
     setupSettings() {
-        // Preset buttons
-        document.querySelectorAll('.preset-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                this.applyPreset(e.target.dataset.preset);
-                document.querySelectorAll('.preset-btn').forEach(b => b.classList.remove('active'));
-                e.target.classList.add('active');
-            });
-        });
-        
+        this.bindPresetButtons();
+        this.bindMotionPresetButtons();
+
         // Settings controls
         this.setupSettingControl('strokeColor', 'color', (value) => {
             this.settings.strokeColor = value;
@@ -285,6 +308,38 @@ class EchoDrawingApp {
         this.updateShiftAxisState('Y');
     }
 
+    bindPresetButtons() {
+        const buttons = Array.from(document.querySelectorAll('.preset-btn'));
+        buttons.forEach(btn => {
+            if (btn.dataset.presetBound === 'true') {
+                return;
+            }
+            btn.addEventListener('click', (e) => {
+                e.preventDefault();
+                const presetName = e.currentTarget.dataset.preset;
+                this.applyPreset(presetName);
+            });
+            btn.dataset.presetBound = 'true';
+        });
+        this.presetButtons = buttons;
+    }
+
+    bindMotionPresetButtons() {
+        const buttons = Array.from(document.querySelectorAll('.motion-preset-btn'));
+        buttons.forEach(btn => {
+            if (btn.dataset.motionBound === 'true') {
+                return;
+            }
+            btn.addEventListener('click', (e) => {
+                e.preventDefault();
+                const presetName = e.currentTarget.dataset.motion;
+                this.applyMotionPreset(presetName);
+            });
+            btn.dataset.motionBound = 'true';
+        });
+        this.motionPresetButtons = buttons;
+    }
+
     setupSettingControl(id, type, callback) {
         const element = document.getElementById(id);
         const event = type === 'range' ? 'input' : 'change';
@@ -317,31 +372,40 @@ class EchoDrawingApp {
         const preset = this.presets[presetName];
         if (!preset) return;
 
-        Object.assign(this.settings, preset);
-        this.echoManager.setMaxEchoes(this.settings.echoCountMax);
+        this.activePreset = presetName;
 
-        // Update UI controls
         Object.keys(preset).forEach(key => {
-            const element = document.getElementById(this.getControlId(key));
-            if (element) {
-                let value = preset[key];
-                if (key === 'strokeAlpha') {
-                    value = preset[key] * 100;
-                }
-                element.value = value;
+            if (this.shiftSettingKeys.includes(key)) {
+                return;
+            }
 
-                // Update display values
-                const valueDisplay = document.getElementById(this.getControlId(key) + 'Value');
-                if (valueDisplay) {
-                    valueDisplay.textContent = this.formatSettingValue(key, value);
-                }
+            const value = preset[key];
+            this.settings[key] = value;
+
+            if (key === 'strokeAlpha') {
+                this.updateControlValue(key, value * 100);
+            } else {
+                this.updateControlValue(key, value);
             }
         });
 
-        this.updateShiftAxisState('X');
-        this.updateShiftAxisState('Y');
-        this.restartEchoTimer();
+        this.echoManager.setMaxEchoes(this.settings.echoCountMax);
+
+        if (this.presetButtons.length) {
+            this.presetButtons.forEach(btn => {
+                btn.classList.toggle('active', btn.dataset.preset === presetName);
+            });
+        }
+
         this.updateBackgroundEffect();
+
+        const activeMotion = (this.activeMotionPreset && this.motionPresets[this.activeMotionPreset])
+            ? this.activeMotionPreset
+            : Object.keys(this.motionPresets)[0];
+
+        if (activeMotion) {
+            this.applyMotionPreset(activeMotion);
+        }
     }
 
     getControlId(settingKey) {
@@ -350,6 +414,42 @@ class EchoDrawingApp {
             echoCountMax: 'echoCount'
         };
         return mapping[settingKey] || settingKey;
+    }
+
+    updateControlValue(settingKey, value) {
+        const controlId = this.getControlId(settingKey);
+        const element = document.getElementById(controlId);
+        if (!element) return;
+
+        element.value = value;
+
+        const valueDisplay = document.getElementById(controlId + 'Value');
+        if (valueDisplay) {
+            valueDisplay.textContent = this.formatSettingValue(settingKey, value);
+        }
+    }
+
+    applyMotionPreset(presetName) {
+        const preset = this.motionPresets[presetName];
+        if (!preset) return;
+
+        this.activeMotionPreset = presetName;
+
+        Object.keys(preset).forEach(key => {
+            const value = preset[key];
+            this.settings[key] = value;
+            this.updateControlValue(key, value);
+        });
+
+        if (this.motionPresetButtons.length) {
+            this.motionPresetButtons.forEach(btn => {
+                btn.classList.toggle('active', btn.dataset.motion === presetName);
+            });
+        }
+
+        this.updateShiftAxisState('X');
+        this.updateShiftAxisState('Y');
+        this.restartEchoTimer();
     }
 
     formatSettingValue(key, value) {

--- a/game27/index.html
+++ b/game27/index.html
@@ -38,6 +38,12 @@
                         <button class="btn btn--secondary btn--sm preset-btn" data-preset="rainbow">レインボー</button>
                         <button class="btn btn--secondary btn--sm preset-btn" data-preset="wireframe-lite">ワイヤーフレーム</button>
                     </div>
+                    <h5 class="preset-subheading">時間変化</h5>
+                    <div class="preset-buttons motion-preset-buttons">
+                        <button class="btn btn--secondary btn--sm motion-preset-btn active" data-motion="steady">ステディ</button>
+                        <button class="btn btn--secondary btn--sm motion-preset-btn" data-motion="sway">スウェイ</button>
+                        <button class="btn btn--secondary btn--sm motion-preset-btn" data-motion="orbit">オービット</button>
+                    </div>
                 </div>
 
                 <!-- Drawing Tools -->

--- a/game27/style.css
+++ b/game27/style.css
@@ -1141,6 +1141,25 @@ input[type="range"]:active::-moz-range-thumb {
   gap: var(--space-8);
 }
 
+.preset-subheading {
+  margin: var(--space-12) 0 var(--space-6);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: rgba(255, 255, 255, 0.75);
+  letter-spacing: 0.01em;
+}
+
+.motion-preset-buttons {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: var(--space-6);
+}
+
+.motion-preset-buttons .motion-preset-btn {
+  flex: 1 1 calc(33.333% - var(--space-6));
+  min-width: 120px;
+}
+
 .preset-btn {
   background-color: rgba(255, 255, 255, 0.1);
   color: var(--color-white);


### PR DESCRIPTION
## Summary
- add dedicated motion presets and track the active base and motion selections
- update preset application logic to merge timing presets without overwriting shift settings
- extend the settings UI with motion preset buttons and styling adjustments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7d26329e483259d761eb01d1e74ba