### PR TITLE
Initialize progress bar at zero width

### DIFF
--- a/game38/app.js
+++ b/game38/app.js
@@ -774,7 +774,7 @@ class DigitalArtApp {
                 progressBar.style.width = `${progress * 100}%`;
             }
         };
-        
+
         this.animationManager.onPhaseChange = (phase, progress) => {
             const phaseDisplay = document.getElementById('animationPhase');
             const timeDisplay = document.getElementById('timeDisplay');
@@ -824,6 +824,9 @@ class DigitalArtApp {
                 timeDisplay.textContent = '時間: 0.0 / 3.5s';
             }
         };
+
+        // Ensure the UI reflects the initial animation state on load.
+        this.animationManager.triggerCallbacks();
     }
     
     setupCanvas() {

--- a/game38/style.css
+++ b/game38/style.css
@@ -823,7 +823,7 @@ select.form-control {
   background: linear-gradient(90deg, var(--color-primary), var(--color-primary-hover));
   border-radius: var(--radius-sm);
   transition: width var(--duration-fast) var(--ease-standard);
-  width: 100%;
+  width: 0%;
 }
 
 .phase-display {


### PR DESCRIPTION
## Summary
- set the progress bar fill style to start at zero width by default
- trigger animation callbacks on load so the UI initializes to the manager's current state

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1f72d08408325b210e97132128ddf