### PR TITLE
Add time preset controls and grouped preset highlighting

### DIFF
--- a/game27/app.js
+++ b/game27/app.js
@@ -94,6 +94,33 @@ class EchoDrawingApp {
                 strokeColor: '#00ff64',
                 strokeWidth: 1,
                 strokeAlpha: 1
+            },
+            'time-drift': {
+                echoIntervalMs: 90,
+                shiftXMode: 'oscillate',
+                shiftXOscAmplitude: 6,
+                shiftXOscFrequency: 0.2,
+                shiftYMode: 'oscillate',
+                shiftYOscAmplitude: 8,
+                shiftYOscFrequency: 0.2
+            },
+            'time-pulse': {
+                echoIntervalMs: 50,
+                shiftXMode: 'oscillate',
+                shiftXOscAmplitude: 18,
+                shiftXOscFrequency: 0.6,
+                shiftYMode: 'oscillate',
+                shiftYOscAmplitude: 22,
+                shiftYOscFrequency: 0.7
+            },
+            'time-hyper': {
+                echoIntervalMs: 40,
+                shiftXMode: 'oscillate',
+                shiftXOscAmplitude: 35,
+                shiftXOscFrequency: 1.1,
+                shiftYMode: 'oscillate',
+                shiftYOscAmplitude: 40,
+                shiftYOscFrequency: 1.3
             }
         };
         
@@ -173,9 +200,13 @@ class EchoDrawingApp {
         // Preset buttons
         document.querySelectorAll('.preset-btn').forEach(btn => {
             btn.addEventListener('click', (e) => {
-                this.applyPreset(e.target.dataset.preset);
-                document.querySelectorAll('.preset-btn').forEach(b => b.classList.remove('active'));
-                e.target.classList.add('active');
+                const button = e.currentTarget;
+                this.applyPreset(button.dataset.preset);
+
+                const group = button.dataset.group;
+                const selector = group ? `.preset-btn[data-group="${group}"]` : '.preset-btn:not([data-group])';
+                document.querySelectorAll(selector).forEach(b => b.classList.remove('active'));
+                button.classList.add('active');
             });
         });
         

--- a/game27/index.html
+++ b/game27/index.html
@@ -34,9 +34,18 @@
                 <div class="settings-section">
                     <h4>プリセット</h4>
                     <div class="preset-buttons">
-                        <button class="btn btn--secondary btn--sm preset-btn active" data-preset="default">デフォルト</button>
-                        <button class="btn btn--secondary btn--sm preset-btn" data-preset="rainbow">レインボー</button>
-                        <button class="btn btn--secondary btn--sm preset-btn" data-preset="wireframe-lite">ワイヤーフレーム</button>
+                        <button class="btn btn--secondary btn--sm preset-btn active" data-group="base" data-preset="default">デフォルト</button>
+                        <button class="btn btn--secondary btn--sm preset-btn" data-group="base" data-preset="rainbow">レインボー</button>
+                        <button class="btn btn--secondary btn--sm preset-btn" data-group="base" data-preset="wireframe-lite">ワイヤーフレーム</button>
+                    </div>
+                </div>
+
+                <div class="settings-section">
+                    <h4>時間変化プリセット</h4>
+                    <div class="preset-buttons">
+                        <button class="btn btn--secondary btn--sm preset-btn" data-group="time" data-preset="time-drift">タイムドリフト</button>
+                        <button class="btn btn--secondary btn--sm preset-btn" data-group="time" data-preset="time-pulse">タイムパルス</button>
+                        <button class="btn btn--secondary btn--sm preset-btn" data-group="time" data-preset="time-hyper">タイムハイパー</button>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- add time-focused presets that adjust echo timing and oscillation only
- scope preset button active states by group so base and time presets highlight independently
- expose new time preset buttons in the settings panel

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d7dc803984832588cbf90b0ce91d8c