### PR TITLE
Add game61: reflex duel mini-app (HTML/CSS/JS)

### DIFF
--- a/game61/index.html
+++ b/game61/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>反射神経対戦ミニアプリ</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="app" aria-label="反射神経対戦ミニアプリ">
+      <section class="player-zone player-zone--top" aria-label="上側プレイヤー ♦️">
+        <header class="player-header">
+          <span class="player-label">♦️</span>
+          <span class="player-score" id="score-diamond">0</span>
+        </header>
+        <div class="choices" id="choices-diamond"></div>
+      </section>
+
+      <section class="center-zone" aria-live="polite">
+        <p class="round-label" id="round-label">Round 1</p>
+        <div class="topic" id="topic-shape" aria-label="お題"></div>
+        <div class="status-panel" id="status-panel"></div>
+      </section>
+
+      <section class="player-zone player-zone--bottom" aria-label="下側プレイヤー ❤️">
+        <div class="choices" id="choices-heart"></div>
+        <header class="player-header player-header--bottom">
+          <span class="player-label">❤️</span>
+          <span class="player-score" id="score-heart">0</span>
+        </header>
+      </section>
+    </main>
+
+    <template id="choice-button-template">
+      <button class="choice-btn" type="button">
+        <span class="shape"></span>
+      </button>
+    </template>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/game61/script.js
+++ b/game61/script.js
@@ -1,0 +1,412 @@
+'use strict';
+
+// =========================
+// Constants
+// =========================
+const WIN_SCORE = 3;
+const INPUT_GUARD_MS = 100;
+const POST_DECISION_CAPTURE_MS = 100;
+
+const COLORS = ['red', 'blue', 'green'];
+const SHAPES = ['circle', 'triangle', 'square'];
+
+const PLAYER = {
+  DIAMOND: 'diamond',
+  HEART: 'heart'
+};
+
+const PLAYER_SYMBOL = {
+  [PLAYER.DIAMOND]: '♦️',
+  [PLAYER.HEART]: '❤️'
+};
+
+const COMBINATIONS = createCombinations();
+
+// =========================
+// State
+// =========================
+const state = {
+  roundNumber: 0,
+  scores: {
+    [PLAYER.DIAMOND]: 0,
+    [PLAYER.HEART]: 0
+  },
+  currentTopic: null,
+  currentChoices: [],
+  acceptingInput: false,
+  roundSettled: false,
+  gameEnded: false,
+  reactionStartAt: 0,
+  pressedAt: {
+    [PLAYER.DIAMOND]: null,
+    [PLAYER.HEART]: null
+  },
+  reactionsMs: {
+    [PLAYER.DIAMOND]: null,
+    [PLAYER.HEART]: null
+  },
+  correctness: {
+    [PLAYER.DIAMOND]: null,
+    [PLAYER.HEART]: null
+  },
+  winnerOfRound: null,
+  roundHistory: [],
+  roundTimers: {
+    guard: null,
+    finish: null
+  }
+};
+
+// =========================
+// DOM refs
+// =========================
+const ui = {
+  scoreDiamond: document.getElementById('score-diamond'),
+  scoreHeart: document.getElementById('score-heart'),
+  roundLabel: document.getElementById('round-label'),
+  topicShape: document.getElementById('topic-shape'),
+  statusPanel: document.getElementById('status-panel'),
+  diamondChoices: document.getElementById('choices-diamond'),
+  heartChoices: document.getElementById('choices-heart'),
+  choiceTemplate: document.getElementById('choice-button-template')
+};
+
+// =========================
+// Init
+// =========================
+startNewGame();
+
+// =========================
+// Core round flow
+// =========================
+function startNewGame() {
+  clearRoundTimers();
+
+  state.roundNumber = 0;
+  state.scores[PLAYER.DIAMOND] = 0;
+  state.scores[PLAYER.HEART] = 0;
+  state.roundHistory = [];
+  state.gameEnded = false;
+
+  startNextRound();
+}
+
+function startNextRound() {
+  clearRoundTimers();
+
+  state.roundNumber += 1;
+  state.currentTopic = randomFrom(COMBINATIONS);
+  state.currentChoices = generateRoundChoices(state.currentTopic);
+
+  state.acceptingInput = false;
+  state.roundSettled = false;
+  state.winnerOfRound = null;
+
+  resetRoundInputState();
+  renderAll();
+
+  state.roundTimers.guard = window.setTimeout(() => {
+    state.acceptingInput = true;
+    state.reactionStartAt = performance.now();
+    renderStatusWaiting();
+  }, INPUT_GUARD_MS);
+}
+
+function generateRoundChoices(topic) {
+  const correctPool = COMBINATIONS.filter(
+    (item) => item.color !== topic.color && item.shape !== topic.shape
+  );
+
+  const wrongPool = COMBINATIONS.filter(
+    (item) => !(item.color !== topic.color && item.shape !== topic.shape)
+  );
+
+  const correct = randomFrom(correctPool);
+  const wrong = randomFrom(wrongPool);
+
+  const twoChoices = [
+    { ...correct, isCorrect: true, key: makeKey(correct) },
+    { ...wrong, isCorrect: false, key: makeKey(wrong) }
+  ];
+
+  return Math.random() < 0.5 ? twoChoices : [twoChoices[1], twoChoices[0]];
+}
+
+function handlePlayerPress(player, choiceIndex) {
+  if (state.gameEnded || !state.acceptingInput) {
+    return;
+  }
+
+  const now = performance.now();
+
+  if (state.pressedAt[player] !== null) {
+    return;
+  }
+
+  state.pressedAt[player] = now;
+  state.reactionsMs[player] = Math.max(0, Math.round(now - state.reactionStartAt));
+
+  const selected = state.currentChoices[choiceIndex];
+  state.correctness[player] = selected.isCorrect;
+
+  markPressedVisual(player, choiceIndex);
+
+  if (!state.roundSettled) {
+    settleRoundByFirstInput(player, selected.isCorrect);
+  }
+}
+
+function settleRoundByFirstInput(firstPlayer, firstIsCorrect) {
+  state.roundSettled = true;
+
+  const other = firstPlayer === PLAYER.DIAMOND ? PLAYER.HEART : PLAYER.DIAMOND;
+  state.winnerOfRound = firstIsCorrect ? firstPlayer : other;
+
+  state.scores[state.winnerOfRound] += 1;
+
+  state.roundTimers.finish = window.setTimeout(() => {
+    finishRound();
+  }, POST_DECISION_CAPTURE_MS);
+
+  renderStatusRoundResult();
+}
+
+function finishRound() {
+  state.acceptingInput = false;
+
+  if (state.correctness[PLAYER.DIAMOND] === null) {
+    state.correctness[PLAYER.DIAMOND] = null;
+  }
+  if (state.correctness[PLAYER.HEART] === null) {
+    state.correctness[PLAYER.HEART] = null;
+  }
+
+  saveRoundHistory();
+
+  if (state.scores[PLAYER.DIAMOND] >= WIN_SCORE || state.scores[PLAYER.HEART] >= WIN_SCORE) {
+    state.gameEnded = true;
+    renderGameFinished();
+    return;
+  }
+
+  renderStatusRoundResult(true);
+}
+
+function saveRoundHistory() {
+  state.roundHistory.push({
+    round: state.roundNumber,
+    winner: state.winnerOfRound,
+    diamondReaction: state.reactionsMs[PLAYER.DIAMOND],
+    heartReaction: state.reactionsMs[PLAYER.HEART],
+    diamondCorrect: state.correctness[PLAYER.DIAMOND],
+    heartCorrect: state.correctness[PLAYER.HEART]
+  });
+}
+
+function resetRoundInputState() {
+  state.pressedAt[PLAYER.DIAMOND] = null;
+  state.pressedAt[PLAYER.HEART] = null;
+  state.reactionsMs[PLAYER.DIAMOND] = null;
+  state.reactionsMs[PLAYER.HEART] = null;
+  state.correctness[PLAYER.DIAMOND] = null;
+  state.correctness[PLAYER.HEART] = null;
+}
+
+// =========================
+// Render
+// =========================
+function renderAll() {
+  renderScore();
+  renderRoundLabel();
+  renderTopic();
+  renderChoices();
+  renderStatusWaiting();
+}
+
+function renderScore() {
+  ui.scoreDiamond.textContent = state.scores[PLAYER.DIAMOND];
+  ui.scoreHeart.textContent = state.scores[PLAYER.HEART];
+}
+
+function renderRoundLabel() {
+  ui.roundLabel.textContent = `Round ${state.roundNumber}`;
+}
+
+function renderTopic() {
+  ui.topicShape.innerHTML = '';
+  ui.topicShape.appendChild(buildShapeElement(state.currentTopic));
+}
+
+function renderChoices() {
+  renderPlayerChoices(ui.diamondChoices, PLAYER.DIAMOND);
+  renderPlayerChoices(ui.heartChoices, PLAYER.HEART);
+}
+
+function renderPlayerChoices(container, player) {
+  container.innerHTML = '';
+
+  state.currentChoices.forEach((choice, index) => {
+    const fragment = ui.choiceTemplate.content.cloneNode(true);
+    const btn = fragment.querySelector('.choice-btn');
+
+    btn.dataset.player = player;
+    btn.dataset.index = String(index);
+    btn.setAttribute('aria-label', `${PLAYER_SYMBOL[player]} の候補 ${index + 1}`);
+    btn.appendChild(buildShapeElement(choice));
+
+    btn.addEventListener('click', () => handlePlayerPress(player, index));
+
+    container.appendChild(fragment);
+  });
+}
+
+function renderStatusWaiting() {
+  if (state.roundSettled || state.gameEnded) {
+    return;
+  }
+
+  ui.statusPanel.innerHTML = `
+    <p class="status-title">お題と違う「色」かつ違う「図形」を押す！</p>
+    <div>先に3点で勝利</div>
+  `;
+}
+
+function renderStatusRoundResult(showNextButton = false) {
+  const diamondTime = formatReaction(
+    state.reactionsMs[PLAYER.DIAMOND],
+    state.correctness[PLAYER.DIAMOND]
+  );
+  const heartTime = formatReaction(state.reactionsMs[PLAYER.HEART], state.correctness[PLAYER.HEART]);
+
+  const winnerLabel = state.winnerOfRound ? PLAYER_SYMBOL[state.winnerOfRound] : '—';
+
+  ui.statusPanel.innerHTML = `
+    <p class="status-title">ラウンド勝者: ${winnerLabel}</p>
+    <div class="result-grid">
+      <div>♦️ ${diamondTime} / ${formatCorrectness(state.correctness[PLAYER.DIAMOND])}</div>
+      <div>❤️ ${heartTime} / ${formatCorrectness(state.correctness[PLAYER.HEART])}</div>
+    </div>
+    ${
+      showNextButton
+        ? '<button class="control-btn" id="next-round-btn" type="button">次へ</button>'
+        : '<div>判定中...</div>'
+    }
+  `;
+
+  paintChoiceFeedback();
+
+  if (showNextButton) {
+    const nextBtn = document.getElementById('next-round-btn');
+    nextBtn.addEventListener('click', startNextRound, { once: true });
+  }
+}
+
+function renderGameFinished() {
+  renderScore();
+  const winner =
+    state.scores[PLAYER.DIAMOND] > state.scores[PLAYER.HEART] ? PLAYER.DIAMOND : PLAYER.HEART;
+
+  const historyItems = state.roundHistory
+    .map((row) => {
+      return `<li>R${row.round} 勝者:${PLAYER_SYMBOL[row.winner]} / ♦️ ${formatReaction(
+        row.diamondReaction,
+        row.diamondCorrect
+      )} / ❤️ ${formatReaction(row.heartReaction, row.heartCorrect)}</li>`;
+    })
+    .join('');
+
+  ui.statusPanel.innerHTML = `
+    <p class="status-title">ゲーム勝者: ${PLAYER_SYMBOL[winner]}</p>
+    <div>最終スコア: ♦️ ${state.scores[PLAYER.DIAMOND]} - ❤️ ${state.scores[PLAYER.HEART]}</div>
+    <ul class="history">${historyItems}</ul>
+    <button class="control-btn" id="restart-btn" type="button">もう一度</button>
+  `;
+
+  paintChoiceFeedback();
+
+  const restartBtn = document.getElementById('restart-btn');
+  restartBtn.addEventListener('click', startNewGame, { once: true });
+}
+
+function paintChoiceFeedback() {
+  [ui.diamondChoices, ui.heartChoices].forEach((container, idx) => {
+    const player = idx === 0 ? PLAYER.DIAMOND : PLAYER.HEART;
+    const buttons = container.querySelectorAll('.choice-btn');
+
+    buttons.forEach((btn, index) => {
+      btn.classList.toggle('is-correct', state.currentChoices[index].isCorrect);
+
+      const pressed = state.correctness[player] !== null && Number(btn.dataset.index) === pressedChoiceIndex(player);
+      btn.classList.toggle('is-pressed', pressed);
+
+      if (pressed) {
+        btn.classList.toggle('is-wrong', state.correctness[player] === false);
+      }
+    });
+  });
+}
+
+function pressedChoiceIndex(player) {
+  if (state.correctness[player] === null) {
+    return -1;
+  }
+
+  const isCorrect = state.correctness[player];
+  return state.currentChoices.findIndex((choice) => choice.isCorrect === isCorrect);
+}
+
+// =========================
+// Utilities
+// =========================
+function createCombinations() {
+  const result = [];
+
+  COLORS.forEach((color) => {
+    SHAPES.forEach((shape) => {
+      result.push({ color, shape });
+    });
+  });
+
+  return result;
+}
+
+function buildShapeElement({ color, shape }) {
+  const shapeEl = document.createElement('span');
+  shapeEl.className = `shape color-${color} ${shape}`;
+  return shapeEl;
+}
+
+function randomFrom(list) {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+function makeKey(item) {
+  return `${item.color}-${item.shape}`;
+}
+
+function formatReaction(ms, isCorrect) {
+  if (ms === null) {
+    return '—';
+  }
+
+  return isCorrect === false ? `✕ ${ms}ms` : `${ms}ms`;
+}
+
+function formatCorrectness(correctness) {
+  if (correctness === null) {
+    return '—';
+  }
+  return correctness ? '○' : '✕';
+}
+
+function clearRoundTimers() {
+  if (state.roundTimers.guard !== null) {
+    window.clearTimeout(state.roundTimers.guard);
+    state.roundTimers.guard = null;
+  }
+
+  if (state.roundTimers.finish !== null) {
+    window.clearTimeout(state.roundTimers.finish);
+    state.roundTimers.finish = null;
+  }
+}

--- a/game61/style.css
+++ b/game61/style.css
@@ -1,0 +1,220 @@
+:root {
+  --bg: #11131a;
+  --panel: #1a1f2c;
+  --panel-soft: #242b3c;
+  --text: #f2f5ff;
+  --muted: #a8b1c7;
+  --accent: #ffd54a;
+  --ok: #27c26c;
+  --ng: #f2526d;
+  --red: #ff5c5c;
+  --blue: #55a8ff;
+  --green: #5fd485;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  -webkit-tap-highlight-color: transparent;
+}
+
+body {
+  min-height: 100vh;
+}
+
+.app {
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: 1fr auto 1fr;
+  gap: 12px;
+  padding: 12px;
+}
+
+.player-zone,
+.center-zone {
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 12px;
+}
+
+.player-zone {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 8px;
+}
+
+.player-zone--bottom {
+  grid-template-rows: 1fr auto;
+}
+
+.player-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 700;
+}
+
+.player-score {
+  font-size: 1.4rem;
+  background: var(--panel-soft);
+  border-radius: 10px;
+  padding: 4px 10px;
+}
+
+.choices {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  align-items: center;
+}
+
+.choice-btn {
+  min-height: 120px;
+  border-radius: 14px;
+  border: 2px solid transparent;
+  background: var(--panel-soft);
+  color: inherit;
+  display: grid;
+  place-items: center;
+  touch-action: manipulation;
+  transition: transform 80ms ease, border-color 120ms ease, filter 120ms ease;
+}
+
+.choice-btn:active {
+  transform: scale(0.97);
+}
+
+.choice-btn.is-correct {
+  border-color: var(--ok);
+  box-shadow: 0 0 0 1px var(--ok) inset;
+}
+
+.choice-btn.is-wrong {
+  border-color: var(--ng);
+  box-shadow: 0 0 0 1px var(--ng) inset;
+}
+
+.choice-btn.is-pressed {
+  filter: brightness(1.2);
+}
+
+.shape {
+  width: 64px;
+  height: 64px;
+  display: inline-block;
+}
+
+.shape.circle {
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.shape.square {
+  border-radius: 8px;
+  background: currentColor;
+}
+
+.shape.triangle {
+  width: 0;
+  height: 0;
+  border-left: 32px solid transparent;
+  border-right: 32px solid transparent;
+  border-bottom: 56px solid currentColor;
+}
+
+.shape.color-red {
+  color: var(--red);
+}
+
+.shape.color-blue {
+  color: var(--blue);
+}
+
+.shape.color-green {
+  color: var(--green);
+}
+
+.center-zone {
+  display: grid;
+  gap: 10px;
+  align-content: start;
+}
+
+.round-label {
+  margin: 0;
+  font-weight: 700;
+  color: var(--muted);
+}
+
+.topic {
+  display: grid;
+  place-items: center;
+  min-height: 100px;
+  background: var(--panel-soft);
+  border-radius: 12px;
+}
+
+.topic .shape {
+  width: 72px;
+  height: 72px;
+}
+
+.topic .shape.triangle {
+  border-left-width: 36px;
+  border-right-width: 36px;
+  border-bottom-width: 64px;
+}
+
+.status-panel {
+  background: var(--panel-soft);
+  border-radius: 12px;
+  padding: 10px;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.status-title {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.result-grid {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 10px;
+}
+
+.control-btn {
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  border-radius: 10px;
+  background: var(--accent);
+  color: #1f1f1f;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.history {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 4px;
+  max-height: 160px;
+  overflow: auto;
+  font-size: 0.86rem;
+}
+
+.history li {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  padding-bottom: 4px;
+}


### PR DESCRIPTION
### Motivation

- Implement a small reflex-competition mini-app where two players race to press the choice that differs in both color and shape from the presented topic. 
- Provide a simple round-based scoring system with first-to-3 wins and per-round history and feedback. 
- Deliver an accessible, touch-friendly UI for mobile with clear visual correctness/press feedback.

### Description

- Added `game61/index.html`, `game61/style.css`, and `game61/script.js` to create the new mini-app and its assets. 
- Implemented core game logic in `script.js` including state management, round flow (`startNewGame`, `startNextRound`, `finishRound`), input handling (`handlePlayerPress`), timers (input guard and post-decision capture), and round history. 
- Implemented rendering and DOM interactions including choice templating, topic/shape rendering, status panel updates, and visual feedback (`paintChoiceFeedback`) with accessibility labels. 
- Added styling in `style.css` for layout, responsive touch targets, shape rendering (`.shape.circle/.triangle/.square`) and correctness/pressed states, and created the HTML shell in `index.html` with the choice template and links to the assets.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1f78f29483258fd8b1fb8489e054)