### PR TITLE
Add delete selected shape control

### DIFF
--- a/game38/index.html
+++ b/game38/index.html
@@ -155,6 +155,7 @@
                 <!-- アクション -->
                 <div class="form-group">
                     <div class="button-group">
+                        <button id="deleteSelected" class="btn btn--outline btn--sm" disabled>選択削除</button>
                         <button id="exportPNG" class="btn btn--primary btn--sm">📷 PNG出力</button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add a delete-selected control to the pro menu action area and keep it disabled with no active selection
- implement shape deletion logic that clears selection, refreshes handles, and updates counts
- wire the button into existing UI setup and listeners

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0b748c62c832581b095eb8212eced