### PR TITLE
game60: タップエリアのラベルを絵文字に変更

### DIFF
--- a/game60/index.html
+++ b/game60/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <main class="app">
-    <button id="topBtn" class="tap-zone top" type="button">上エリアをタップ</button>
+    <button id="topBtn" class="tap-zone top" type="button">🍌</button>
 
     <section class="center-ui">
       <header id="introPanel" class="panel intro-panel">
@@ -42,7 +42,7 @@
       </section>
     </section>
 
-    <button id="bottomBtn" class="tap-zone bottom" type="button">下エリアをタップ</button>
+    <button id="bottomBtn" class="tap-zone bottom" type="button">🍎</button>
   </main>
 
   <script src="app.js"></script>


### PR DESCRIPTION
### Motivation
- game60 のタップエリア表示をテキストではなく視認性の高い絵文字（上: 🍌、下: 🍎）だけで表示するため。  

### Description
- `game60/index.html` の上下タップボタン文言をそれぞれ `上エリアをタップ` → `🍌` および `下エリアをタップ` → `🍎` に置換し、UIテキストのみを変更した。  

### Testing
- テキスト検索で該当箇所を特定し、置換スクリプトを実行して `game60/index.html` の内容を表示確認したところ変更が反映されていることを確認し成功した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da52fea8108325ba99c7d7618257dd)