### PR TITLE
Ensure draw canvas overlays echo canvas in game32

### DIFF
--- a/game32/style.css
+++ b/game32/style.css
@@ -1,6 +1,8 @@
 html,body{margin:0;height:100%;}
 .app{position:relative;width:100%;height:100%;overflow:hidden;background:#000;}
 canvas{position:absolute;top:0;left:0;width:100%;height:100%;touch-action:none;}
+#echoCanvas{z-index:0;}
+#drawCanvas{z-index:1;}
 .control-btn{position:absolute;z-index:10;padding:8px 12px;font-size:16px;border:none;border-radius:4px;background:#333;color:#fff;opacity:0.8;}
 #echoBtn{top:10px;left:10px;}
 .panel-btn{top:10px;right:10px;}


### PR DESCRIPTION
## Summary
- assign explicit z-indices to the echo and draw canvases so drawing stays above the echo layer
- retain existing stacking order that keeps controls above both canvases

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7d7dfc5088325ab703bf0623a8f34