### PR TITLE
game61: add start screen and fix runtime bug (markPressedVisual)

### DIFF
--- a/game61/index.html
+++ b/game61/index.html
@@ -7,7 +7,14 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <main class="app" aria-label="反射神経対戦ミニアプリ">
+    <main class="start-screen" id="start-screen" aria-label="ゲームトップページ">
+      <p class="start-screen__eyebrow">game61</p>
+      <h1>反射神経対戦ミニアプリ</h1>
+      <p>お題と違う「色」かつ違う「図形」を先にタップ！ 3点先取で勝利です。</p>
+      <button class="control-btn start-btn" id="start-btn" type="button">スタート</button>
+    </main>
+
+    <main class="app" id="game-app" aria-label="反射神経対戦ミニアプリ" hidden>
       <section class="player-zone player-zone--top" aria-label="上側プレイヤー ♦️">
         <header class="player-header">
           <span class="player-label">♦️</span>
@@ -32,9 +39,7 @@
     </main>
 
     <template id="choice-button-template">
-      <button class="choice-btn" type="button">
-        <span class="shape"></span>
-      </button>
+      <button class="choice-btn" type="button"></button>
     </template>
 
     <script src="script.js"></script>

--- a/game61/script.js
+++ b/game61/script.js
@@ -26,6 +26,7 @@ const COMBINATIONS = createCombinations();
 // State
 // =========================
 const state = {
+  isStarted: false,
   roundNumber: 0,
   scores: {
     [PLAYER.DIAMOND]: 0,
@@ -38,6 +39,10 @@ const state = {
   gameEnded: false,
   reactionStartAt: 0,
   pressedAt: {
+    [PLAYER.DIAMOND]: null,
+    [PLAYER.HEART]: null
+  },
+  pressedChoiceIndex: {
     [PLAYER.DIAMOND]: null,
     [PLAYER.HEART]: null
   },
@@ -61,6 +66,9 @@ const state = {
 // DOM refs
 // =========================
 const ui = {
+  startScreen: document.getElementById('start-screen'),
+  startButton: document.getElementById('start-btn'),
+  app: document.getElementById('game-app'),
   scoreDiamond: document.getElementById('score-diamond'),
   scoreHeart: document.getElementById('score-heart'),
   roundLabel: document.getElementById('round-label'),
@@ -74,7 +82,16 @@ const ui = {
 // =========================
 // Init
 // =========================
-startNewGame();
+init();
+
+function init() {
+  ui.startButton.addEventListener('click', () => {
+    state.isStarted = true;
+    ui.startScreen.hidden = true;
+    ui.app.hidden = false;
+    startNewGame();
+  });
+}
 
 // =========================
 // Core round flow
@@ -144,6 +161,7 @@ function handlePlayerPress(player, choiceIndex) {
   }
 
   state.pressedAt[player] = now;
+  state.pressedChoiceIndex[player] = choiceIndex;
   state.reactionsMs[player] = Math.max(0, Math.round(now - state.reactionStartAt));
 
   const selected = state.currentChoices[choiceIndex];
@@ -174,13 +192,6 @@ function settleRoundByFirstInput(firstPlayer, firstIsCorrect) {
 function finishRound() {
   state.acceptingInput = false;
 
-  if (state.correctness[PLAYER.DIAMOND] === null) {
-    state.correctness[PLAYER.DIAMOND] = null;
-  }
-  if (state.correctness[PLAYER.HEART] === null) {
-    state.correctness[PLAYER.HEART] = null;
-  }
-
   saveRoundHistory();
 
   if (state.scores[PLAYER.DIAMOND] >= WIN_SCORE || state.scores[PLAYER.HEART] >= WIN_SCORE) {
@@ -206,6 +217,8 @@ function saveRoundHistory() {
 function resetRoundInputState() {
   state.pressedAt[PLAYER.DIAMOND] = null;
   state.pressedAt[PLAYER.HEART] = null;
+  state.pressedChoiceIndex[PLAYER.DIAMOND] = null;
+  state.pressedChoiceIndex[PLAYER.HEART] = null;
   state.reactionsMs[PLAYER.DIAMOND] = null;
   state.reactionsMs[PLAYER.HEART] = null;
   state.correctness[PLAYER.DIAMOND] = null;
@@ -336,23 +349,25 @@ function paintChoiceFeedback() {
     buttons.forEach((btn, index) => {
       btn.classList.toggle('is-correct', state.currentChoices[index].isCorrect);
 
-      const pressed = state.correctness[player] !== null && Number(btn.dataset.index) === pressedChoiceIndex(player);
+      const pressedIndex = pressedChoiceIndex(player);
+      const pressed = pressedIndex !== null && Number(btn.dataset.index) === pressedIndex;
       btn.classList.toggle('is-pressed', pressed);
-
-      if (pressed) {
-        btn.classList.toggle('is-wrong', state.correctness[player] === false);
-      }
+      btn.classList.toggle('is-wrong', pressed && state.correctness[player] === false);
     });
   });
 }
 
-function pressedChoiceIndex(player) {
-  if (state.correctness[player] === null) {
-    return -1;
-  }
+function markPressedVisual(player, choiceIndex) {
+  const container = player === PLAYER.DIAMOND ? ui.diamondChoices : ui.heartChoices;
+  const button = container.querySelector(`.choice-btn[data-index="${choiceIndex}"]`);
 
-  const isCorrect = state.correctness[player];
-  return state.currentChoices.findIndex((choice) => choice.isCorrect === isCorrect);
+  if (button) {
+    button.classList.add('is-pressed');
+  }
+}
+
+function pressedChoiceIndex(player) {
+  return state.pressedChoiceIndex[player];
 }
 
 // =========================

--- a/game61/style.css
+++ b/game61/style.css
@@ -30,6 +30,31 @@ body {
   min-height: 100vh;
 }
 
+.start-screen {
+  min-height: 100vh;
+  display: grid;
+  place-content: center;
+  gap: 12px;
+  padding: 24px;
+  text-align: center;
+}
+
+.start-screen h1,
+.start-screen p {
+  margin: 0;
+}
+
+.start-screen__eyebrow {
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.start-btn {
+  margin-top: 8px;
+}
+
 .app {
   min-height: 100vh;
   display: grid;


### PR DESCRIPTION
### Motivation
- Provide a clear top/start page with a `スタート` button so the game only initializes after the player opts in.
- Restore gameplay that was blocked by a runtime error when an undefined visual helper was invoked on click.
- Make round feedback deterministic by explicitly tracking which choice each player pressed.

### Description
- Add a start screen (`#start-screen`) and `スタート` button (`#start-btn`) to `game61/index.html` and hide the main game (`#game-app`) until start is pressed.
- Defer initialization by adding `init()` that listens to `#start-btn` and calls `startNewGame()` only after start is pressed.
- Implement `markPressedVisual(player, choiceIndex)` in `game61/script.js` and wire it into `handlePlayerPress` to avoid the previous `ReferenceError`.
- Add `pressedChoiceIndex` to `state`, set it on press, and update `paintChoiceFeedback` to use it for stable `is-pressed`/`is-wrong` styling; remove an unused correctness no-op in `finishRound`.
- Simplify the choice template (remove empty inner `<span>`) and add start-screen styles in `game61/style.css`.

### Testing
- `node --check game61/script.js` ran and exited without errors (success).
- `git diff --check` ran and reported no whitespace or diff issues (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da53d7c0348325bb4f01726e556df5)