### PR TITLE
Add quick clear control to game40 canvas

### DIFF
--- a/game40/app.js
+++ b/game40/app.js
@@ -634,7 +634,15 @@ class DigitalArtApp {
         const del = document.getElementById('deleteSelected');
         del.addEventListener('click', ()=> { if (!del.disabled) this.deleteSelectedShape(); });
         document.getElementById('exportPNG').addEventListener('click', this.exportPNG.bind(this));
-        document.getElementById('clearAll').addEventListener('click', this.clearAll.bind(this));
+        const clearAllButton = document.getElementById('clearAll');
+        if (clearAllButton) {
+            clearAllButton.addEventListener('click', () => this.clearAll());
+        }
+
+        const quickClearAllButton = document.getElementById('quickClearAll');
+        if (quickClearAllButton) {
+            quickClearAllButton.addEventListener('click', () => this.clearAll('消してよいですか？'));
+        }
 
         this.updateDeleteButtonState();
     }
@@ -986,16 +994,20 @@ class DigitalArtApp {
         link.click();
     }
 
-    clearAll() {
-        if (confirm('すべての図形と手描きを削除しますか？')) {
-            this.state.shapes.clear();
-            this.state.selectedShapeId = null;
-            this.state.freehand.strokes = [];
-            this.state.freehand.current = null;
-            this.addShapeCounter = 0;
-            this.history = [];
-            this.updateCountsAndHandles();
+    clearAll(confirmMessage = 'すべての図形と手描きを削除しますか？') {
+        if (confirm(confirmMessage)) {
+            this.performClearAll();
         }
+    }
+
+    performClearAll() {
+        this.state.shapes.clear();
+        this.state.selectedShapeId = null;
+        this.state.freehand.strokes = [];
+        this.state.freehand.current = null;
+        this.addShapeCounter = 0;
+        this.history = [];
+        this.updateCountsAndHandles();
     }
 
     clearStrokes() {

--- a/game40/index.html
+++ b/game40/index.html
@@ -23,6 +23,9 @@
                 <button id="toggleVisibility" class="main-control-button btn btn--secondary" aria-label="プレゼン用に一時的に表示を隠す" title="一時的に非表示">
                     🙈
                 </button>
+                <button id="quickClearAll" class="main-control-button btn btn--secondary" aria-label="全ての図形と手描きを消去" title="全消去">
+                    🧹
+                </button>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add a quick access clear-all button to the main canvas controls in game40
- reuse the clearAll logic with a shared helper so both buttons can clear the scene with different confirmations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1ddf1c7288325978c05b66e4087bc