### PR TITLE
Center grid calculations on canvas midpoint

### DIFF
--- a/game38/app.js
+++ b/game38/app.js
@@ -252,22 +252,33 @@ class AnimationManager {
 class Grid {
     constructor(size = 16) {
         this.size = size;
+        this.width = 0;
+        this.height = 0;
+        this.originX = 0;
+        this.originY = 0;
     }
-    
+
+    updateDimensions(width, height) {
+        this.width = width;
+        this.height = height;
+        this.originX = width / 2;
+        this.originY = height / 2;
+    }
+
     gridToPixel(i, j) {
         return {
-            x: (i + 0.5) * this.size,
-            y: (j + 0.5) * this.size
+            x: this.originX + i * this.size,
+            y: this.originY + j * this.size
         };
     }
-    
+
     pixelToGrid(x, y) {
         return {
-            i: Math.floor(x / this.size),
-            j: Math.floor(y / this.size)
+            i: Math.round((x - this.originX) / this.size),
+            j: Math.round((y - this.originY) / this.size)
         };
     }
-    
+
     snapToGrid(x, y) {
         const grid = this.pixelToGrid(x, y);
         return this.gridToPixel(grid.i, grid.j);
@@ -644,18 +655,25 @@ class DigitalArtApp {
     }
     
     setupCanvas() {
-        // キャンバスサイズを画面全体に設定
-        this.canvas.width = window.innerWidth;
-        this.canvas.height = window.innerHeight;
-        this.canvas.style.width = window.innerWidth + 'px';
-        this.canvas.style.height = window.innerHeight + 'px';
-        
+        const applyDimensions = () => {
+            // キャンバスサイズを画面全体に設定
+            this.canvas.width = window.innerWidth;
+            this.canvas.height = window.innerHeight;
+            this.canvas.style.width = window.innerWidth + 'px';
+            this.canvas.style.height = window.innerHeight + 'px';
+
+            this.grid.updateDimensions(this.canvas.width, this.canvas.height);
+        };
+
+        applyDimensions();
         this.ctx.imageSmoothingEnabled = true;
-        
-        // リサイズハンドリング
-        window.addEventListener('resize', () => {
-            this.setupCanvas();
-        });
+
+        if (!this._handleResize) {
+            this._handleResize = () => {
+                applyDimensions();
+            };
+            window.addEventListener('resize', this._handleResize);
+        }
     }
     
     setupEventListeners() {


### PR DESCRIPTION
## Summary
- extend the grid helper to track the canvas midpoint and convert coordinates relative to the screen center
- refresh the grid dimensions during canvas setup and resize so existing artwork recenters after window changes

## Testing
- Manual verification via node script to confirm grid-to-pixel and pixel-to-grid conversions around the canvas midpoint

------
https://chatgpt.com/codex/tasks/task_e_68e0ae7522a083259dad69849dbb8093