### PR TITLE
Add shadow-xl token for game38 hover states

### DIFF
--- a/game38/style.css
+++ b/game38/style.css
@@ -129,6 +129,8 @@
     0 2px 4px -1px rgba(0, 0, 0, 0.02);
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.04),
     0 4px 6px -2px rgba(0, 0, 0, 0.02);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+    0 10px 10px -5px rgba(0, 0, 0, 0.04);
   --shadow-inset-sm: inset 0 1px 0 rgba(255, 255, 255, 0.15),
     inset 0 -1px 0 rgba(0, 0, 0, 0.03);
 


### PR DESCRIPTION
## Summary
- add the missing `--shadow-xl` shadow token used by game 38 hover styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0ecbf77cc8325bb52fb24bb0fefe8