### PR TITLE
Add playback controls and time-based drawing in game34

### DIFF
--- a/game34/index.html
+++ b/game34/index.html
@@ -11,6 +11,14 @@
     <header class="display-area" aria-label="スピログラフ描画領域">
       <canvas id="mainCanvas" role="img" aria-label="スピログラフの描画キャンバス"></canvas>
       <div class="canvas-toolbar">
+        <div class="playback-controls" role="group" aria-label="描画操作">
+          <button id="startRender" class="toolbar-btn" type="button" aria-label="スピログラフの描画を開始">描画開始</button>
+          <label class="speed-control" for="playbackSpeedRange">
+            <span>速度</span>
+            <input type="range" id="playbackSpeedRange" min="0.2" max="3" step="0.1" value="1" aria-label="描画速度を調整">
+            <span id="speedValue" aria-live="polite">1.0x</span>
+          </label>
+        </div>
         <button id="exportPng" class="toolbar-btn" aria-label="PNGとして保存">PNG保存</button>
         <button id="exportSnapshot" class="toolbar-btn" aria-label="現在の設定をスナップショット保存">スナップショット保存</button>
         <label class="snapshot-restore">

--- a/game34/style.css
+++ b/game34/style.css
@@ -62,6 +62,36 @@ body {
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.playback-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #f1f4ff;
+}
+
+.playback-controls .toolbar-btn {
+  margin-right: 0;
+}
+
+.speed-control {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: #f1f4ff;
+}
+
+.speed-control input[type="range"] {
+  width: 120px;
+  accent-color: #4d6fff;
+}
+
+#speedValue {
+  min-width: 48px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
 .toolbar-btn {
   background: rgba(237, 241, 255, 0.1);
   color: #f1f4ff;


### PR DESCRIPTION
## Summary
- add a dedicated start button and optional playback speed slider to the canvas toolbar
- defer rendering until the user starts playback and keep the latest geometry ready
- animate drawing with a time-based progression that updates the progress ring during playback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7f70eaee08325ab1217cc5990e348