### PR TITLE
Remove period customization sliders and enable layout resizing

### DIFF
--- a/game42/index.html
+++ b/game42/index.html
@@ -71,20 +71,6 @@
             <div class="canvas-stage">
                 <canvas id="simulationCanvas" tabindex="0" aria-label="ペンデュラムウェーブシミュレーション"></canvas>
             </div>
-            <div class="period-controls" aria-label="周期カスタマイズ">
-                <div class="period-slider">
-                    <label for="periodLeft" class="form-label">Left: <span id="periodLeftValue">6.00s</span></label>
-                    <input type="range" id="periodLeft" class="form-control" min="0.5" max="12" step="0.1" value="6.0">
-                </div>
-                <div class="period-slider">
-                    <label for="periodCenter" class="form-label">Center: <span id="periodCenterValue">5.20s</span></label>
-                    <input type="range" id="periodCenter" class="form-control" min="0.5" max="12" step="0.1" value="5.2">
-                </div>
-                <div class="period-slider">
-                    <label for="periodRight" class="form-label">Right: <span id="periodRightValue">4.40s</span></label>
-                    <input type="range" id="periodRight" class="form-control" min="0.5" max="12" step="0.1" value="4.4">
-                </div>
-            </div>
         </div>
         
     </div>

--- a/game42/style.css
+++ b/game42/style.css
@@ -903,41 +903,8 @@ select.form-control {
     width: 100%;
     height: 100%;
     display: block;
-    cursor: crosshair;
-}
-
-.period-controls {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-12);
-    padding: var(--space-10) var(--space-16);
-    background: rgba(245, 245, 245, 0.04);
-    border-top: 1px solid rgba(245, 245, 245, 0.08);
-    flex-shrink: 0;
-}
-
-.period-slider {
-    flex: 0 0 auto;
-    min-width: 96px;
-    max-width: 120px;
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-4);
-}
-
-.period-slider .form-label {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    font-size: var(--font-size-xs);
-}
-
-.period-slider span {
-    font-variant-numeric: tabular-nums;
-}
-
-.period-slider input[type="range"] {
-    width: 96px;
+    cursor: default;
+    user-select: none;
 }
 
 /* Responsive adjustments */
@@ -956,8 +923,7 @@ select.form-control {
         min-width: 88px;
     }
 
-    .control-item input[type="range"],
-    .period-slider input[type="range"] {
+    .control-item input[type="range"] {
         width: 88px;
     }
 
@@ -969,9 +935,6 @@ select.form-control {
         width: 100%;
     }
 
-    .period-controls {
-        justify-content: flex-start;
-    }
 }
 
 /* Dark mode enhancements */


### PR DESCRIPTION
## Summary
- remove the custom period sliders and associated UI so period anchors are derived from presets or the return time
- add pointer-based resizing for the pendulum, aggregate, and waveform regions with minimum widths and highlight feedback
- update canvas styling to reflect the new layout and dragging behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5319407708325a95be4de6bb36648