### PR TITLE
game61: スタート画面とプレイ画面を分離し、カウントダウン後に選択肢を表示

### DIFF
--- a/game61/index.html
+++ b/game61/index.html
@@ -7,41 +7,11 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <main class="start-screen" id="start-screen" aria-label="ゲームトップページ">
+    <main class="start-screen" aria-label="ゲームトップページ">
       <p class="start-screen__eyebrow">game61</p>
       <h1>反射神経対戦ミニアプリ</h1>
       <p>お題と違う「色」かつ違う「図形」を先にタップ！ 3点先取で勝利です。</p>
-      <button class="control-btn start-btn" id="start-btn" type="button">スタート</button>
+      <a class="control-btn start-btn" href="./play.html">スタート</a>
     </main>
-
-    <main class="app" id="game-app" aria-label="反射神経対戦ミニアプリ" hidden>
-      <section class="player-zone player-zone--top" aria-label="上側プレイヤー ♦️">
-        <header class="player-header">
-          <span class="player-label">♦️</span>
-          <span class="player-score" id="score-diamond">0</span>
-        </header>
-        <div class="choices" id="choices-diamond"></div>
-      </section>
-
-      <section class="center-zone" aria-live="polite">
-        <p class="round-label" id="round-label">Round 1</p>
-        <div class="topic" id="topic-shape" aria-label="お題"></div>
-        <div class="status-panel" id="status-panel"></div>
-      </section>
-
-      <section class="player-zone player-zone--bottom" aria-label="下側プレイヤー ❤️">
-        <div class="choices" id="choices-heart"></div>
-        <header class="player-header player-header--bottom">
-          <span class="player-label">❤️</span>
-          <span class="player-score" id="score-heart">0</span>
-        </header>
-      </section>
-    </main>
-
-    <template id="choice-button-template">
-      <button class="choice-btn" type="button"></button>
-    </template>
-
-    <script src="script.js"></script>
   </body>
 </html>

--- a/game61/play.html
+++ b/game61/play.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>反射神経対戦ミニアプリ</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="app" id="game-app" aria-label="反射神経対戦ミニアプリ">
+      <section class="player-zone player-zone--top" aria-label="上側プレイヤー ♦️">
+        <header class="player-header">
+          <span class="player-label">♦️</span>
+          <span class="player-score" id="score-diamond">0</span>
+        </header>
+        <div class="choices" id="choices-diamond"></div>
+      </section>
+
+      <section class="center-zone" aria-live="polite">
+        <p class="round-label" id="round-label">Round 1</p>
+        <div class="topic" id="topic-shape" aria-label="お題"></div>
+        <div class="status-panel" id="status-panel"></div>
+      </section>
+
+      <section class="player-zone player-zone--bottom" aria-label="下側プレイヤー ❤️">
+        <div class="choices" id="choices-heart"></div>
+        <header class="player-header player-header--bottom">
+          <span class="player-label">❤️</span>
+          <span class="player-score" id="score-heart">0</span>
+        </header>
+      </section>
+    </main>
+
+    <template id="choice-button-template">
+      <button class="choice-btn" type="button"></button>
+    </template>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/game61/script.js
+++ b/game61/script.js
@@ -27,7 +27,6 @@ const COMBINATIONS = createCombinations();
 // State
 // =========================
 const state = {
-  isStarted: false,
   roundNumber: 0,
   scores: {
     [PLAYER.DIAMOND]: 0,
@@ -69,9 +68,6 @@ const state = {
 // DOM refs
 // =========================
 const ui = {
-  startScreen: document.getElementById('start-screen'),
-  startButton: document.getElementById('start-btn'),
-  app: document.getElementById('game-app'),
   scoreDiamond: document.getElementById('score-diamond'),
   scoreHeart: document.getElementById('score-heart'),
   roundLabel: document.getElementById('round-label'),
@@ -88,21 +84,12 @@ const ui = {
 init();
 
 function init() {
-  ui.startButton.addEventListener('click', () => {
-    state.isStarted = true;
-    showGameScreen();
-    startNewGame();
-  });
+  startNewGame();
 }
 
 // =========================
 // Core round flow
 // =========================
-
-function showGameScreen() {
-  ui.startScreen.hidden = true;
-  ui.app.hidden = false;
-}
 
 function startNewGame() {
   clearRoundTimers();
@@ -131,7 +118,7 @@ function startNextRound() {
 
   renderScore();
   renderRoundLabel();
-  renderChoices();
+  renderChoices(true);
   startRoundCountdown();
 }
 
@@ -162,6 +149,7 @@ function beginRoundInput() {
   state.isCountingDown = false;
 
   renderTopic();
+  renderChoices(false);
 
   state.roundTimers.guard = window.setTimeout(() => {
     state.acceptingInput = true;
@@ -291,12 +279,12 @@ function renderTopic() {
   ui.topicShape.appendChild(buildShapeElement(state.currentTopic));
 }
 
-function renderChoices() {
-  renderPlayerChoices(ui.diamondChoices, PLAYER.DIAMOND);
-  renderPlayerChoices(ui.heartChoices, PLAYER.HEART);
+function renderChoices(hiddenUntilStart = false) {
+  renderPlayerChoices(ui.diamondChoices, PLAYER.DIAMOND, hiddenUntilStart);
+  renderPlayerChoices(ui.heartChoices, PLAYER.HEART, hiddenUntilStart);
 }
 
-function renderPlayerChoices(container, player) {
+function renderPlayerChoices(container, player, hiddenUntilStart) {
   container.innerHTML = '';
 
   state.currentChoices.forEach((choice, index) => {
@@ -306,7 +294,11 @@ function renderPlayerChoices(container, player) {
     btn.dataset.player = player;
     btn.dataset.index = String(index);
     btn.setAttribute('aria-label', `${PLAYER_SYMBOL[player]} の候補 ${index + 1}`);
-    btn.appendChild(buildShapeElement(choice));
+    if (hiddenUntilStart) {
+      btn.setAttribute('aria-label', `${PLAYER_SYMBOL[player]} の候補（カウントダウン中）`);
+    } else {
+      btn.appendChild(buildShapeElement(choice));
+    }
 
     btn.addEventListener('click', () => handlePlayerPress(player, index));
 

--- a/game61/style.css
+++ b/game61/style.css
@@ -218,6 +218,7 @@ body {
 }
 
 .control-btn {
+  display: inline-block;
   width: 100%;
   padding: 10px 12px;
   border: none;
@@ -226,6 +227,8 @@ body {
   color: #1f1f1f;
   font-weight: 700;
   font-size: 1rem;
+  text-align: center;
+  text-decoration: none;
 }
 
 .history {


### PR DESCRIPTION
### Motivation
- スタート画面とゲーム本体を分離して、スタートボタン押下で本編ページへ遷移させることでページ遷移を明確化するための変更です。
- カウントダウン中にプレイヤーのボタン上のマークや色を先に表示しないようにして、`3-2-1` のカウントダウン終了後に選択肢を初めて表示する要望に対応するためです。

### Description
- `game61/index.html` をスタート専用ページに変更し、スタート操作を `<a class="control-btn start-btn" href="./play.html">スタート</a>` に置き換えました。
- 新規ファイル `game61/play.html` を追加し、ゲーム本体の UI（スコア・お題・選択肢・ステータス）をこちらへ移動しました。
- `game61/script.js` を変更し、`init()` でページロード時に `startNewGame()` を呼ぶようにして `start` ボタン依存を削除し、ラウンド開始時に `renderChoices(true)` を呼んでカウントダウン中は選択肢を非表示にし、`beginRoundInput()` 内で `renderChoices(false)` を呼んでカウントダウン後に選択肢（色・図形）を描画するようにしました（`renderChoices(hiddenUntilStart)` と `renderPlayerChoices(..., hiddenUntilStart)` を追加）。
- `game61/style.css` の `.control-btn` にアンカーでも見た目が崩れないようスタイル調整を行いました。

### Testing
- 自動構文チェックとして `node --check game61/script.js` を実行し成功しました。
- リンク・初期化関連の差分を確認するために `rg -n "start-screen|start-btn|isStarted|showGameScreen" game61 -S` を実行し期待どおりの変更を検出しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da65fe8d5083259c606b91af7bb725)