### PR TITLE
game60: center management UI and improve tap-state feedback colors

### DIFF
--- a/game60/app.js
+++ b/game60/app.js
@@ -6,14 +6,14 @@ const state = {
   phase: 'idle', // idle | waiting | go | roundOver | gameOver
   goTime: 0,
   timeoutId: null,
-  round: 0
+  round: 0,
+  toneTop: 'red',
+  toneBottom: 'red'
 };
 
 const ui = {
-  battleArea: document.getElementById('battleArea'),
   topBtn: document.getElementById('topBtn'),
   bottomBtn: document.getElementById('bottomBtn'),
-  overlay: document.getElementById('overlay'),
   status: document.getElementById('status'),
   scoreTop: document.getElementById('scoreTop'),
   scoreBottom: document.getElementById('scoreBottom'),
@@ -29,20 +29,22 @@ function clearTimer() {
   }
 }
 
+function applyTone(button, tone) {
+  button.classList.remove('state-red', 'state-green', 'state-orange', 'state-gray');
+  button.classList.add(`state-${tone}`);
+}
+
 function render() {
   ui.scoreTop.textContent = String(state.scoreTop);
   ui.scoreBottom.textContent = String(state.scoreBottom);
 
-  ui.battleArea.classList.remove('waiting', 'go', 'finished');
-  if (state.phase === 'waiting') ui.battleArea.classList.add('waiting');
-  if (state.phase === 'go') ui.battleArea.classList.add('go');
-  if (state.phase === 'gameOver') ui.battleArea.classList.add('finished');
+  applyTone(ui.topBtn, state.toneTop);
+  applyTone(ui.bottomBtn, state.toneBottom);
 
   ui.nextBtn.disabled = !(state.phase === 'roundOver' || state.phase === 'idle');
 }
 
-function setMessage(overlayText, statusText) {
-  ui.overlay.textContent = overlayText;
+function setStatus(statusText) {
   ui.status.textContent = statusText;
 }
 
@@ -50,23 +52,35 @@ function startRound() {
   clearTimer();
   state.round += 1;
   state.phase = 'waiting';
-  setMessage('まだ押さないで！', `第${state.round}ラウンド 準備中`);
+  state.toneTop = 'red';
+  state.toneBottom = 'red';
+  setStatus(`第${state.round}ラウンド：まだ押さないで！`);
   render();
 
   const wait = Math.floor(Math.random() * 2500) + 1500;
   state.timeoutId = setTimeout(() => {
     state.phase = 'go';
     state.goTime = performance.now();
-    setMessage('タップ！', '早く押した方に1点');
+    state.toneTop = 'green';
+    state.toneBottom = 'green';
+    setStatus('タップ！早く押した方に1点');
     render();
   }, wait);
 }
 
-function endRound(winner) {
+function endRound(winner, cause = 'react', actor = null) {
   clearTimer();
 
   if (winner === 'top') state.scoreTop += 1;
   if (winner === 'bottom') state.scoreBottom += 1;
+
+  if (cause === 'react') {
+    state.toneTop = winner === 'top' ? 'green' : 'gray';
+    state.toneBottom = winner === 'bottom' ? 'green' : 'gray';
+  } else if (cause === 'foul') {
+    state.toneTop = actor === 'top' ? 'orange' : 'green';
+    state.toneBottom = actor === 'bottom' ? 'orange' : 'green';
+  }
 
   const winTop = state.scoreTop >= WIN_SCORE;
   const winBottom = state.scoreBottom >= WIN_SCORE;
@@ -74,11 +88,11 @@ function endRound(winner) {
   if (winTop || winBottom) {
     state.phase = 'gameOver';
     const champ = winTop ? '上プレイヤー' : '下プレイヤー';
-    setMessage('ゲーム終了', `${champ}の勝ち！`);
+    setStatus(`ゲーム終了：${champ}の勝ち！`);
   } else {
     state.phase = 'roundOver';
     const roundWinner = winner === 'top' ? '上プレイヤー' : '下プレイヤー';
-    setMessage(`${roundWinner} 1点！`, '次のラウンドへ進んでください');
+    setStatus(`${roundWinner} 1点！「次のラウンド」を押してください`);
   }
 
   render();
@@ -88,20 +102,19 @@ function handlePress(player) {
   if (state.phase === 'idle') return;
 
   if (state.phase === 'waiting') {
-    // フライングは相手に1点
     const winner = player === 'top' ? 'bottom' : 'top';
-    endRound(winner);
+    endRound(winner, 'foul', player);
     const fouler = player === 'top' ? '上プレイヤー' : '下プレイヤー';
-    ui.status.textContent = `${fouler}のフライング！相手に1点`;
+    ui.status.textContent = `${fouler}のフライング！惜しかったのでオレンジ表示`;
     return;
   }
 
   if (state.phase !== 'go') return;
 
   const reaction = Math.round(performance.now() - state.goTime);
-  endRound(player);
+  endRound(player, 'react');
   const winnerLabel = player === 'top' ? '上プレイヤー' : '下プレイヤー';
-  ui.status.textContent = `${winnerLabel}が${reaction}msで獲得！`;
+  ui.status.textContent = `${winnerLabel}が${reaction}msで獲得！押し負けはグレー表示`;
 }
 
 function resetGame() {
@@ -110,7 +123,9 @@ function resetGame() {
   state.scoreBottom = 0;
   state.phase = 'idle';
   state.round = 0;
-  setMessage('待機中…', 'スタートを押して開始');
+  state.toneTop = 'red';
+  state.toneBottom = 'red';
+  setStatus('スタートを押して開始（待機色は赤 / 押せる時は緑）');
   render();
 }
 

--- a/game60/index.html
+++ b/game60/index.html
@@ -8,34 +8,34 @@
 </head>
 <body>
   <main class="app">
-    <header class="panel">
-      <h1>反射神経バトル</h1>
-      <p>画面が「タップ！」になったら、上と下のプレイヤーで同時対戦。先に3点取った方が勝ち！</p>
-    </header>
+    <button id="topBtn" class="tap-zone top" type="button">上プレイヤー タップ</button>
 
-    <section class="panel score-panel" aria-live="polite">
-      <div class="score-item">
-        <span class="label">上プレイヤー</span>
-        <strong id="scoreTop">0</strong>
-      </div>
-      <div class="status" id="status">スタートを押して開始</div>
-      <div class="score-item">
-        <span class="label">下プレイヤー</span>
-        <strong id="scoreBottom">0</strong>
-      </div>
+    <section class="center-ui">
+      <header class="panel">
+        <h1>反射神経バトル</h1>
+        <p>画面が「タップ！」になったら、上と下のプレイヤーで同時対戦。先に3点取った方が勝ち！</p>
+      </header>
+
+      <section class="panel score-panel" aria-live="polite">
+        <div class="score-item">
+          <span class="label">上プレイヤー</span>
+          <strong id="scoreTop">0</strong>
+        </div>
+        <div class="status" id="status">スタートを押して開始</div>
+        <div class="score-item">
+          <span class="label">下プレイヤー</span>
+          <strong id="scoreBottom">0</strong>
+        </div>
+      </section>
+
+      <section class="controls panel">
+        <button id="startBtn" class="btn primary" type="button">スタート</button>
+        <button id="nextBtn" class="btn" type="button" disabled>次のラウンド</button>
+        <button id="resetBtn" class="btn" type="button">リセット</button>
+      </section>
     </section>
 
-    <section class="battle-area" id="battleArea">
-      <button id="topBtn" class="tap-zone top" type="button">上プレイヤー タップ</button>
-      <button id="bottomBtn" class="tap-zone bottom" type="button">下プレイヤー タップ</button>
-      <div class="overlay" id="overlay">待機中…</div>
-    </section>
-
-    <section class="controls panel">
-      <button id="startBtn" class="btn primary" type="button">スタート</button>
-      <button id="nextBtn" class="btn" type="button" disabled>次のラウンド</button>
-      <button id="resetBtn" class="btn" type="button">リセット</button>
-    </section>
+    <button id="bottomBtn" class="tap-zone bottom" type="button">下プレイヤー タップ</button>
   </main>
 
   <script src="app.js"></script>

--- a/game60/style.css
+++ b/game60/style.css
@@ -5,9 +5,10 @@
   --muted: #66708a;
   --line: #d8e0f3;
   --primary: #2f6df6;
-  --ready: #f6c343;
-  --go: #18a16a;
-  --danger: #e45757;
+  --danger-red: #e45757;
+  --ready-green: #18a16a;
+  --near-orange: #f08a32;
+  --lose-gray: #8f96a8;
 }
 
 * { box-sizing: border-box; }
@@ -25,9 +26,15 @@ body {
   margin: 0 auto;
   min-height: 100dvh;
   display: grid;
-  grid-template-rows: auto auto 1fr auto;
+  grid-template-rows: 1fr auto 1fr;
   gap: 10px;
   padding: max(10px, env(safe-area-inset-top)) 12px calc(10px + env(safe-area-inset-bottom));
+}
+
+.center-ui {
+  display: grid;
+  gap: 10px;
+  align-content: center;
 }
 
 .panel {
@@ -75,49 +82,27 @@ p {
   text-align: center;
 }
 
-.battle-area {
-  position: relative;
-  border-radius: 16px;
-  overflow: hidden;
-  border: 1px solid var(--line);
-  display: grid;
-  grid-template-rows: 1fr 1fr;
-  min-height: 380px;
-  background: #dbe4fa;
-}
-
 .tap-zone {
+  width: 100%;
+  min-height: 180px;
   border: none;
-  font-size: 1.05rem;
+  border-radius: 16px;
+  font-size: 1.1rem;
   font-weight: 700;
   color: #fff;
   touch-action: manipulation;
+  box-shadow: 0 4px 16px rgba(11, 20, 45, 0.14);
+  transition: background-color .15s ease;
 }
 
-.tap-zone.top { background: #5078de; }
-.tap-zone.bottom { background: #7350de; }
+.tap-zone.state-red { background: var(--danger-red); }
+.tap-zone.state-green { background: var(--ready-green); }
+.tap-zone.state-orange { background: var(--near-orange); }
+.tap-zone.state-gray { background: var(--lose-gray); }
 
 .tap-zone:active {
-  filter: brightness(0.9);
+  filter: brightness(0.92);
 }
-
-.overlay {
-  position: absolute;
-  inset: 50% 12px auto;
-  transform: translateY(-50%);
-  background: rgba(11, 20, 45, 0.78);
-  color: #fff;
-  border-radius: 999px;
-  padding: 10px 14px;
-  text-align: center;
-  font-weight: 700;
-  letter-spacing: .02em;
-  pointer-events: none;
-}
-
-.battle-area.waiting .overlay { background: rgba(246, 195, 67, 0.9); color: #402d00; }
-.battle-area.go .overlay { background: rgba(24, 161, 106, 0.92); }
-.battle-area.finished .overlay { background: rgba(228, 87, 87, 0.92); }
 
 .controls {
   display: grid;


### PR DESCRIPTION
### Motivation
- Move management UI (title, rules, score, and control buttons) out of the top/bottom tap areas and place them in the screen center so the control buttons no longer compete with the players' tap zones. 
- Make round outcome and actionable states visually obvious by using distinct button colors for waiting/ready/foul/loss to reduce ambiguity in win/loss feedback. 

### Description
- Updated layout in `game60/index.html` to place top and bottom tap buttons at the screen edges and group title/description/score/controls inside a new `.center-ui` section. 
- Added color variables and new style rules in `game60/style.css`, including `--danger-red`, `--ready-green`, `--near-orange`, `--lose-gray` and `.tap-zone.state-{red,green,orange,gray}` classes, plus layout adjustments for the centered UI. 
- Reworked game logic in `game60/app.js` to track `toneTop`/`toneBottom`, added `applyTone()` and updated state transitions so that `startRound`, the `go` event, fouls, and round results set the appropriate color states and update status text. 
- Removed the previous overlay usage and simplified status messages to match the new color cues and clearer round flow. 

### Testing
- Ran static syntax check with `node --check game60/app.js`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7b4fb671083259a2a2ed735beeb5e)