### PR TITLE
Add camera facing toggle to video effects app

### DIFF
--- a/game37/index.html
+++ b/game37/index.html
@@ -38,10 +38,16 @@
         </div>
 
         <div class="recording-controls">
-            <button id="startBtn" class="btn btn--primary record-btn">
-                <span id="recordIcon">●</span>
-                <span id="recordText">録画開始</span>
-            </button>
+            <div class="recording-buttons">
+                <button id="cameraToggle" class="btn btn--secondary camera-toggle-btn" type="button">
+                    <span class="camera-toggle-icon" aria-hidden="true">📷</span>
+                    <span class="camera-toggle-text">背面カメラ</span>
+                </button>
+                <button id="startBtn" class="btn btn--primary record-btn" type="button">
+                    <span id="recordIcon">●</span>
+                    <span id="recordText">録画開始</span>
+                </button>
+            </div>
             <div id="downloadSection" style="display: none;">
                 <p>録画完了！</p>
                 <a id="downloadLink" class="btn btn--secondary" download="video-effect.mp4">

--- a/game37/style.css
+++ b/game37/style.css
@@ -871,6 +871,36 @@ header p {
     margin-bottom: var(--space-24);
 }
 
+.recording-buttons {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: var(--space-12);
+    margin-bottom: var(--space-16);
+}
+
+.camera-toggle-btn {
+    min-height: 56px;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-6);
+    font-weight: var(--font-weight-medium);
+    -webkit-tap-highlight-color: transparent;
+}
+
+.camera-toggle-icon {
+    font-size: var(--font-size-xl);
+    transition: transform var(--duration-normal) var(--ease-standard);
+}
+
+.camera-toggle-icon.is-rear {
+    transform: scaleX(-1);
+}
+
+.camera-toggle-btn.is-switching .camera-toggle-icon {
+    opacity: 0.8;
+}
+
 .record-btn {
     min-height: 56px;
     min-width: 150px;


### PR DESCRIPTION
## Summary
- add a dedicated camera toggle control beside the recording button
- extend VideoEffectApp to restart streams with the requested facing mode and gracefully fall back when unavailable
- style the new control alongside existing recording actions

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e0acedc02c8325b908fd7650d9f09c