### PR TITLE
Adjust game42 control layout

### DIFF
--- a/game42/index.html
+++ b/game42/index.html
@@ -43,31 +43,31 @@
                     <label for="waveSpeed" class="form-label">波形速度: <span id="waveSpeedValue">1.00</span>x</label>
                     <input type="range" id="waveSpeed" class="form-control" min="0.25" max="3.0" value="1.0" step="0.25">
                 </div>
-            </div>
+                <div class="control-item control-item--select">
+                    <label for="presetSelect" class="form-label">プリセット</label>
+                    <select id="presetSelect" class="form-control preset-select" aria-label="プリセット選択">
+                        <option value="custom" selected>カスタム</option>
+                        <option value="calm">Calm</option>
+                        <option value="classic">Classic</option>
+                        <option value="dense">Dense</option>
+                        <option value="async">Async</option>
+                    </select>
+                </div>
 
-            <div class="controls-group presets">
-                <label for="presetSelect" class="form-label">プリセット</label>
-                <select id="presetSelect" class="form-control preset-select" aria-label="プリセット選択">
-                    <option value="custom" selected>カスタム</option>
-                    <option value="calm">Calm</option>
-                    <option value="classic">Classic</option>
-                    <option value="dense">Dense</option>
-                    <option value="async">Async</option>
-                </select>
+                <div class="control-item control-item--select">
+                    <label for="phasePreset" class="form-label">開始位相</label>
+                    <select id="phasePreset" class="form-control phase-preset-select">
+                        <option value="uniform" selected>Uniform</option>
+                        <option value="linear">Linear</option>
+                        <option value="center-fan">Center Fan</option>
+                        <option value="alternating">Alternating</option>
+                        <option value="random">Random</option>
+                    </select>
+                </div>
             </div>
         </div>
-        
+
         <div class="canvas-container">
-            <div class="canvas-header">
-                <label for="phasePreset" class="phase-preset-label">開始位相</label>
-                <select id="phasePreset" class="form-control phase-preset-select">
-                    <option value="uniform" selected>Uniform</option>
-                    <option value="linear">Linear</option>
-                    <option value="center-fan">Center Fan</option>
-                    <option value="alternating">Alternating</option>
-                    <option value="random">Random</option>
-                </select>
-            </div>
             <div class="canvas-stage">
                 <canvas id="simulationCanvas" tabindex="0" aria-label="ペンデュラムウェーブシミュレーション"></canvas>
             </div>

--- a/game42/style.css
+++ b/game42/style.css
@@ -809,6 +809,14 @@ select.form-control {
     min-width: 96px;
 }
 
+.control-item--select {
+    min-width: 140px;
+}
+
+.control-item--select .form-control {
+    min-width: 140px;
+}
+
 .control-item .form-label {
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-medium);
@@ -852,18 +860,8 @@ select.form-control {
     outline-offset: 2px;
 }
 
-.presets {
-    margin-left: auto;
-}
-
 .preset-select {
     min-width: 140px;
-}
-
-.presets .form-label {
-    margin-bottom: 0;
-    font-size: var(--font-size-xs);
-    color: var(--color-text-secondary);
 }
 
 .preset-label {
@@ -886,21 +884,7 @@ select.form-control {
     overflow: hidden;
     display: flex;
     flex-direction: column;
-}
-
-.canvas-header {
-    display: flex;
-    align-items: center;
-    gap: var(--space-12);
-    padding: var(--space-8) var(--space-16);
-    background: rgba(245, 245, 245, 0.04);
-    border-bottom: 1px solid rgba(245, 245, 245, 0.08);
-}
-
-.phase-preset-label {
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-medium);
-    color: rgba(245, 245, 245, 0.8);
+    min-height: 0;
 }
 
 .phase-preset-select {
@@ -912,6 +896,7 @@ select.form-control {
 .canvas-stage {
     flex: 1;
     position: relative;
+    min-height: 0;
 }
 
 #simulationCanvas {
@@ -928,6 +913,7 @@ select.form-control {
     padding: var(--space-10) var(--space-16);
     background: rgba(245, 245, 245, 0.04);
     border-top: 1px solid rgba(245, 245, 245, 0.08);
+    flex-shrink: 0;
 }
 
 .period-slider {
@@ -975,14 +961,8 @@ select.form-control {
         width: 88px;
     }
 
-    .presets {
-        margin-left: 0;
-    }
-
-    .canvas-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: var(--space-8);
+    .control-item--select {
+        min-width: 120px;
     }
 
     .phase-preset-select {


### PR DESCRIPTION
## Summary
- Move the preset selector next to the main sliders and relocate the phase preset dropdown into the top controls for easier access
- Update layout styling so the canvas area flexes and keeps the period sliders visible without scrolling on desktop

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5156c830c8325b820cba37d963959