### PR TITLE
Adjust pendulum defaults for game42

### DIFF
--- a/game42/app.js
+++ b/game42/app.js
@@ -37,9 +37,9 @@ class PendulumWaveSimulation {
     this.lastTime = 0;
 
     // パラメータ（初期値）
-    this.N = 36;
+    this.N = 8;
     this.T_return = 6.0;
-    this.amplitude = 50; // px
+    this.amplitude = 100; // px
     this.speed = 1.0;
 
     // データ構造

--- a/game42/index.html
+++ b/game42/index.html
@@ -18,8 +18,8 @@
             
             <div class="controls-group">
                 <div class="control-item">
-                    <label for="pendulumCount" class="form-label">振り子数: <span id="pendulumCountValue">36</span></label>
-                    <input type="range" id="pendulumCount" class="form-control" min="12" max="72" value="36" step="1">
+                    <label for="pendulumCount" class="form-label">振り子数: <span id="pendulumCountValue">8</span></label>
+                    <input type="range" id="pendulumCount" class="form-control" min="1" max="72" value="8" step="1">
                 </div>
                 
                 <div class="control-item">
@@ -28,8 +28,8 @@
                 </div>
                 
                 <div class="control-item">
-                    <label for="amplitude" class="form-label">振幅: <span id="amplitudeValue">50</span></label>
-                    <input type="range" id="amplitude" class="form-control" min="10" max="100" value="50" step="5">
+                    <label for="amplitude" class="form-label">振幅: <span id="amplitudeValue">100</span></label>
+                    <input type="range" id="amplitude" class="form-control" min="10" max="300" value="100" step="5">
                 </div>
                 
                 <div class="control-item">


### PR DESCRIPTION
## Summary
- allow selecting as few as one pendulum in game42 while defaulting to eight
- increase amplitude slider range to 300 and start at 100 to match new defaults

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e37b380f8483259795e0ac8a3b33e7