### PR TITLE
Fix quick clear button handling in game40

### DIFF
--- a/game40/app.js
+++ b/game40/app.js
@@ -544,6 +544,23 @@ class DigitalArtApp {
 
         document.getElementById('undoAction').addEventListener('click', () => this.undoLastAction());
         document.getElementById('toggleVisibility').addEventListener('click', () => this.togglePresentationMode());
+
+        const quickClearAllButton = document.getElementById('quickClearAll');
+        if (quickClearAllButton) {
+            const triggerQuickClear = () => this.clearAll('消してよいですか？');
+            quickClearAllButton.addEventListener('click', (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                triggerQuickClear();
+            });
+            quickClearAllButton.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    triggerQuickClear();
+                }
+            });
+        }
         if (this.presentationOverlay) {
             this.presentationOverlay.addEventListener('click', () => this.deactivatePresentationHide(true));
             this.presentationOverlay.addEventListener('keydown', (e) => {
@@ -634,7 +651,10 @@ class DigitalArtApp {
         const del = document.getElementById('deleteSelected');
         del.addEventListener('click', ()=> { if (!del.disabled) this.deleteSelectedShape(); });
         document.getElementById('exportPNG').addEventListener('click', this.exportPNG.bind(this));
-        document.getElementById('clearAll').addEventListener('click', this.clearAll.bind(this));
+        const clearAllButton = document.getElementById('clearAll');
+        if (clearAllButton) {
+            clearAllButton.addEventListener('click', () => this.clearAll());
+        }
 
         this.updateDeleteButtonState();
     }
@@ -986,16 +1006,23 @@ class DigitalArtApp {
         link.click();
     }
 
-    clearAll() {
-        if (confirm('すべての図形と手描きを削除しますか？')) {
-            this.state.shapes.clear();
-            this.state.selectedShapeId = null;
-            this.state.freehand.strokes = [];
-            this.state.freehand.current = null;
-            this.addShapeCounter = 0;
-            this.history = [];
-            this.updateCountsAndHandles();
+    clearAll(confirmMessage = 'すべての図形と手描きを削除しますか？') {
+        const shouldClear = (typeof window !== 'undefined' && typeof window.confirm === 'function')
+            ? window.confirm(confirmMessage)
+            : true;
+        if (shouldClear) {
+            this.performClearAll();
         }
+    }
+
+    performClearAll() {
+        this.state.shapes.clear();
+        this.state.selectedShapeId = null;
+        this.state.freehand.strokes = [];
+        this.state.freehand.current = null;
+        this.addShapeCounter = 0;
+        this.history = [];
+        this.updateCountsAndHandles();
     }
 
     clearStrokes() {

--- a/game40/index.html
+++ b/game40/index.html
@@ -23,6 +23,9 @@
                 <button id="toggleVisibility" class="main-control-button btn btn--secondary" aria-label="プレゼン用に一時的に表示を隠す" title="一時的に非表示">
                     🙈
                 </button>
+                <button id="quickClearAll" class="main-control-button btn btn--secondary" aria-label="全ての図形と手描きを消去" title="全消去">
+                    🧹
+                </button>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- wire the quick clear button in the main controls directly so it stops propagation and triggers the shared clear confirmation
- guard the confirmation dialog invocation to fall back safely outside the browser

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1ddf1c7288325978c05b66e4087bc