### PR TITLE
Add undo and presentation hide controls to game40

### DIFF
--- a/game40/app.js
+++ b/game40/app.js
@@ -419,6 +419,11 @@ class DigitalArtApp {
         this.vertexHandles = [];
         this.animationManager = new AnimationManager();
 
+        this.appContainer = document.querySelector('.app-container');
+        this.presentationOverlay = document.getElementById('presentationOverlay');
+        this.presentationHidden = false;
+        this.history = [];
+
         this.addShapeCounter = 0;
 
         // 状態
@@ -459,6 +464,7 @@ class DigitalArtApp {
         this.setupAnimationManager();
         this.initializeDefaultShapes();
         this.startAnimationLoop();
+        this.updateUndoButtonState();
     }
 
     // ---- 初期化 ----
@@ -535,6 +541,18 @@ class DigitalArtApp {
         document.getElementById('mainPlayButton').addEventListener('click', () => {
             this.animationManager.isPlaying ? this.animationManager.stop() : this.animationManager.start();
         });
+
+        document.getElementById('undoAction').addEventListener('click', () => this.undoLastAction());
+        document.getElementById('toggleVisibility').addEventListener('click', () => this.togglePresentationMode());
+        if (this.presentationOverlay) {
+            this.presentationOverlay.addEventListener('click', () => this.deactivatePresentationHide(true));
+            this.presentationOverlay.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+                    e.preventDefault();
+                    this.deactivatePresentationHide(true);
+                }
+            });
+        }
 
         // 右下UI
         document.getElementById('addTriangle').addEventListener('click', () => this.addShape('triangle'));
@@ -647,6 +665,41 @@ class DigitalArtApp {
         }
     }
 
+    togglePresentationMode() {
+        if (this.presentationHidden) this.deactivatePresentationHide(true);
+        else this.activatePresentationHide();
+    }
+
+    activatePresentationHide() {
+        if (this.presentationHidden) return;
+        this.presentationHidden = true;
+        this.animationManager.reset();
+        this.closeMenu();
+        if (this.appContainer) this.appContainer.classList.add('presentation-hidden');
+        if (this.presentationOverlay) {
+            this.presentationOverlay.classList.remove('hidden');
+            this.presentationOverlay.setAttribute('aria-hidden', 'false');
+            this.presentationOverlay.setAttribute('tabindex', '0');
+            setTimeout(() => {
+                if (this.presentationOverlay) {
+                    this.presentationOverlay.focus({ preventScroll: true });
+                }
+            }, 0);
+        }
+    }
+
+    deactivatePresentationHide(autoPlay = false) {
+        if (!this.presentationHidden) return;
+        this.presentationHidden = false;
+        if (this.appContainer) this.appContainer.classList.remove('presentation-hidden');
+        if (this.presentationOverlay) {
+            this.presentationOverlay.classList.add('hidden');
+            this.presentationOverlay.setAttribute('aria-hidden', 'true');
+            this.presentationOverlay.setAttribute('tabindex', '-1');
+        }
+        if (autoPlay) this.animationManager.start();
+    }
+
     // ---- 図形/パターン ----
     addShape(type, clockwise = true) {
         if (this.state.shapes.size >= 100) return;
@@ -656,18 +709,22 @@ class DigitalArtApp {
         const centerI = Math.round(Math.cos(angle) * distance);
         const centerJ = Math.round(Math.sin(angle) * distance);
 
+        let createdId = null;
         if (type === 'triangle') {
             const t = new Triangle(`triangle-${this.state.nextTriangleId++}`, centerI, centerJ, 0, 3, clockwise);
             t.zIndex = Date.now();
             this.state.shapes.set(t.id, t);
             this.state.selectedShapeId = t.id;
+            createdId = t.id;
         } else {
             const s = new Square(`square-${this.state.nextSquareId++}`, centerI, centerJ, 0, 3, clockwise);
             s.zIndex = Date.now();
             this.state.shapes.set(s.id, s);
             this.state.selectedShapeId = s.id;
+            createdId = s.id;
         }
         this.updateCountsAndHandles();
+        if (createdId) this.recordAction({ type: 'shape-add', shapeId: createdId });
     }
 
     applyPattern(patternName) {
@@ -767,6 +824,7 @@ class DigitalArtApp {
             if (cur.total > 0) {
                 this.state.freehand.strokes.push(cur);
                 this._enforceStrokePointBudget(); // 安全上限
+                this.recordAction({ type: 'stroke-add', stroke: cur });
             }
             this.state.freehand.current = null;
             this.updateCountsAndHandles();
@@ -861,6 +919,14 @@ class DigitalArtApp {
         btn.title = ok ? '' : '図形が選択されていません';
     }
 
+    updateUndoButtonState() {
+        const btn = document.getElementById('undoAction');
+        if (!btn) return;
+        const hasHistory = this.history.length > 0;
+        btn.disabled = !hasHistory;
+        btn.setAttribute('aria-disabled', String(!hasHistory));
+    }
+
     updateCountsAndHandles() {
         const t = Array.from(this.state.shapes.values()).filter(s => s.type === 'triangle').length;
         const s = Array.from(this.state.shapes.values()).filter(s => s.type === 'square').length;
@@ -870,6 +936,46 @@ class DigitalArtApp {
         document.getElementById('strokeCount').textContent = strokes;
         this.updateDeleteButtonState();
         this.updateVertexHandles();
+        this.updateUndoButtonState();
+    }
+
+    recordAction(action) {
+        if (!action) return;
+        this.history.push(action);
+        if (this.history.length > 100) this.history.shift();
+        this.updateUndoButtonState();
+    }
+
+    undoLastAction() {
+        const last = this.history.pop();
+        if (!last) { this.updateUndoButtonState(); return; }
+
+        switch (last.type) {
+            case 'shape-add': {
+                if (last.shapeId && this.state.shapes.has(last.shapeId)) {
+                    this.state.shapes.delete(last.shapeId);
+                    if (this.state.selectedShapeId === last.shapeId) {
+                        this.state.selectedShapeId = null;
+                    }
+                    this.updateCountsAndHandles();
+                }
+                break;
+            }
+            case 'stroke-add': {
+                if (last.stroke) {
+                    const idx = this.state.freehand.strokes.lastIndexOf(last.stroke);
+                    if (idx >= 0) {
+                        this.state.freehand.strokes.splice(idx, 1);
+                        this.updateCountsAndHandles();
+                    }
+                }
+                break;
+            }
+            default:
+                break;
+        }
+
+        this.updateUndoButtonState();
     }
 
     // ---- 書き出し/消去 ----
@@ -887,6 +993,7 @@ class DigitalArtApp {
             this.state.freehand.strokes = [];
             this.state.freehand.current = null;
             this.addShapeCounter = 0;
+            this.history = [];
             this.updateCountsAndHandles();
         }
     }
@@ -895,6 +1002,7 @@ class DigitalArtApp {
         if (confirm('すべての手描きストロークを削除しますか？')) {
             this.state.freehand.strokes = [];
             this.state.freehand.current = null;
+            this.history = this.history.filter(action => action.type !== 'stroke-add');
             this.updateCountsAndHandles();
         }
     }
@@ -1026,6 +1134,12 @@ class DigitalArtApp {
     render() {
         const w = this.canvas.width, h = this.canvas.height;
         this.ctx.clearRect(0,0,w,h);
+
+        if (this.presentationHidden) {
+            this.ctx.fillStyle = '#000000';
+            this.ctx.fillRect(0, 0, w, h);
+            return;
+        }
 
         const theme = this.themes[this.state.visual.preset];
         this.backgroundEffects.drawBackground(this.ctx, this.state.visual.backgroundMode, theme?.settings || {});

--- a/game40/index.html
+++ b/game40/index.html
@@ -11,10 +11,20 @@
         <!-- メインキャンバス -->
         <canvas id="mainCanvas" class="main-canvas"></canvas>
 
-        <!-- メイン再生ボタン（大きい） -->
-        <button id="mainPlayButton" class="main-play-button btn btn--primary" aria-label="アニメーション再生">
-            ▶️
-        </button>
+        <!-- メイン再生ボタン + 追加操作 -->
+        <div class="main-controls">
+            <button id="mainPlayButton" class="main-play-button btn btn--primary" aria-label="アニメーション再生">
+                ▶️
+            </button>
+            <div class="main-utility-buttons" aria-label="編集操作">
+                <button id="undoAction" class="main-control-button btn btn--secondary" aria-label="直前の操作を取り消す" title="戻る (Undo)" disabled>
+                    ↩️
+                </button>
+                <button id="toggleVisibility" class="main-control-button btn btn--secondary" aria-label="プレゼン用に一時的に表示を隠す" title="一時的に非表示">
+                    🙈
+                </button>
+            </div>
+        </div>
 
         <!-- 図形/手描き追加ボタン（右下） -->
         <div class="shape-controls">
@@ -192,6 +202,9 @@
 
         <!-- オーバーレイ -->
         <div id="menuOverlay" class="menu-overlay hidden"></div>
+        <div id="presentationOverlay" class="presentation-overlay hidden" role="button" aria-hidden="true" tabindex="-1">
+            画面をタップして再生 ▶️
+        </div>
 
         <!-- ステータス表示 -->
         <div id="statusInfo" class="status-info">

--- a/game40/style.css
+++ b/game40/style.css
@@ -756,11 +756,19 @@ select.form-control {
   user-select: none;
 }
 
-/* メイン再生ボタン（左下大きい） */
-.main-play-button {
+/* メイン再生ボタン（左下大きい）と補助操作 */
+.main-controls {
   position: fixed;
   bottom: var(--space-24);
   left: var(--space-24);
+  display: flex;
+  align-items: center;
+  gap: var(--space-12);
+  z-index: 500;
+}
+
+.main-play-button {
+  position: relative;
   width: 80px;
   height: 80px;
   border-radius: var(--radius-full);
@@ -768,7 +776,6 @@ select.form-control {
   padding: 0;
   box-shadow: var(--shadow-lg);
   transition: all var(--duration-normal) var(--ease-standard);
-  z-index: 500;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -781,6 +788,35 @@ select.form-control {
 }
 
 .main-play-button:active {
+  transform: scale(0.95);
+}
+
+.main-utility-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.main-control-button {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-full);
+  font-size: 20px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-md);
+  border: 2px solid rgba(255, 255, 255, 0.1);
+  transition: all var(--duration-normal) var(--ease-standard);
+}
+
+.main-control-button:hover {
+  transform: scale(1.05);
+  box-shadow: var(--shadow-lg);
+}
+
+.main-control-button:active {
   transform: scale(0.95);
 }
 
@@ -1052,11 +1088,56 @@ input[type="range"]::-moz-range-thumb {
   gap: var(--space-16);
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
-  margin-left: 110px; /* メイン再生ボタンの右側に配置 */
+  margin-left: calc(80px + var(--space-12) + 48px);
 }
 
 .status-item {
   white-space: nowrap;
+}
+
+.presentation-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at center, rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0.95));
+  color: var(--color-white);
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.05em;
+  text-align: center;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
+  z-index: 800;
+  cursor: pointer;
+  user-select: none;
+  padding: var(--space-32);
+}
+
+.presentation-overlay:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 6px;
+}
+
+.app-container.presentation-hidden .main-controls,
+.app-container.presentation-hidden .shape-controls,
+.app-container.presentation-hidden .menu-toggle,
+.app-container.presentation-hidden .status-info {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration-fast) var(--ease-standard);
+}
+
+.app-container.presentation-hidden #proMenu {
+  display: none !important;
+}
+
+.app-container.presentation-hidden #menuOverlay {
+  display: none !important;
+}
+
+.app-container.presentation-hidden .main-canvas {
+  opacity: 0;
 }
 
 /* レスポンシブデザイン */
@@ -1082,12 +1163,26 @@ input[type="range"]::-moz-range-thumb {
     height: 44px;
   }
   
+  .main-controls {
+    bottom: var(--space-20);
+    left: var(--space-20);
+    gap: var(--space-10);
+  }
+
   .main-play-button {
     width: 70px;
     height: 70px;
     font-size: 28px;
-    bottom: var(--space-20);
-    left: var(--space-20);
+  }
+
+  .main-utility-buttons {
+    gap: var(--space-10);
+  }
+
+  .main-control-button {
+    width: 44px;
+    height: 44px;
+    font-size: 18px;
   }
   
   .shape-btn {
@@ -1112,7 +1207,7 @@ input[type="range"]::-moz-range-thumb {
   .status-info {
     bottom: var(--space-12);
     left: var(--space-12);
-    margin-left: 90px;
+    margin-left: calc(70px + var(--space-10) + 44px);
     flex-direction: column;
     gap: var(--space-4);
   }
@@ -1135,12 +1230,26 @@ input[type="range"]::-moz-range-thumb {
     font-size: var(--font-size-base);
   }
   
+  .main-controls {
+    bottom: var(--space-16);
+    left: var(--space-16);
+    gap: var(--space-8);
+  }
+
   .main-play-button {
     width: 60px;
     height: 60px;
     font-size: 24px;
-    bottom: var(--space-16);
-    left: var(--space-16);
+  }
+
+  .main-utility-buttons {
+    gap: var(--space-8);
+  }
+
+  .main-control-button {
+    width: 40px;
+    height: 40px;
+    font-size: 16px;
   }
   
   .shape-btn {
@@ -1150,7 +1259,7 @@ input[type="range"]::-moz-range-thumb {
   }
   
   .status-info {
-    margin-left: 80px;
+    margin-left: calc(60px + var(--space-8) + 40px);
     font-size: var(--font-size-xs);
   }
 }


### PR DESCRIPTION
## Summary
- add undo and temporary hide controls next to the main play button in game40
- implement history tracking for shape and stroke additions to support undo and auto-play presentation reveal flow
- refresh layout and styling for the new controls and presentation overlay

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1b269f49483259908c9f202c95b42