### PR TITLE
Move game41 start button to top of home screen

### DIFF
--- a/game41/index.html
+++ b/game41/index.html
@@ -50,6 +50,12 @@
                 </button>
             </div>
 
+            <div class="home-primary-action">
+                <button id="start-btn" class="btn btn--primary btn--lg btn--full-width">
+                    はじめる
+                </button>
+            </div>
+
             <div class="mode-selection">
                 <h2>モード選択</h2>
                 <div class="mode-buttons">
@@ -88,10 +94,6 @@
                     <p class="no-history">まだ記録がありません</p>
                 </div>
             </div>
-
-            <button id="start-btn" class="btn btn--primary btn--lg btn--full-width">
-                はじめる
-            </button>
         </div>
     </div>
 

--- a/game41/style.css
+++ b/game41/style.css
@@ -841,6 +841,10 @@ body {
   color: var(--color-primary);
 }
 
+.home-primary-action {
+  margin-bottom: var(--space-32);
+}
+
 .settings-btn {
   min-width: 80px;
   font-size: var(--font-size-sm);


### PR DESCRIPTION
## Summary
- move the game41 home screen start button above the content so it no longer overlaps mobile browser UI
- add spacing to the relocated primary action for consistent layout

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1f959a5d083259fa1382bce849103