### PR TITLE
Improve game42 control layout and preset handling

### DIFF
--- a/game42/index.html
+++ b/game42/index.html
@@ -9,41 +9,46 @@
 <body>
     <div class="app-container">
         <div class="control-panel">
-            <div class="controls-group">
-                <button id="playPauseBtn" class="btn btn--primary" aria-label="再生・一時停止">
-                    <span id="playPauseText">一時停止</span>
+            <div class="controls-group controls-group--primary">
+                <button id="playPauseBtn" class="btn btn--primary btn--icon" aria-label="一時停止" title="一時停止">
+                    <span class="btn-icon" aria-hidden="true">⏸</span>
+                    <span class="sr-only">一時停止</span>
                 </button>
-                <button id="resetBtn" class="btn btn--secondary" aria-label="リセット">リセット</button>
-            </div>
-            
-            <div class="controls-group">
+                <button id="resetBtn" class="btn btn--secondary btn--icon" aria-label="リセット" title="リセット">
+                    <span class="btn-icon" aria-hidden="true">🪄</span>
+                    <span class="sr-only">リセット</span>
+                </button>
+
                 <div class="control-item">
                     <label for="pendulumCount" class="form-label">振り子数: <span id="pendulumCountValue">8</span></label>
                     <input type="range" id="pendulumCount" class="form-control" min="1" max="72" value="8" step="1">
                 </div>
-                
+
                 <div class="control-item">
-                    <label for="returnTime" class="form-label">再同期時間: <span id="returnTimeValue">6.0</span></label>
+                    <label for="returnTime" class="form-label">再同期時間: <span id="returnTimeValue">6.0s</span></label>
                     <input type="range" id="returnTime" class="form-control" min="0" max="20" value="6" step="0.5">
                 </div>
-                
+
                 <div class="control-item">
                     <label for="amplitude" class="form-label">振幅: <span id="amplitudeValue">100</span></label>
                     <input type="range" id="amplitude" class="form-control" min="10" max="300" value="100" step="5">
                 </div>
-                
+
                 <div class="control-item">
                     <label for="speed" class="form-label">速度: <span id="speedValue">1.0</span>x</label>
                     <input type="range" id="speed" class="form-control" min="0.25" max="2.0" value="1.0" step="0.25">
                 </div>
             </div>
-            
+
             <div class="controls-group presets">
-                <span class="preset-label">プリセット:</span>
-                <button class="btn btn--outline preset-btn" data-preset="calm">Calm</button>
-                <button class="btn btn--outline preset-btn" data-preset="classic">Classic</button>
-                <button class="btn btn--outline preset-btn" data-preset="dense">Dense</button>
-                <button class="btn btn--outline preset-btn" data-preset="async">Async</button>
+                <label for="presetSelect" class="form-label">プリセット</label>
+                <select id="presetSelect" class="form-control preset-select" aria-label="プリセット選択">
+                    <option value="custom" selected>カスタム</option>
+                    <option value="calm">Calm</option>
+                    <option value="classic">Classic</option>
+                    <option value="dense">Dense</option>
+                    <option value="async">Async</option>
+                </select>
             </div>
         </div>
         
@@ -77,13 +82,6 @@
             </div>
         </div>
         
-        <div class="info-panel">
-            <div class="region-labels">
-                <span class="region-label pendulum-label">ペンデュラム</span>
-                <span class="region-label strip-label">集約振幅</span>
-                <span class="region-label wave-label">流れる波形</span>
-            </div>
-        </div>
     </div>
     
     <script src="app.js"></script>

--- a/game42/style.css
+++ b/game42/style.css
@@ -366,6 +366,18 @@ a:hover {
   color: var(--color-primary-hover);
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 code,
 pre {
   font-family: var(--font-family-mono);
@@ -405,6 +417,19 @@ pre code {
   border: none;
   text-decoration: none;
   position: relative;
+}
+
+.btn--icon {
+  padding: var(--space-4);
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  border-radius: var(--radius-sm);
+}
+
+.btn-icon {
+  font-size: var(--font-size-lg);
+  line-height: 1;
 }
 
 .btn:focus-visible {
@@ -749,7 +774,7 @@ select.form-control {
 .control-panel {
     display: flex;
     flex-wrap: wrap;
-    align-items: center;
+    align-items: flex-start;
     gap: var(--space-16);
     padding: var(--space-12) var(--space-16);
     background: var(--color-surface);
@@ -762,13 +787,26 @@ select.form-control {
     display: flex;
     align-items: center;
     gap: var(--space-12);
+    flex-wrap: wrap;
+}
+
+.controls-group--primary {
+    flex: 1 1 auto;
+    min-width: 260px;
+    align-items: flex-end;
+    gap: var(--space-10);
+}
+
+.controls-group--primary .control-item,
+.controls-group--primary .btn--icon {
+    flex: 0 0 auto;
 }
 
 .control-item {
     display: flex;
     flex-direction: column;
     gap: var(--space-4);
-    min-width: 120px;
+    min-width: 96px;
 }
 
 .control-item .form-label {
@@ -779,7 +817,7 @@ select.form-control {
 }
 
 .control-item input[type="range"] {
-    width: 100px;
+    width: 96px;
     height: 4px;
     background: var(--color-secondary);
     border-radius: var(--radius-full);
@@ -816,6 +854,16 @@ select.form-control {
 
 .presets {
     margin-left: auto;
+}
+
+.preset-select {
+    min-width: 140px;
+}
+
+.presets .form-label {
+    margin-bottom: 0;
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
 }
 
 .preset-label {
@@ -875,85 +923,60 @@ select.form-control {
 
 .period-controls {
     display: flex;
-    gap: var(--space-16);
+    flex-wrap: wrap;
+    gap: var(--space-12);
     padding: var(--space-10) var(--space-16);
     background: rgba(245, 245, 245, 0.04);
     border-top: 1px solid rgba(245, 245, 245, 0.08);
 }
 
 .period-slider {
-    flex: 1;
-    min-width: 0;
+    flex: 0 0 auto;
+    min-width: 96px;
+    max-width: 120px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
 }
 
 .period-slider .form-label {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    font-size: var(--font-size-xs);
 }
 
 .period-slider span {
     font-variant-numeric: tabular-nums;
 }
 
-.info-panel {
-    padding: var(--space-8) var(--space-16);
-    background: var(--color-surface);
-    border-top: 1px solid var(--color-border);
-}
-
-.region-labels {
-    display: flex;
-    align-items: center;
-    font-size: var(--font-size-xs);
-    color: var(--color-text-secondary);
-}
-
-.region-label {
-    font-weight: var(--font-weight-medium);
-    padding: var(--space-4) var(--space-8);
-    border-radius: var(--radius-sm);
-    background: var(--color-bg-1);
-}
-
-.pendulum-label {
-    width: 42%;
-    text-align: center;
-    background: var(--color-bg-2);
-}
-
-.strip-label {
-    width: 8%;
-    text-align: center;
-    background: var(--color-bg-3);
-}
-
-.wave-label {
-    width: 50%;
-    text-align: center;
-    background: var(--color-bg-4);
+.period-slider input[type="range"] {
+    width: 96px;
 }
 
 /* Responsive adjustments */
 @media (max-width: 768px) {
     .control-panel {
-        flex-direction: column;
-        align-items: stretch;
+        gap: var(--space-12);
+    }
+
+    .controls-group--primary {
+        align-items: center;
         gap: var(--space-8);
-    }
-    
-    .controls-group {
-        justify-content: space-between;
-        flex-wrap: wrap;
-    }
-    
-    .presets {
-        margin-left: 0;
-        justify-content: center;
+        min-width: 0;
     }
 
     .control-item {
-        min-width: 100px;
+        min-width: 88px;
+    }
+
+    .control-item input[type="range"],
+    .period-slider input[type="range"] {
+        width: 88px;
+    }
+
+    .presets {
+        margin-left: 0;
     }
 
     .canvas-header {
@@ -967,17 +990,7 @@ select.form-control {
     }
 
     .period-controls {
-        flex-direction: column;
-        gap: var(--space-12);
-    }
-
-    .region-labels {
-        flex-direction: column;
-        gap: var(--space-4);
-    }
-    
-    .region-label {
-        width: 100% !important;
+        justify-content: flex-start;
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the preset buttons with a dropdown and remove the lower info panel to maximize the canvas
- restyle the control panel with icon-based pause/reset buttons and compact sliders that fit on mobile
- update the simulation script to drive the new preset selector and preserve custom configurations

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e4dc4c90c08325aa6e8e66a9ad163b