### PR TITLE
Add configurable speech interval for game41

### DIFF
--- a/game41/app.js
+++ b/game41/app.js
@@ -51,7 +51,7 @@ class DigitSpanApp {
                 allowLeadingZero: true,
                 maxRepeatRun: 2,
                 beep: true,
-                digitIntervalMs: 100,
+                digitIntervalMs: 50,
                 preDelayMs: 300,
                 postDelayMs: 300
             },
@@ -186,26 +186,32 @@ class DigitSpanApp {
             { id: 'rate-slider', path: 'tts.rate', display: 'rate-value' },
             { id: 'volume-slider', path: 'tts.volume', display: 'volume-value' },
             { id: 'pitch-slider', path: 'tts.pitch', display: 'pitch-value' },
-            { id: 'repeat-limit-slider', path: 'delivery.maxRepeatRun', display: 'repeat-limit-value' }
+            { id: 'repeat-limit-slider', path: 'delivery.maxRepeatRun', display: 'repeat-limit-value' },
+            {
+                id: 'digit-interval-slider',
+                path: 'delivery.digitIntervalMs',
+                display: 'digit-interval-value',
+                formatter: (value) => `${Math.round(value)}ms`
+            }
         ];
 
-        controls.forEach(({ id, path, display }) => {
+        controls.forEach(({ id, path, display, formatter }) => {
             const slider = document.getElementById(id);
             const valueDisplay = document.getElementById(display);
-            
+
             if (!slider || !valueDisplay) return;
-            
+
             slider.addEventListener('input', (e) => {
                 const value = parseFloat(e.target.value);
                 this.setNestedProperty(this.settings, path, value);
-                valueDisplay.textContent = value;
+                valueDisplay.textContent = formatter ? formatter(value) : value;
                 this.saveSettings();
             });
 
             // 初期値設定
             const currentValue = this.getNestedProperty(this.settings, path);
             slider.value = currentValue;
-            valueDisplay.textContent = currentValue;
+            valueDisplay.textContent = formatter ? formatter(currentValue) : currentValue;
         });
 
         // チェックボックス

--- a/game41/index.html
+++ b/game41/index.html
@@ -125,6 +125,10 @@
                         <input type="range" id="rate-slider" class="form-control range-slider" min="0.5" max="1.5" step="0.05" value="0.95">
                     </div>
                     <div class="range-setting">
+                        <label class="form-label">数字間の間隔: <span id="digit-interval-value">50ms</span></label>
+                        <input type="range" id="digit-interval-slider" class="form-control range-slider" min="0" max="1500" step="50" value="50">
+                    </div>
+                    <div class="range-setting">
                         <label class="form-label">音量: <span id="volume-value">1.0</span></label>
                         <input type="range" id="volume-slider" class="form-control range-slider" min="0" max="1" step="0.1" value="1.0">
                     </div>


### PR DESCRIPTION
## Summary
- add a UI slider to control the pause between spoken digits
- reduce the default pause duration and format the slider readout in milliseconds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e325a0a47c8325815b4943d9a68878