### PR TITLE
Add guide grid overlay toggle

### DIFF
--- a/game38/index.html
+++ b/game38/index.html
@@ -146,10 +146,16 @@
                 
                 <!-- ハンドル表示 -->
                 <div class="form-group">
-                    <label class="form-label">
-                        <input type="checkbox" id="showHandles" checked>
-                        ⚙️ 頂点ハンドル表示
-                    </label>
+                    <div class="form-checkbox-row">
+                        <label class="form-label form-checkbox">
+                            <input type="checkbox" id="showHandles" checked>
+                            ⚙️ 頂点ハンドル表示
+                        </label>
+                        <label class="form-label form-checkbox">
+                            <input type="checkbox" id="showGridOverlay">
+                            📐 ガイドグリッド表示
+                        </label>
+                    </div>
                 </div>
                 
                 <!-- アクション -->

--- a/game38/style.css
+++ b/game38/style.css
@@ -897,6 +897,21 @@ select.form-control {
   cursor: pointer;
 }
 
+.form-checkbox-row {
+  display: flex;
+  gap: var(--space-12);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.form-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-6);
+  margin-bottom: 0;
+  cursor: pointer;
+}
+
 /* ボタングループ */
 .button-group {
   display: flex;


### PR DESCRIPTION
## Summary
- add a grid overlay checkbox to the menu UI
- store the overlay flag in application state and update it from the UI
- render optional crosshair/grid guides beneath shapes when enabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0b905f5a083259d318adf29800a10