### PR TITLE
Improve control panel collapse behavior

### DIFF
--- a/game34/app.js
+++ b/game34/app.js
@@ -63,6 +63,7 @@ let computeToken = 0;
 let currentGeometry = null;
 let drawTask = null;
 let lastRandomSignature = '';
+let panelCollapsed = false;
 
 function jsonClone(value) {
   return JSON.parse(JSON.stringify(value));
@@ -994,7 +995,6 @@ function setupUIEvents() {
 
   if (panelToggleBtn && controlPanelEl) {
     const mobileQuery = window.matchMedia('(max-width: 720px)');
-    let panelCollapsed = mobileQuery.matches;
 
     const applyPanelState = (collapsed) => {
       panelCollapsed = collapsed;
@@ -1004,14 +1004,14 @@ function setupUIEvents() {
       panelToggleBtn.textContent = collapsed ? '設定を開く' : '設定を閉じる';
     };
 
-    applyPanelState(panelCollapsed);
+    applyPanelState(mobileQuery.matches);
 
     panelToggleBtn.addEventListener('click', () => {
       applyPanelState(!panelCollapsed);
     });
 
     const handleMediaChange = (event) => {
-      if (!event.matches) {
+      if (!event.matches && panelCollapsed) {
         applyPanelState(false);
       }
     };

--- a/game34/index.html
+++ b/game34/index.html
@@ -29,61 +29,63 @@
         </svg>
       </div>
     </header>
-    <main class="control-panel collapsed" id="controlPanel">
-      <section class="column pinion" aria-label="ピニオン設定">
-        <div class="column-header">
-          <h2>ピニオン</h2>
-          <button id="randomBtn" class="pill" aria-label="ランダム構成を試す">ランダム</button>
-        </div>
-        <div class="selector" aria-label="ピニオンの種類を選ぶ">
-          <button class="selector-btn" id="selectorPrev" aria-label="前のピニオン"><span aria-hidden="true">◀</span></button>
-          <div class="selector-track" id="pinionTrack" role="listbox"></div>
-          <button class="selector-btn" id="selectorNext" aria-label="次のピニオン"><span aria-hidden="true">▶</span></button>
-        </div>
-        <div class="pinion-model" aria-live="polite">
-          <canvas id="pinionCanvas" width="220" height="220" aria-label="ピニオン模型。ドラッグで初期位相を調整、穴をタップでペン位置を変更"></canvas>
-          <div class="pinion-overlay">
-            <p>ドラッグで回転 / 穴タップで選択</p>
+    <div class="control-region">
+      <main class="control-panel" id="controlPanel">
+        <section class="column pinion" aria-label="ピニオン設定">
+          <div class="column-header">
+            <h2>ピニオン</h2>
+            <button id="randomBtn" class="pill" aria-label="ランダム構成を試す">ランダム</button>
           </div>
-        </div>
-        <div class="stepper" aria-label="ピニオンの歯数を調整">
-          <button id="pinionMinus" aria-label="ピニオンの歯数を減らす">−</button>
-          <span><strong>r</strong>=<span id="pinionValue">35</span></span>
-          <button id="pinionPlus" aria-label="ピニオンの歯数を増やす">＋</button>
-        </div>
-        <div class="hole-info">
-          <span>穴: <span id="holeRatio">0.55r</span></span>
-        </div>
-      </section>
-      <section class="column ring" aria-label="外側歯車設定">
-        <div class="column-header">
-          <h2>外側歯車</h2>
-        </div>
-        <div class="ring-art">
-          <canvas id="ringCanvas" width="220" height="220" aria-hidden="true"></canvas>
-        </div>
-        <div class="stepper" aria-label="外側歯車の歯数を調整">
-          <button id="ringMinus" aria-label="外側歯車の歯数を減らす">−</button>
-          <span><strong>R</strong>=<span id="ringValue">96</span></span>
-          <button id="ringPlus" aria-label="外側歯車の歯数を増やす">＋</button>
-        </div>
-        <div class="mode-toggle" role="group" aria-label="モード切り替え">
-          <button id="modeInner" class="toggle active" aria-pressed="true">inner</button>
-          <button id="modeOuter" class="toggle" aria-pressed="false">outer</button>
-        </div>
-        <div class="options">
-          <label>
-            サンプル間隔(px)
-            <input type="range" id="spacingRange" min="0.5" max="3.0" step="0.1" value="1.5">
-          </label>
-          <label>
-            線幅(px)
-            <input type="range" id="lineWidthRange" min="0.5" max="3" step="0.1" value="1.5">
-          </label>
-        </div>
-      </section>
-    </main>
-    <button type="button" class="panel-toggle" id="panelToggle" aria-controls="controlPanel" aria-expanded="false">設定を開く</button>
+          <div class="selector" aria-label="ピニオンの種類を選ぶ">
+            <button class="selector-btn" id="selectorPrev" aria-label="前のピニオン"><span aria-hidden="true">◀</span></button>
+            <div class="selector-track" id="pinionTrack" role="listbox"></div>
+            <button class="selector-btn" id="selectorNext" aria-label="次のピニオン"><span aria-hidden="true">▶</span></button>
+          </div>
+          <div class="pinion-model" aria-live="polite">
+            <canvas id="pinionCanvas" width="220" height="220" aria-label="ピニオン模型。ドラッグで初期位相を調整、穴をタップでペン位置を変更"></canvas>
+            <div class="pinion-overlay">
+              <p>ドラッグで回転 / 穴タップで選択</p>
+            </div>
+          </div>
+          <div class="stepper" aria-label="ピニオンの歯数を調整">
+            <button id="pinionMinus" aria-label="ピニオンの歯数を減らす">−</button>
+            <span><strong>r</strong>=<span id="pinionValue">35</span></span>
+            <button id="pinionPlus" aria-label="ピニオンの歯数を増やす">＋</button>
+          </div>
+          <div class="hole-info">
+            <span>穴: <span id="holeRatio">0.55r</span></span>
+          </div>
+        </section>
+        <section class="column ring" aria-label="外側歯車設定">
+          <div class="column-header">
+            <h2>外側歯車</h2>
+          </div>
+          <div class="ring-art">
+            <canvas id="ringCanvas" width="220" height="220" aria-hidden="true"></canvas>
+          </div>
+          <div class="stepper" aria-label="外側歯車の歯数を調整">
+            <button id="ringMinus" aria-label="外側歯車の歯数を減らす">−</button>
+            <span><strong>R</strong>=<span id="ringValue">96</span></span>
+            <button id="ringPlus" aria-label="外側歯車の歯数を増やす">＋</button>
+          </div>
+          <div class="mode-toggle" role="group" aria-label="モード切り替え">
+            <button id="modeInner" class="toggle active" aria-pressed="true">inner</button>
+            <button id="modeOuter" class="toggle" aria-pressed="false">outer</button>
+          </div>
+          <div class="options">
+            <label>
+              サンプル間隔(px)
+              <input type="range" id="spacingRange" min="0.5" max="3.0" step="0.1" value="1.5">
+            </label>
+            <label>
+              線幅(px)
+              <input type="range" id="lineWidthRange" min="0.5" max="3" step="0.1" value="1.5">
+            </label>
+          </div>
+        </section>
+      </main>
+      <button type="button" class="panel-toggle" id="panelToggle" aria-controls="controlPanel" aria-expanded="false">設定を開く</button>
+    </div>
     <footer class="status-bar" aria-live="polite">
       <div id="statusText">準備中…</div>
     </footer>

--- a/game34/style.css
+++ b/game34/style.css
@@ -32,6 +32,16 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  position: relative;
+}
+
+.control-region {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 0 18px 18px;
+  width: 100%;
 }
 
 .display-area {
@@ -153,6 +163,24 @@ body {
   border-top-left-radius: 28px;
   border-top-right-radius: 28px;
   box-shadow: var(--control-shadow);
+  overflow: hidden;
+  width: 100%;
+  --panel-max-height: 1100px;
+  max-height: var(--panel-max-height);
+  transition: max-height 0.45s ease, padding-top 0.3s ease, padding-bottom 0.3s ease,
+    opacity 0.3s ease;
+  opacity: 1;
+}
+
+.control-panel.collapsed {
+  --panel-max-height: 0px;
+  padding-top: 0;
+  padding-bottom: 0;
+  opacity: 0;
+  pointer-events: none;
+  box-shadow: none;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .column {
@@ -195,12 +223,12 @@ body {
 }
 
 .panel-toggle {
-  display: none;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
   align-self: center;
-  margin: 12px auto 0;
+  margin: 0 auto;
   padding: 10px 24px;
   background: var(--pill-bg);
   color: var(--pill-text);
@@ -212,6 +240,8 @@ body {
   box-shadow: 0 10px 22px rgba(66, 87, 210, 0.32);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   touch-action: manipulation;
+  position: relative;
+  z-index: 2;
 }
 
 .panel-toggle:hover,
@@ -460,14 +490,29 @@ body {
   }
 
   .panel-toggle {
-    display: inline-flex;
     margin-bottom: 8px;
   }
+}
 
-  .control-panel.collapsed {
-    display: none;
+@media (min-width: 721px) {
+  .control-region {
+    padding: 0 32px 32px;
   }
 
+  .panel-toggle {
+    margin: 0;
+    align-self: flex-end;
+  }
+
+  .control-panel.collapsed + .panel-toggle {
+    position: absolute;
+    right: 32px;
+    bottom: 32px;
+  }
+
+  .control-panel:not(.collapsed) + .panel-toggle {
+    position: static;
+  }
 }
 
 @media (max-width: 540px) {


### PR DESCRIPTION
## Summary
- allow the control panel toggle to work across breakpoints by tracking the collapse state in JavaScript and updating button messaging
- add a wrapper and responsive styles so the control panel collapses with height transitions instead of being hidden, keeping the drawing area fluid
- expose the toggle button on desktop with positioning that floats it near the panel while collapsed

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7f70bd3a88325bc5d82cfd0df0714