### PR TITLE
Improve game60 play UI and add compact round history

### DIFF
--- a/game60/app.js
+++ b/game60/app.js
@@ -1,22 +1,32 @@
 const WIN_SCORE = 3;
 
+const PLAYER = {
+  apple: '🍎',
+  banana: '🍌'
+};
+
 const state = {
-  scoreTop: 0,
-  scoreBottom: 0,
+  score: { apple: 0, banana: 0 },
   phase: 'idle', // idle | waiting | go | roundOver | gameOver
   goTime: 0,
   timeoutId: null,
   round: 0,
   toneTop: 'red',
-  toneBottom: 'red'
+  toneBottom: 'red',
+  topPlayer: 'apple',
+  bottomPlayer: 'banana',
+  history: []
 };
 
 const ui = {
   topBtn: document.getElementById('topBtn'),
   bottomBtn: document.getElementById('bottomBtn'),
   status: document.getElementById('status'),
-  scoreTop: document.getElementById('scoreTop'),
-  scoreBottom: document.getElementById('scoreBottom'),
+  scoreApple: document.getElementById('scoreApple'),
+  scoreBanana: document.getElementById('scoreBanana'),
+  positionHint: document.getElementById('positionHint'),
+  historyList: document.getElementById('historyList'),
+  introPanel: document.getElementById('introPanel'),
   startBtn: document.getElementById('startBtn'),
   nextBtn: document.getElementById('nextBtn'),
   resetBtn: document.getElementById('resetBtn')
@@ -34,18 +44,60 @@ function applyTone(button, tone) {
   button.classList.add(`state-${tone}`);
 }
 
-function render() {
-  ui.scoreTop.textContent = String(state.scoreTop);
-  ui.scoreBottom.textContent = String(state.scoreBottom);
+function playerIcon(key) {
+  return PLAYER[key];
+}
 
-  applyTone(ui.topBtn, state.toneTop);
-  applyTone(ui.bottomBtn, state.toneBottom);
+function formatMs(value) {
+  return Number.isFinite(value) ? `${value}ms` : '--';
+}
 
-  ui.nextBtn.disabled = !(state.phase === 'roundOver' || state.phase === 'idle');
+function updateHistory() {
+  ui.historyList.innerHTML = '';
+
+  if (state.history.length === 0) {
+    const li = document.createElement('li');
+    li.className = 'empty';
+    li.textContent = '履歴なし';
+    ui.historyList.appendChild(li);
+    return;
+  }
+
+  state.history.forEach((item) => {
+    const li = document.createElement('li');
+    const winner = item.winner ? playerIcon(item.winner) : 'なし';
+    const detail = `R${item.round} 🍎 ${item.apple} / 🍌 ${item.banana} → ${winner}`;
+    li.textContent = detail;
+    ui.historyList.appendChild(li);
+  });
+
+  ui.historyList.scrollTop = ui.historyList.scrollHeight;
 }
 
 function setStatus(statusText) {
   ui.status.textContent = statusText;
+}
+
+function setPhaseUi() {
+  const isIdle = state.phase === 'idle';
+  const isRoundOver = state.phase === 'roundOver';
+  const isGameOver = state.phase === 'gameOver';
+
+  ui.introPanel.classList.toggle('hidden', !isIdle);
+  ui.startBtn.classList.toggle('hidden', !isIdle && !isGameOver);
+  ui.nextBtn.classList.toggle('hidden', !isRoundOver);
+  ui.nextBtn.disabled = !isRoundOver;
+}
+
+function render() {
+  ui.scoreApple.textContent = String(state.score.apple);
+  ui.scoreBanana.textContent = String(state.score.banana);
+  ui.positionHint.textContent = `上: ${playerIcon(state.topPlayer)} / 下: ${playerIcon(state.bottomPlayer)}`;
+
+  applyTone(ui.topBtn, state.toneTop);
+  applyTone(ui.bottomBtn, state.toneBottom);
+  updateHistory();
+  setPhaseUi();
 }
 
 function startRound() {
@@ -54,7 +106,7 @@ function startRound() {
   state.phase = 'waiting';
   state.toneTop = 'red';
   state.toneBottom = 'red';
-  setStatus(`第${state.round}ラウンド：まだ押さないで！`);
+  setStatus(`R${state.round} 準備`);
   render();
 
   const wait = Math.floor(Math.random() * 2500) + 1500;
@@ -63,76 +115,107 @@ function startRound() {
     state.goTime = performance.now();
     state.toneTop = 'green';
     state.toneBottom = 'green';
-    setStatus('タップ！早く押した方に1点');
+    setStatus('タップ！');
     render();
   }, wait);
 }
 
-function endRound(winner, cause = 'react', actor = null) {
+function addHistory(entry) {
+  state.history.push({
+    round: state.round,
+    apple: entry.apple,
+    banana: entry.banana,
+    winner: entry.winner
+  });
+}
+
+function endRound(winner, cause = 'react', actor = null, reaction = null) {
   clearTimer();
 
-  if (winner === 'top') state.scoreTop += 1;
-  if (winner === 'bottom') state.scoreBottom += 1;
-
-  if (cause === 'react') {
-    state.toneTop = winner === 'top' ? 'green' : 'gray';
-    state.toneBottom = winner === 'bottom' ? 'green' : 'gray';
-  } else if (cause === 'foul') {
-    state.toneTop = actor === 'top' ? 'orange' : 'green';
-    state.toneBottom = actor === 'bottom' ? 'orange' : 'green';
+  if (winner) {
+    state.score[winner] += 1;
   }
 
-  const winTop = state.scoreTop >= WIN_SCORE;
-  const winBottom = state.scoreBottom >= WIN_SCORE;
+  if (cause === 'react') {
+    state.toneTop = state.topPlayer === winner ? 'green' : 'gray';
+    state.toneBottom = state.bottomPlayer === winner ? 'green' : 'gray';
 
-  if (winTop || winBottom) {
+    addHistory({
+      apple: winner === 'apple' ? formatMs(reaction) : '--',
+      banana: winner === 'banana' ? formatMs(reaction) : '--',
+      winner
+    });
+
+    setStatus(`${playerIcon(winner)}の勝ち！ ${reaction}ms`);
+  } else {
+    const foulerKey = actor === 'top' ? state.topPlayer : state.bottomPlayer;
+    const winnerKey = winner;
+
+    state.toneTop = actor === 'top' ? 'orange' : 'green';
+    state.toneBottom = actor === 'bottom' ? 'orange' : 'green';
+
+    addHistory({
+      apple: foulerKey === 'apple' ? 'false start' : '--',
+      banana: foulerKey === 'banana' ? 'false start' : '--',
+      winner: winnerKey
+    });
+
+    setStatus('フライング');
+  }
+
+  const winApple = state.score.apple >= WIN_SCORE;
+  const winBanana = state.score.banana >= WIN_SCORE;
+
+  if (winApple || winBanana) {
     state.phase = 'gameOver';
-    const champ = winTop ? '上プレイヤー' : '下プレイヤー';
-    setStatus(`ゲーム終了：${champ}の勝ち！`);
+    const champ = winApple ? 'apple' : 'banana';
+    setStatus(`${playerIcon(champ)}の勝ち！`);
   } else {
     state.phase = 'roundOver';
-    const roundWinner = winner === 'top' ? '上プレイヤー' : '下プレイヤー';
-    setStatus(`${roundWinner} 1点！「次のラウンド」を押してください`);
   }
 
   render();
 }
 
-function handlePress(player) {
-  if (state.phase === 'idle') return;
+function handlePress(position) {
+  if (state.phase === 'idle' || state.phase === 'roundOver' || state.phase === 'gameOver') return;
 
   if (state.phase === 'waiting') {
-    const winner = player === 'top' ? 'bottom' : 'top';
-    endRound(winner, 'foul', player);
-    const fouler = player === 'top' ? '上プレイヤー' : '下プレイヤー';
-    ui.status.textContent = `${fouler}のフライング！惜しかったのでオレンジ表示`;
+    const winner = position === 'top' ? state.bottomPlayer : state.topPlayer;
+    endRound(winner, 'foul', position);
     return;
   }
 
   if (state.phase !== 'go') return;
 
   const reaction = Math.round(performance.now() - state.goTime);
-  endRound(player, 'react');
-  const winnerLabel = player === 'top' ? '上プレイヤー' : '下プレイヤー';
-  ui.status.textContent = `${winnerLabel}が${reaction}msで獲得！押し負けはグレー表示`;
+  const winner = position === 'top' ? state.topPlayer : state.bottomPlayer;
+  endRound(winner, 'react', null, reaction);
+}
+
+function swapPositions() {
+  [state.topPlayer, state.bottomPlayer] = [state.bottomPlayer, state.topPlayer];
 }
 
 function resetGame() {
   clearTimer();
-  state.scoreTop = 0;
-  state.scoreBottom = 0;
+  state.score.apple = 0;
+  state.score.banana = 0;
   state.phase = 'idle';
   state.round = 0;
   state.toneTop = 'red';
   state.toneBottom = 'red';
-  setStatus('スタートを押して開始（待機色は赤 / 押せる時は緑）');
+  state.topPlayer = 'apple';
+  state.bottomPlayer = 'banana';
+  state.history = [];
+  setStatus('スタートで開始');
   render();
 }
 
-function bindPress(target, player) {
+function bindPress(target, position) {
   const onPress = (event) => {
     event.preventDefault();
-    handlePress(player);
+    handlePress(position);
   };
 
   target.addEventListener('pointerdown', onPress);
@@ -143,16 +226,20 @@ function bindPress(target, player) {
 ui.startBtn.addEventListener('click', () => {
   if (state.phase === 'idle' || state.phase === 'gameOver') {
     if (state.phase === 'gameOver') {
-      state.scoreTop = 0;
-      state.scoreBottom = 0;
+      state.score.apple = 0;
+      state.score.banana = 0;
       state.round = 0;
+      state.history = [];
+      state.topPlayer = 'apple';
+      state.bottomPlayer = 'banana';
     }
     startRound();
   }
 });
 
 ui.nextBtn.addEventListener('click', () => {
-  if (state.phase === 'roundOver' || state.phase === 'idle') {
+  if (state.phase === 'roundOver') {
+    swapPositions();
     startRound();
   }
 });

--- a/game60/index.html
+++ b/game60/index.html
@@ -8,34 +8,41 @@
 </head>
 <body>
   <main class="app">
-    <button id="topBtn" class="tap-zone top" type="button">上プレイヤー タップ</button>
+    <button id="topBtn" class="tap-zone top" type="button">上エリアをタップ</button>
 
     <section class="center-ui">
-      <header class="panel">
+      <header id="introPanel" class="panel intro-panel">
         <h1>反射神経バトル</h1>
-        <p>画面が「タップ！」になったら、上と下のプレイヤーで同時対戦。先に3点取った方が勝ち！</p>
+        <p>「タップ！」になったらすぐ押して先に3点先取。ラウンドごとに上下を交代して遊べます。</p>
       </header>
 
       <section class="panel score-panel" aria-live="polite">
         <div class="score-item">
-          <span class="label">上プレイヤー</span>
-          <strong id="scoreTop">0</strong>
+          <span class="label">🍎</span>
+          <strong id="scoreApple">0</strong>
         </div>
-        <div class="status" id="status">スタートを押して開始</div>
+        <div class="status-block">
+          <div class="status" id="status">スタートで開始</div>
+          <div class="position-hint" id="positionHint">上: 🍎 / 下: 🍌</div>
+        </div>
         <div class="score-item">
-          <span class="label">下プレイヤー</span>
-          <strong id="scoreBottom">0</strong>
+          <span class="label">🍌</span>
+          <strong id="scoreBanana">0</strong>
         </div>
+      </section>
+
+      <section class="panel history-panel">
+        <ul id="historyList" class="history-list" aria-live="polite"></ul>
       </section>
 
       <section class="controls panel">
         <button id="startBtn" class="btn primary" type="button">スタート</button>
-        <button id="nextBtn" class="btn" type="button" disabled>次のラウンド</button>
-        <button id="resetBtn" class="btn" type="button">リセット</button>
+        <button id="nextBtn" class="btn primary next-btn" type="button" disabled>次のラウンド</button>
+        <button id="resetBtn" class="btn subtle" type="button">リセット</button>
       </section>
     </section>
 
-    <button id="bottomBtn" class="tap-zone bottom" type="button">下プレイヤー タップ</button>
+    <button id="bottomBtn" class="tap-zone bottom" type="button">下エリアをタップ</button>
   </main>
 
   <script src="app.js"></script>

--- a/game60/style.css
+++ b/game60/style.css
@@ -27,39 +27,45 @@ body {
   min-height: 100dvh;
   display: grid;
   grid-template-rows: 1fr auto 1fr;
-  gap: 10px;
-  padding: max(10px, env(safe-area-inset-top)) 12px calc(10px + env(safe-area-inset-bottom));
+  gap: 8px;
+  padding: max(8px, env(safe-area-inset-top)) 10px calc(10px + env(safe-area-inset-bottom));
 }
 
 .center-ui {
   display: grid;
-  gap: 10px;
+  gap: 6px;
   align-content: center;
 }
 
 .panel {
   background: var(--panel);
   border: 1px solid var(--line);
-  border-radius: 14px;
-  padding: 10px 12px;
+  border-radius: 12px;
+  padding: 8px 10px;
 }
 
-h1 {
+.intro-panel h1 {
   margin: 0;
-  font-size: 1.25rem;
+  font-size: 1.15rem;
 }
 
-p {
+.intro-panel p {
   margin: 6px 0 0;
   color: var(--muted);
-  font-size: 0.92rem;
+  font-size: 0.9rem;
+}
+
+.intro-panel.hidden {
+  display: none;
 }
 
 .score-panel {
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: 80px 1fr 80px;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+  padding-top: 6px;
+  padding-bottom: 6px;
 }
 
 .score-item {
@@ -68,8 +74,7 @@ p {
 
 .score-item .label {
   display: block;
-  font-size: 0.8rem;
-  color: var(--muted);
+  font-size: 1rem;
 }
 
 .score-item strong {
@@ -77,22 +82,60 @@ p {
   line-height: 1;
 }
 
-.status {
-  font-weight: 700;
+.status-block {
+  display: grid;
+  gap: 2px;
   text-align: center;
+}
+
+.status {
+  font-weight: 800;
+  font-size: 1rem;
+  min-height: 1.3em;
+}
+
+.position-hint {
+  font-size: 0.72rem;
+  color: var(--muted);
+  min-height: 1.2em;
+}
+
+.history-panel {
+  padding: 4px 8px;
+}
+
+.history-list {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  max-height: 82px;
+  overflow-y: auto;
+}
+
+.history-list li {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #33405f;
+  padding: 1px 0;
+}
+
+.history-list li.empty {
+  color: var(--muted);
 }
 
 .tap-zone {
   width: 100%;
-  min-height: 180px;
+  min-height: 190px;
   border: none;
   border-radius: 16px;
-  font-size: 1.1rem;
+  font-size: 1rem;
   font-weight: 700;
   color: #fff;
   touch-action: manipulation;
   box-shadow: 0 4px 16px rgba(11, 20, 45, 0.14);
-  transition: background-color .15s ease;
 }
 
 .tap-zone.state-red { background: var(--danger-red); }
@@ -100,23 +143,23 @@ p {
 .tap-zone.state-orange { background: var(--near-orange); }
 .tap-zone.state-gray { background: var(--lose-gray); }
 
-.tap-zone:active {
-  filter: brightness(0.92);
-}
+.tap-zone:active { filter: brightness(0.92); }
 
 .controls {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: 1fr auto;
   gap: 8px;
+  align-items: center;
 }
 
 .btn {
-  min-height: 44px;
+  min-height: 42px;
   border-radius: 10px;
   border: 1px solid var(--line);
   background: #fff;
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   font-weight: 700;
+  padding: 0 12px;
 }
 
 .btn.primary {
@@ -125,6 +168,24 @@ p {
   border-color: transparent;
 }
 
+.next-btn {
+  grid-column: 1;
+  font-size: 1rem;
+  min-height: 48px;
+}
+
+.subtle {
+  grid-column: 2;
+  min-height: 34px;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+#startBtn.hidden,
+#nextBtn.hidden {
+  display: none;
+}
+
 .btn:disabled {
-  opacity: 0.5;
+  opacity: 0.4;
 }


### PR DESCRIPTION
### Motivation
- プレイ中の画面を説明文で占有せず反応に集中できるようにし、情報量を減らすことを目的としています。 
- 複数ラウンド遊んだときに反応速度の流れを追えるよう、過去ラウンドをコンパクトな履歴として残す必要がありました。 
- 次に押すべき主要操作を自然に目立たせ、誤操作を減らすために操作ボタンの優先度を明確化します。

### Description
- 画面分離を行い、開始前にだけ表示する紹介パネルを `introPanel` として `index.html` に追加し、プレイ開始で非表示にする制御を `app.js` の `setPhaseUi` / `render` で行うようにしました。 
- スコア表示を `上/下` から `🍎/🍌` に簡略化して `scoreApple` / `scoreBanana` を導入し、`style.css` を調整して余白・高さを圧縮しタップ領域を優先しました。 
- 中央の状態メッセージを短文化して `タップ！` / `Rn 準備` / `🍎の勝ち！ 408ms` / `フライング` など反応に即した文言のみを出すように変更しました。 
- ラウンド履歴を `historyList` として追加し、1行フォーマット `Rn 🍎 <ms/false start> / 🍌 <ms/false start> → <勝者>` で蓄積・表示（高さ制限 + 内部スクロール）する `addHistory` / `updateHistory` を実装しました。 
- ラウンド間で上下を入れ替えてもプレイヤー識別子（`apple` / `banana` = `🍎/🍌`）で履歴とスコアが追えるように `topPlayer` / `bottomPlayer` を導入し、`swapPositions` を `次のラウンド` 時に呼ぶようにしました。 
- 操作ボタンの優先度を見た目で差別化し、`次のラウンド` を目立つ主ボタン（`next-btn` / primary 大きめ）に、`リセット` を小さく控えめな `subtle` ボタンに変更しました. 

### Testing
- Ran `node --check game60/app.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da153b4e608325bda77e4e14127df5)