### PR TITLE
game61: スタート遷移とラウンド開始前カウントダウンを追加

### DIFF
--- a/game61/script.js
+++ b/game61/script.js
@@ -6,6 +6,7 @@
 const WIN_SCORE = 3;
 const INPUT_GUARD_MS = 100;
 const POST_DECISION_CAPTURE_MS = 100;
+const COUNTDOWN_STEP_MS = 700;
 
 const COLORS = ['red', 'blue', 'green'];
 const SHAPES = ['circle', 'triangle', 'square'];
@@ -58,8 +59,10 @@ const state = {
   roundHistory: [],
   roundTimers: {
     guard: null,
-    finish: null
-  }
+    finish: null,
+    countdown: null
+  },
+  isCountingDown: false
 };
 
 // =========================
@@ -87,8 +90,7 @@ init();
 function init() {
   ui.startButton.addEventListener('click', () => {
     state.isStarted = true;
-    ui.startScreen.hidden = true;
-    ui.app.hidden = false;
+    showGameScreen();
     startNewGame();
   });
 }
@@ -96,6 +98,12 @@ function init() {
 // =========================
 // Core round flow
 // =========================
+
+function showGameScreen() {
+  ui.startScreen.hidden = true;
+  ui.app.hidden = false;
+}
+
 function startNewGame() {
   clearRoundTimers();
 
@@ -120,7 +128,40 @@ function startNextRound() {
   state.winnerOfRound = null;
 
   resetRoundInputState();
-  renderAll();
+
+  renderScore();
+  renderRoundLabel();
+  renderChoices();
+  startRoundCountdown();
+}
+
+function startRoundCountdown() {
+  const countdownValues = ['3', '2', '1'];
+  let index = 0;
+
+  state.isCountingDown = true;
+
+  const tick = () => {
+    const value = countdownValues[index];
+    renderCountdown(value);
+
+    if (index === countdownValues.length - 1) {
+      state.roundTimers.countdown = window.setTimeout(beginRoundInput, COUNTDOWN_STEP_MS);
+      return;
+    }
+
+    index += 1;
+    state.roundTimers.countdown = window.setTimeout(tick, COUNTDOWN_STEP_MS);
+  };
+
+  tick();
+}
+
+function beginRoundInput() {
+  state.roundTimers.countdown = null;
+  state.isCountingDown = false;
+
+  renderTopic();
 
   state.roundTimers.guard = window.setTimeout(() => {
     state.acceptingInput = true;
@@ -273,8 +314,17 @@ function renderPlayerChoices(container, player) {
   });
 }
 
+
+function renderCountdown(value) {
+  ui.topicShape.innerHTML = `<p class="countdown-number" aria-label="カウントダウン ${value}">${value}</p>`;
+  ui.statusPanel.innerHTML = `
+    <p class="status-title">まもなく開始</p>
+    <div>${value}...</div>
+  `;
+}
+
 function renderStatusWaiting() {
-  if (state.roundSettled || state.gameEnded) {
+  if (state.roundSettled || state.gameEnded || state.isCountingDown) {
     return;
   }
 
@@ -423,5 +473,10 @@ function clearRoundTimers() {
   if (state.roundTimers.finish !== null) {
     window.clearTimeout(state.roundTimers.finish);
     state.roundTimers.finish = null;
+  }
+
+  if (state.roundTimers.countdown !== null) {
+    window.clearTimeout(state.roundTimers.countdown);
+    state.roundTimers.countdown = null;
   }
 }

--- a/game61/style.css
+++ b/game61/style.css
@@ -243,3 +243,12 @@ body {
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
   padding-bottom: 4px;
 }
+
+
+.countdown-number {
+  margin: 0;
+  font-size: clamp(2.8rem, 9vw, 4.4rem);
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+}


### PR DESCRIPTION
### Motivation
- スタート操作で確実にゲーム画面へ遷移させ、ラウンド開始時に視覚的な準備時間を与えるためにカウントダウン表示を追加する意図です。 
- 次ラウンド移行時も同じ `3→2→1` カウントダウンを表示してからお題を出し、入力受付を開始することで表示や入力の競合を防止する狙いです。

### Description
- 追加した定数と状態管理: `COUNTDOWN_STEP_MS` を追加し、`state.roundTimers.countdown` と `state.isCountingDown` を `game61/script.js` に導入しました。 
- カウントダウン制御: 新たに `startRoundCountdown()` / `beginRoundInput()` / `renderCountdown()` を実装し、`startNextRound()` はカウントダウンを起動してからお題表示と入力受付を開始するよう変更しました。 
- スタート遷移の明示化: スタートボタンのハンドラは `showGameScreen()` を呼び出して start 画面を閉じてから `startNewGame()` を実行するように変更しました。 
- 表示とタイマーのクリア強化: `renderStatusWaiting()` でカウントダウン中は通常の説明を表示しないようにし、`clearRoundTimers()` でカウントダウンタイマーも確実にクリアするようにしました。 
- スタイル追加: カウントダウン数字用の `.countdown-number` スタイルを `game61/style.css` に追加しました。 
- 変更ファイル: `game61/script.js`, `game61/style.css`。

### Testing
- `node --check game61/script.js` を実行して構文チェックを行い、エラーは発生しませんでした（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5c9243e083258d3e9644cf62250e)