### PR TITLE
Improve game34 playback pacing and canvas layout

### DIFF
--- a/game34/app.js
+++ b/game34/app.js
@@ -1,7 +1,8 @@
 const TWO_PI = Math.PI * 2;
 const CIRCUMFERENCE = 2 * Math.PI * 52;
 const SNAPSHOT_KEY = 'game34_snapshots_v1';
-const BASE_PLAYBACK_SPEED = 420;
+const BASE_PLAYBACK_SPEED = 160;
+const MIN_PLAYBACK_SPEED = 0.01;
 
 const DEFAULT_STATE = {
   mode: 'inner',
@@ -350,13 +351,15 @@ function setStartButtonState(mode) {
 }
 
 function updatePlaybackSpeedControl() {
+  const value = clamp(Number(state.playbackSpeed ?? 1), MIN_PLAYBACK_SPEED, Number(playbackSpeedRange?.max ?? 3));
   if (playbackSpeedRange) {
-    playbackSpeedRange.value = String(state.playbackSpeed ?? 1);
+    playbackSpeedRange.value = String(value);
   }
   if (speedValueEl) {
-    const value = Number(state.playbackSpeed ?? 1);
-    speedValueEl.textContent = `${value.toFixed(1)}x`;
+    const decimals = value < 1 ? 2 : 1;
+    speedValueEl.textContent = `${value.toFixed(decimals)}x`;
   }
+  state.playbackSpeed = value;
 }
 
 function prepareCanvasBackground() {
@@ -741,7 +744,8 @@ function startDrawing(geometry) {
 
     const deltaSeconds = Math.max(0, (timestamp - drawTask.lastTime) / 1000);
     drawTask.lastTime = timestamp;
-    const speed = Math.max(0.05, Number(state.playbackSpeed ?? 1)) * BASE_PLAYBACK_SPEED;
+    const playbackScale = Math.max(MIN_PLAYBACK_SPEED, Number(state.playbackSpeed ?? 1));
+    const speed = playbackScale * BASE_PLAYBACK_SPEED;
     drawTask.progressLength = Math.min(drawTask.progressLength + deltaSeconds * speed, drawTask.totalLength);
 
     while (drawTask.currentIndex < drawTask.totalPoints && cumulative[drawTask.currentIndex] <= drawTask.progressLength) {

--- a/game34/index.html
+++ b/game34/index.html
@@ -15,8 +15,8 @@
           <button id="startRender" class="toolbar-btn" type="button" aria-label="スピログラフの描画を開始">描画開始</button>
           <label class="speed-control" for="playbackSpeedRange">
             <span>速度</span>
-            <input type="range" id="playbackSpeedRange" min="0.2" max="3" step="0.1" value="1" aria-label="描画速度を調整">
-            <span id="speedValue" aria-live="polite">1.0x</span>
+            <input type="range" id="playbackSpeedRange" min="0.01" max="3" step="0.01" value="1" aria-label="描画速度を調整">
+            <span id="speedValue" aria-live="polite">1.00x</span>
           </label>
         </div>
         <button id="exportPng" class="toolbar-btn" aria-label="PNGとして保存">PNG保存</button>

--- a/game34/style.css
+++ b/game34/style.css
@@ -44,18 +44,28 @@ body {
   width: 100%;
 }
 
+
 .display-area {
   flex: 1;
   position: relative;
   background: #05060a;
   overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  --canvas-padding: clamp(16px, 4vw, 48px);
+  padding: var(--canvas-padding);
 }
 
 #mainCanvas {
-  width: 100%;
-  height: 100%;
+  width: min(90vmin, 900px, calc(100% - 2 * var(--canvas-padding)));
+  max-width: min(90vmin, 900px, calc(100% - 2 * var(--canvas-padding)));
+  aspect-ratio: 1 / 1;
+  height: auto;
+  max-height: min(90vmin, 900px, calc(100% - 2 * var(--canvas-padding)));
   display: block;
   background: #05060a;
+  margin: 0 auto;
 }
 
 .canvas-toolbar {


### PR DESCRIPTION
## Summary
- slow the rendering animation by lowering the base playback speed and allowing finer slider control down to 0.01x
- make the canvas area square, centered, and much larger so the drawing fills the screen without distortion
- update the speed indicator formatting to reflect the new precision

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e533314ae4832586cca3fe5ddd7623