### PR TITLE
game60: fix player-side swapping so top is always 🍌 and bottom 🍎

### DIFF
--- a/game60/app.js
+++ b/game60/app.js
@@ -13,8 +13,8 @@ const state = {
   round: 0,
   toneTop: 'red',
   toneBottom: 'red',
-  topPlayer: 'apple',
-  bottomPlayer: 'banana',
+  topPlayer: 'banana',
+  bottomPlayer: 'apple',
   history: []
 };
 
@@ -193,10 +193,6 @@ function handlePress(position) {
   endRound(winner, 'react', null, reaction);
 }
 
-function swapPositions() {
-  [state.topPlayer, state.bottomPlayer] = [state.bottomPlayer, state.topPlayer];
-}
-
 function resetGame() {
   clearTimer();
   state.score.apple = 0;
@@ -205,8 +201,8 @@ function resetGame() {
   state.round = 0;
   state.toneTop = 'red';
   state.toneBottom = 'red';
-  state.topPlayer = 'apple';
-  state.bottomPlayer = 'banana';
+  state.topPlayer = 'banana';
+  state.bottomPlayer = 'apple';
   state.history = [];
   setStatus('スタートで開始');
   render();
@@ -230,8 +226,8 @@ ui.startBtn.addEventListener('click', () => {
       state.score.banana = 0;
       state.round = 0;
       state.history = [];
-      state.topPlayer = 'apple';
-      state.bottomPlayer = 'banana';
+      state.topPlayer = 'banana';
+      state.bottomPlayer = 'apple';
     }
     startRound();
   }
@@ -239,7 +235,6 @@ ui.startBtn.addEventListener('click', () => {
 
 ui.nextBtn.addEventListener('click', () => {
   if (state.phase === 'roundOver') {
-    swapPositions();
     startRound();
   }
 });


### PR DESCRIPTION
### Motivation
- Fix a bug where player mapping flipped between rounds causing top presses to be interpreted as the opposite player (banana/apple), which is inconsistent with the requirement that top is always 🍌 and bottom is always 🍎.

### Description
- Updated `game60/app.js` to set `state.topPlayer = 'banana'` and `state.bottomPlayer = 'apple'` as the default and on reset, and removed the round-position swap by deleting `swapPositions()` and its call from the `next` button flow.

### Testing
- Ran `node --check game60/app.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4b29f97083258b686bd051df6e46)