### PR TITLE
Add cosmic ring and pyramid patterns to game38

### DIFF
--- a/game38/app.js
+++ b/game38/app.js
@@ -537,6 +537,173 @@ class DigitalArtApp {
                     {"type": "square", "centerI": 0, "centerJ": -4, "orientation": 1, "sizeN": 1, "clockwise": true},
                     {"type": "square", "centerI": 0, "centerJ": 4, "orientation": 3, "sizeN": 1, "clockwise": true}
                 ]
+            },
+            "cosmic-rings": {
+                "name": "コズミックリングス",
+                "description": "中心から重なり合う同心正方形による宇宙的な広がり",
+                "shapes": (() => {
+                    const sizes = [2, 3, 4, 5, 6];
+                    return sizes.map((size, index) => ({
+                        "type": "square",
+                        "centerI": 0,
+                        "centerJ": 0,
+                        "orientation": index % 4,
+                        "sizeN": size,
+                        "clockwise": index % 2 === 0
+                    }));
+                })()
+            },
+            "mandala-matrix": {
+                "name": "マンダラマトリックス",
+                "description": "コズミックリングスを3×3に配置した神聖幾何学的な構成",
+                "shapes": (() => {
+                    const shapes = [];
+                    const sizes = [2, 3, 4, 5, 6];
+                    const spacing = 14;
+                    const offsets = [-spacing, 0, spacing];
+                    offsets.forEach((offsetJ, rowIndex) => {
+                        offsets.forEach((offsetI, colIndex) => {
+                            sizes.forEach((size, index) => {
+                                shapes.push({
+                                    "type": "square",
+                                    "centerI": offsetI,
+                                    "centerJ": offsetJ,
+                                    "orientation": (index + rowIndex + colIndex) % 4,
+                                    "sizeN": size,
+                                    "clockwise": (index + rowIndex) % 2 === 0
+                                });
+                            });
+                        });
+                    });
+                    return shapes;
+                })()
+            },
+            "mystic-pentagons": {
+                "name": "ミスティックペンタゴンズ",
+                "description": "回転する五つの三角形で描く神秘的な輪",
+                "shapes": (() => {
+                    const sizes = [2, 3, 4, 5, 6];
+                    return sizes.map((size, index) => ({
+                        "type": "triangle",
+                        "centerI": 0,
+                        "centerJ": 0,
+                        "orientation": index % 6,
+                        "sizeN": size,
+                        "clockwise": index % 2 === 0
+                    }));
+                })()
+            },
+            "crystal-pyramid": {
+                "name": "クリスタルピラミッド",
+                "description": "ミスティックペンタゴンズを積層したピラミッド構造",
+                "shapes": (() => {
+                    const shapes = [];
+                    const sizes = [2, 3, 4, 5, 6];
+                    const columnSpacing = 12;
+                    const rowSpacing = 12;
+                    const rows = [
+                        { count: 3, centerJ: rowSpacing },
+                        { count: 2, centerJ: 0 },
+                        { count: 1, centerJ: -rowSpacing }
+                    ];
+                    rows.forEach((row, rowIndex) => {
+                        const startI = -((row.count - 1) * columnSpacing) / 2;
+                        for (let col = 0; col < row.count; col++) {
+                            const centerI = startI + col * columnSpacing;
+                            sizes.forEach((size, index) => {
+                                shapes.push({
+                                    "type": "triangle",
+                                    "centerI": parseFloat(centerI.toFixed(2)),
+                                    "centerJ": row.centerJ,
+                                    "orientation": (index + rowIndex + col) % 6,
+                                    "sizeN": size,
+                                    "clockwise": (index + col) % 2 === 0
+                                });
+                            });
+                        }
+                    });
+                    return shapes;
+                })()
+            },
+            "square-grid-10x10": {
+                "name": "10×10スクエアグリッド",
+                "description": "整然と並ぶ100個の正方形による巨大グリッド",
+                "shapes": (() => {
+                    const shapes = [];
+                    const rows = 10;
+                    const cols = 10;
+                    const spacing = 1.4;
+                    const offset = (rows - 1) / 2;
+                    for (let row = 0; row < rows; row++) {
+                        for (let col = 0; col < cols; col++) {
+                            const centerI = (col - offset) * spacing;
+                            const centerJ = (row - offset) * spacing;
+                            shapes.push({
+                                "type": "square",
+                                "centerI": parseFloat(centerI.toFixed(2)),
+                                "centerJ": parseFloat(centerJ.toFixed(2)),
+                                "orientation": 0,
+                                "sizeN": 1,
+                                "clockwise": true
+                            });
+                        }
+                    }
+                    return shapes;
+                })()
+            },
+            "square-grid-staggered": {
+                "name": "シフトスクエアグリッド",
+                "description": "まだらにずれた配置が織りなすアシンメトリックな格子",
+                "shapes": (() => {
+                    const shapes = [];
+                    const rows = 10;
+                    const cols = 10;
+                    const spacing = 1.4;
+                    const offset = (rows - 1) / 2;
+                    for (let row = 0; row < rows; row++) {
+                        const rowShift = (row % 2 === 0 ? -0.35 : 0.35);
+                        for (let col = 0; col < cols; col++) {
+                            const baseI = (col - offset) * spacing;
+                            const baseJ = (row - offset) * spacing;
+                            const jitterI = rowShift + ((col % 3) - 1) * 0.2;
+                            const jitterJ = ((row + col) % 3 - 1) * 0.25;
+                            shapes.push({
+                                "type": "square",
+                                "centerI": parseFloat((baseI + jitterI).toFixed(2)),
+                                "centerJ": parseFloat((baseJ + jitterJ).toFixed(2)),
+                                "orientation": (row + col) % 4,
+                                "sizeN": 1,
+                                "clockwise": true
+                            });
+                        }
+                    }
+                    return shapes;
+                })()
+            },
+            "triangle-overlap-spiral": {
+                "name": "トライアングルスパイラル",
+                "description": "重なり合う三角形が描くダイナミックな螺旋",
+                "shapes": (() => {
+                    const shapes = [];
+                    const count = 18;
+                    for (let step = 0; step < count; step++) {
+                        const angle = step * 0.55;
+                        const radius = 0.8 + step * 0.55;
+                        const centerI = Math.cos(angle) * radius;
+                        const centerJ = Math.sin(angle) * radius;
+                        const orientation = Math.floor((angle / (Math.PI / 3))) % 3;
+                        const sizeN = 1 + Math.floor(step / 6);
+                        shapes.push({
+                            "type": "triangle",
+                            "centerI": parseFloat(centerI.toFixed(2)),
+                            "centerJ": parseFloat(centerJ.toFixed(2)),
+                            "orientation": orientation,
+                            "sizeN": sizeN,
+                            "clockwise": step % 2 === 0
+                        });
+                    }
+                    return shapes;
+                })()
             }
         };
         

--- a/game38/index.html
+++ b/game38/index.html
@@ -47,6 +47,13 @@
                         <option value="spiral-galaxy">スパイラルギャラクシー</option>
                         <option value="wave-pattern">ウェーブパターン</option>
                         <option value="minimalist-zen">ミニマリスト禅</option>
+                        <option value="square-grid-10x10">10×10スクエアグリッド</option>
+                        <option value="square-grid-staggered">シフトスクエアグリッド</option>
+                        <option value="triangle-overlap-spiral">トライアングルスパイラル</option>
+                        <option value="cosmic-rings">コズミックリングス</option>
+                        <option value="mandala-matrix">マンダラマトリックス</option>
+                        <option value="mystic-pentagons">ミスティックペンタゴンズ</option>
+                        <option value="crystal-pyramid">クリスタルピラミッド</option>
                     </select>
                 </div>
                 


### PR DESCRIPTION
## Summary
- add four new pattern options to the game38 sample selector for the cosmic rings, mandala matrix, mystic pentagons, and crystal pyramid presets
- implement generators for the new square-based and triangle-based arrangements in the sample pattern registry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0c68f603c832590998f91b2dcd27c