### PR TITLE
Refine dark mode surface handling in game38

### DIFF
--- a/game38/style.css
+++ b/game38/style.css
@@ -45,7 +45,8 @@
 
   /* Semantic Color Tokens (Light Mode) */
   --color-background: var(--color-cream-50);
-  --color-surface: var(--color-cream-100);
+  --color-surface-rgb: 255, 255, 253;
+  --color-surface: rgba(var(--color-surface-rgb), 1);
   --color-text: var(--color-slate-900);
   --color-text-secondary: var(--color-slate-500);
   --color-primary: var(--color-teal-500);
@@ -182,7 +183,8 @@
 
     /* Semantic Color Tokens (Dark Mode) */
     --color-background: var(--color-charcoal-700);
-    --color-surface: var(--color-charcoal-800);
+    --color-surface-rgb: 38, 40, 40;
+    --color-surface: rgba(var(--color-surface-rgb), 1);
     --color-text: var(--color-gray-200);
     --color-text-secondary: rgba(var(--color-gray-300-rgb), 0.7);
     --color-primary: var(--color-teal-300);
@@ -734,7 +736,7 @@ select.form-control {
   right: 0;
   width: 360px;
   height: 100vh;
-  background: rgba(var(--color-surface), 0.95);
+  background: rgba(var(--color-surface-rgb), 0.92);
   backdrop-filter: blur(10px);
   border-left: 1px solid var(--color-border);
   z-index: 999;
@@ -925,7 +927,7 @@ input[type="range"]::-moz-range-thumb:hover {
   position: fixed;
   bottom: var(--space-16);
   left: var(--space-16);
-  background: rgba(var(--color-surface), 0.9);
+  background: rgba(var(--color-surface-rgb), 0.88);
   backdrop-filter: blur(8px);
   padding: var(--space-8) var(--space-16);
   border-radius: var(--radius-base);
@@ -1035,17 +1037,6 @@ input[type="range"]::-moz-range-thumb:hover {
   .status-info {
     margin-left: 80px;
     font-size: var(--font-size-xs);
-  }
-}
-
-/* ダークモード対応 */
-@media (prefers-color-scheme: dark) {
-  .pro-menu {
-    background: rgba(38, 40, 40, 0.95);
-  }
-
-  .status-info {
-    background: rgba(38, 40, 40, 0.9);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a shared `--color-surface-rgb` token so light and dark themes derive the same surface color
- update `.pro-menu` and `.status-info` backgrounds to use the shared token and drop redundant dark-mode overrides

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e1f98d17f883258e2d65f60dac6aa0