### PR TITLE
Add auto-random playback with crossfade transitions

### DIFF
--- a/game39/index.html
+++ b/game39/index.html
@@ -30,6 +30,11 @@
                     </div>
                     <div class="button-group">
                         <button id="randomizeBtn" class="btn btn--secondary">ランダマイズ</button>
+                        <button id="autoRandomBtn" class="btn btn--secondary">オートランダム: OFF</button>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">オート間隔: <span id="autoIntervalValue">12</span>秒</label>
+                        <input type="range" id="autoIntervalSlider" class="form-control" min="5" max="60" value="12">
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- add an auto-random toggle and interval control to automatically cycle through random dance presets
- implement crossfade rendering between effects so automatic transitions fade out and fade in smoothly
- refactor parameter management to support shared randomization logic and keep UI controls in sync

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e0e39e0b388325930ad467fde4e453