### PR TITLE
Add game62: Qix‑inspired iPhone‑first territory capture mini web game

### DIFF
--- a/game62/index.html
+++ b/game62/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no" />
+    <title>Area Trace 62</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="app">
+      <header class="hud" id="hud">
+        <div>Stage: <span id="hud-stage">1</span></div>
+        <div>Score: <span id="hud-score">0</span></div>
+        <div>Lives: <span id="hud-lives">3</span></div>
+        <div>Filled: <span id="hud-filled">0%</span></div>
+        <div>Target: <span id="hud-target">75%</span></div>
+        <button id="pause-btn" class="small-btn">Pause</button>
+      </header>
+
+      <main class="game-area">
+        <canvas id="game-canvas" width="320" height="480" aria-label="game field"></canvas>
+      </main>
+
+      <section id="controls" class="controls" aria-label="direction controls">
+        <button class="dir up" data-dir="up">▲</button>
+        <button class="dir left" data-dir="left">◀</button>
+        <button class="dir right" data-dir="right">▶</button>
+        <button class="dir down" data-dir="down">▼</button>
+      </section>
+    </div>
+
+    <div id="modal" class="modal hidden" role="dialog" aria-modal="true">
+      <div class="modal-card">
+        <h1 id="modal-title">Area Trace 62</h1>
+        <p id="modal-message">境界を走って、内側へ切り込み、陣地を広げよう。</p>
+        <div id="modal-actions" class="modal-actions"></div>
+      </div>
+    </div>
+
+    <script type="module" src="./js/main.js"></script>
+  </body>
+</html>

--- a/game62/js/audio.js
+++ b/game62/js/audio.js
@@ -1,0 +1,47 @@
+export class AudioManager {
+  constructor() {
+    this.ctx = null;
+    this.enabled = false;
+  }
+
+  unlock() {
+    if (this.enabled) return;
+    const AC = window.AudioContext || window.webkitAudioContext;
+    if (!AC) return;
+    this.ctx = new AC();
+    this.enabled = true;
+  }
+
+  beep(freq = 440, duration = 0.08, type = 'square', gain = 0.04) {
+    if (!this.enabled || !this.ctx) return;
+    const t0 = this.ctx.currentTime;
+    const osc = this.ctx.createOscillator();
+    const amp = this.ctx.createGain();
+    osc.type = type;
+    osc.frequency.value = freq;
+    amp.gain.setValueAtTime(gain, t0);
+    amp.gain.exponentialRampToValueAtTime(0.0001, t0 + duration);
+    osc.connect(amp);
+    amp.connect(this.ctx.destination);
+    osc.start(t0);
+    osc.stop(t0 + duration);
+  }
+
+  playCapture() {
+    this.beep(660, 0.09, 'square', 0.045);
+    this.beep(920, 0.07, 'triangle', 0.035);
+  }
+
+  playMiss() {
+    this.beep(200, 0.15, 'sawtooth', 0.05);
+  }
+
+  playClear() {
+    this.beep(520, 0.08, 'triangle', 0.045);
+    this.beep(780, 0.1, 'triangle', 0.04);
+  }
+
+  playButton() {
+    this.beep(400, 0.04, 'square', 0.03);
+  }
+}

--- a/game62/js/capture.js
+++ b/game62/js/capture.js
@@ -1,0 +1,47 @@
+import { CELL } from './config.js';
+
+export function resolveCapture(field, trail, enemies, cellSize) {
+  const cols = field.cols;
+  const rows = field.rows;
+  const visited = new Uint8Array(cols * rows);
+  const queue = [];
+
+  const pushIfValid = (x, y) => {
+    if (!field.inBounds(x, y)) return;
+    if (field.getCell(x, y) !== CELL.UNCAPTURED) return;
+    const idx = y * cols + x;
+    if (visited[idx]) return;
+    visited[idx] = 1;
+    queue.push({ x, y });
+  };
+
+  for (const enemy of enemies) {
+    const cx = Math.floor(enemy.x / cellSize);
+    const cy = Math.floor(enemy.y / cellSize);
+    pushIfValid(cx, cy);
+  }
+
+  for (let i = 0; i < queue.length; i++) {
+    const { x, y } = queue[i];
+    pushIfValid(x + 1, y);
+    pushIfValid(x - 1, y);
+    pushIfValid(x, y + 1);
+    pushIfValid(x, y - 1);
+  }
+
+  let capturedCount = 0;
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      if (field.getCell(x, y) !== CELL.UNCAPTURED) continue;
+      const idx = y * cols + x;
+      if (!visited[idx]) {
+        field.setCell(x, y, CELL.CAPTURED);
+        capturedCount++;
+      }
+    }
+  }
+
+  capturedCount += trail.order.length;
+  trail.commit(field);
+  return capturedCount;
+}

--- a/game62/js/collision.js
+++ b/game62/js/collision.js
@@ -1,0 +1,28 @@
+export function checkPlayerEnemyCollision(player, enemies, cellSize) {
+  const px = (player.x + 0.5) * cellSize;
+  const py = (player.y + 0.5) * cellSize;
+  const hitRadius = cellSize * 0.45;
+
+  for (const enemy of enemies) {
+    const dx = enemy.x - px;
+    const dy = enemy.y - py;
+    const dist2 = dx * dx + dy * dy;
+    const minDist = hitRadius + enemy.radius;
+    if (dist2 <= minDist * minDist) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function checkTrailEnemyCollision(trail, enemies, cellSize) {
+  if (!trail.active) return false;
+  for (const enemy of enemies) {
+    const cx = Math.floor(enemy.x / cellSize);
+    const cy = Math.floor(enemy.y / cellSize);
+    if (trail.has(cx, cy)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/game62/js/config.js
+++ b/game62/js/config.js
@@ -1,0 +1,62 @@
+export const CELL = {
+  UNCAPTURED: 0,
+  CAPTURED: 1,
+  BOUNDARY: 2,
+  TRAIL: 3,
+};
+
+export const GAME_STATES = {
+  BOOT: 'boot',
+  TITLE: 'title',
+  READY: 'ready',
+  PLAYING: 'playing',
+  PAUSED: 'paused',
+  STAGE_CLEAR: 'stageClear',
+  PLAYER_MISS: 'playerMiss',
+  GAME_OVER: 'gameOver',
+};
+
+export const CONFIG = {
+  grid: {
+    cols: 40,
+    rows: 60,
+    cellSize: 8,
+  },
+  player: {
+    moveIntervalMs: 85,
+  },
+  game: {
+    targetFillRate: 0.75,
+    initialLives: 3,
+    missInvincibleMs: 800,
+  },
+  scoring: {
+    capturePerCell: 8,
+    stageClearBonus: 1200,
+    lifeBonus: 400,
+  },
+  stages: [
+    { enemies: 1, speed: 48, targetFillRate: 0.75 },
+    { enemies: 1, speed: 64, targetFillRate: 0.75 },
+    { enemies: 2, speed: 58, targetFillRate: 0.75 },
+    { enemies: 2, speed: 72, targetFillRate: 0.75 },
+    { enemies: 2, speed: 88, targetFillRate: 0.8 },
+  ],
+  colors: {
+    uncaptured: '#0a1423',
+    captured: '#1f7a6f',
+    boundary: '#8de9cf',
+    trail: '#f7c24b',
+    player: '#e6f1ff',
+    enemy: '#ff5c7a',
+    debugText: '#ffffff',
+  },
+  debug: {
+    enabled: false,
+    showGrid: false,
+  },
+};
+
+export const STORAGE_KEYS = {
+  HIGH_SCORE: 'game62_high_score',
+};

--- a/game62/js/enemy.js
+++ b/game62/js/enemy.js
@@ -1,0 +1,54 @@
+export class Enemy {
+  constructor(field, speedPxPerSec, cellSize, spawn) {
+    this.field = field;
+    this.speed = speedPxPerSec;
+    this.cellSize = cellSize;
+    this.radius = Math.max(2, cellSize * 0.35);
+    this.x = (spawn.x + 0.5) * cellSize;
+    this.y = (spawn.y + 0.5) * cellSize;
+    this.vx = this.speed * (Math.random() > 0.5 ? 1 : -1);
+    this.vy = this.speed * (Math.random() > 0.5 ? 1 : -1);
+  }
+
+  getCell() {
+    return {
+      x: Math.floor(this.x / this.cellSize),
+      y: Math.floor(this.y / this.cellSize),
+    };
+  }
+
+  update(deltaSec) {
+    const nextX = this.x + this.vx * deltaSec;
+    const nextY = this.y + this.vy * deltaSec;
+
+    if (this.willHitSolid(nextX, this.y)) {
+      this.vx *= -1;
+    } else {
+      this.x = nextX;
+    }
+
+    if (this.willHitSolid(this.x, nextY)) {
+      this.vy *= -1;
+    } else {
+      this.y = nextY;
+    }
+  }
+
+  willHitSolid(px, py) {
+    const cx = Math.floor(px / this.cellSize);
+    const cy = Math.floor(py / this.cellSize);
+    return this.field.isSolidForEnemy(cx, cy);
+  }
+}
+
+export function createEnemySpawns(field, count) {
+  const spawns = [];
+  const margin = 6;
+  for (let i = 0; i < count; i++) {
+    spawns.push({
+      x: Math.floor(field.cols / 2) + (i % 2 === 0 ? -margin : margin),
+      y: Math.floor(field.rows / 2) + (i < 2 ? -margin : margin),
+    });
+  }
+  return spawns;
+}

--- a/game62/js/field.js
+++ b/game62/js/field.js
@@ -1,0 +1,66 @@
+import { CELL } from './config.js';
+
+export class Field {
+  constructor(cols, rows) {
+    this.cols = cols;
+    this.rows = rows;
+    this.cells = new Uint8Array(cols * rows);
+  }
+
+  reset() {
+    this.cells.fill(CELL.UNCAPTURED);
+    for (let y = 0; y < this.rows; y++) {
+      for (let x = 0; x < this.cols; x++) {
+        if (x === 0 || y === 0 || x === this.cols - 1 || y === this.rows - 1) {
+          this.setCell(x, y, CELL.BOUNDARY);
+        }
+      }
+    }
+  }
+
+  inBounds(x, y) {
+    return x >= 0 && y >= 0 && x < this.cols && y < this.rows;
+  }
+
+  index(x, y) {
+    return y * this.cols + x;
+  }
+
+  getCell(x, y) {
+    if (!this.inBounds(x, y)) return CELL.CAPTURED;
+    return this.cells[this.index(x, y)];
+  }
+
+  setCell(x, y, state) {
+    if (!this.inBounds(x, y)) return;
+    this.cells[this.index(x, y)] = state;
+  }
+
+  isSafe(x, y) {
+    const cell = this.getCell(x, y);
+    return cell === CELL.CAPTURED || cell === CELL.BOUNDARY;
+  }
+
+  isSolidForEnemy(x, y) {
+    const cell = this.getCell(x, y);
+    return cell === CELL.CAPTURED || cell === CELL.BOUNDARY || cell === CELL.TRAIL;
+  }
+
+  getFillRate() {
+    let filled = 0;
+    const total = this.cols * this.rows;
+    for (let i = 0; i < this.cells.length; i++) {
+      const c = this.cells[i];
+      if (c === CELL.CAPTURED || c === CELL.BOUNDARY) filled++;
+    }
+    return filled / total;
+  }
+
+  forEachCell(callback) {
+    for (let y = 0; y < this.rows; y++) {
+      for (let x = 0; x < this.cols; x++) {
+        callback(x, y, this.getCell(x, y));
+      }
+    }
+  }
+}

--- a/game62/js/game.js
+++ b/game62/js/game.js
@@ -1,0 +1,256 @@
+import { CONFIG, GAME_STATES, STORAGE_KEYS } from './config.js';
+import { Field } from './field.js';
+import { Trail } from './trail.js';
+import { Player } from './player.js';
+import { Enemy, createEnemySpawns } from './enemy.js';
+import { checkPlayerEnemyCollision, checkTrailEnemyCollision } from './collision.js';
+import { resolveCapture } from './capture.js';
+
+export class Game {
+  constructor(canvas, ui, audio) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.ui = ui;
+    this.audio = audio;
+
+    this.cols = CONFIG.grid.cols;
+    this.rows = CONFIG.grid.rows;
+    this.cellSize = CONFIG.grid.cellSize;
+    this.canvas.width = this.cols * this.cellSize;
+    this.canvas.height = this.rows * this.cellSize;
+
+    this.field = new Field(this.cols, this.rows);
+    this.trail = new Trail();
+    this.player = new Player(this.field, this.trail, CONFIG.player);
+    this.enemies = [];
+
+    this.state = GAME_STATES.BOOT;
+    this.lastTs = 0;
+    this.stageIndex = 0;
+    this.score = 0;
+    this.highScore = Number(localStorage.getItem(STORAGE_KEYS.HIGH_SCORE) || 0);
+    this.lives = CONFIG.game.initialLives;
+    this.missLockUntil = 0;
+  }
+
+  init() {
+    this.ui.bindDirectionButtons((dir) => this.player.setDirection(dir), () => this.audio.unlock());
+    this.ui.bindPause(() => this.togglePause(), () => this.audio.unlock());
+    this.showTitle();
+    requestAnimationFrame((ts) => this.loop(ts));
+  }
+
+  loop(ts) {
+    const deltaMs = Math.min(33, ts - (this.lastTs || ts));
+    this.lastTs = ts;
+
+    this.update(deltaMs, ts);
+    this.render();
+
+    requestAnimationFrame((next) => this.loop(next));
+  }
+
+  update(deltaMs, nowTs) {
+    if (this.state !== GAME_STATES.PLAYING) return;
+
+    const moveResult = this.player.update(deltaMs);
+
+    if (moveResult && moveResult.selfCollision) {
+      this.onPlayerMiss();
+      return;
+    }
+
+    for (const enemy of this.enemies) {
+      enemy.update(deltaMs / 1000);
+    }
+
+    if (nowTs > this.missLockUntil) {
+      if (checkTrailEnemyCollision(this.trail, this.enemies, this.cellSize)) {
+        this.onPlayerMiss();
+        return;
+      }
+      if (checkPlayerEnemyCollision(this.player, this.enemies, this.cellSize)) {
+        this.onPlayerMiss();
+        return;
+      }
+    }
+
+    if (moveResult && moveResult.closed) {
+      const gainedCells = resolveCapture(this.field, this.trail, this.enemies, this.cellSize);
+      this.score += gainedCells * CONFIG.scoring.capturePerCell;
+      this.audio.playCapture();
+      this.checkStageClear();
+    }
+
+    this.syncHud();
+  }
+
+  render() {
+    const { ctx, cellSize } = this;
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+
+    this.field.forEachCell((x, y, cell) => {
+      switch (cell) {
+        case 0:
+          ctx.fillStyle = CONFIG.colors.uncaptured;
+          break;
+        case 1:
+          ctx.fillStyle = CONFIG.colors.captured;
+          break;
+        case 2:
+          ctx.fillStyle = CONFIG.colors.boundary;
+          break;
+        case 3:
+          ctx.fillStyle = CONFIG.colors.trail;
+          break;
+      }
+      ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
+    });
+
+    ctx.fillStyle = CONFIG.colors.player;
+    ctx.fillRect(this.player.x * cellSize + 1, this.player.y * cellSize + 1, cellSize - 2, cellSize - 2);
+
+    ctx.fillStyle = CONFIG.colors.enemy;
+    for (const enemy of this.enemies) {
+      ctx.beginPath();
+      ctx.arc(enemy.x, enemy.y, enemy.radius, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    if (CONFIG.debug.enabled) {
+      ctx.fillStyle = CONFIG.colors.debugText;
+      ctx.font = '10px monospace';
+      const fill = Math.floor(this.field.getFillRate() * 100);
+      ctx.fillText(`state:${this.state}`, 4, 12);
+      ctx.fillText(`player:${this.player.x},${this.player.y}`, 4, 24);
+      ctx.fillText(`drawing:${this.player.drawing}`, 4, 36);
+      ctx.fillText(`fill:${fill}%`, 4, 48);
+      this.enemies.forEach((e, idx) => {
+        const c = e.getCell();
+        ctx.fillText(`e${idx}:${c.x},${c.y}`, 4, 60 + idx * 12);
+      });
+    }
+  }
+
+  showTitle() {
+    this.state = GAME_STATES.TITLE;
+    this.ui.showModal('Area Trace 62', `High Score: ${this.highScore}`, [
+      { label: 'Start Game', onClick: () => this.startNewGame() },
+    ]);
+  }
+
+  startNewGame() {
+    this.stageIndex = 0;
+    this.score = 0;
+    this.lives = CONFIG.game.initialLives;
+    this.startStage();
+  }
+
+  startStage() {
+    this.field.reset();
+    this.trail.clear(this.field);
+    this.player.resetPosition();
+
+    const stage = CONFIG.stages[this.stageIndex];
+    const spawns = createEnemySpawns(this.field, stage.enemies);
+    this.enemies = spawns.map((s) => new Enemy(this.field, stage.speed, this.cellSize, s));
+
+    this.state = GAME_STATES.READY;
+    this.syncHud();
+    this.ui.showModal(`Stage ${this.stageIndex + 1}`, 'Ready?', [
+      {
+        label: 'Go',
+        onClick: () => {
+          this.ui.hideModal();
+          this.state = GAME_STATES.PLAYING;
+          this.missLockUntil = performance.now() + CONFIG.game.missInvincibleMs;
+        },
+      },
+    ]);
+  }
+
+  togglePause() {
+    if (this.state === GAME_STATES.PLAYING) {
+      this.state = GAME_STATES.PAUSED;
+      this.ui.showModal('Paused', 'ゲームを一時停止中', [
+        { label: 'Resume', onClick: () => { this.ui.hideModal(); this.state = GAME_STATES.PLAYING; } },
+        { label: 'Retry Stage', secondary: true, onClick: () => this.startStage() },
+      ]);
+      this.audio.playButton();
+    }
+  }
+
+  onPlayerMiss() {
+    this.audio.playMiss();
+    this.state = GAME_STATES.PLAYER_MISS;
+    this.lives -= 1;
+    this.trail.clear(this.field);
+
+    if (this.lives <= 0) {
+      this.toGameOver();
+      return;
+    }
+
+    this.player.resetPosition();
+    this.syncHud();
+    this.ui.showModal('Miss', `残り ${this.lives} 機`, [
+      {
+        label: 'Continue',
+        onClick: () => {
+          this.ui.hideModal();
+          this.state = GAME_STATES.PLAYING;
+          this.missLockUntil = performance.now() + CONFIG.game.missInvincibleMs;
+        },
+      },
+    ]);
+  }
+
+  checkStageClear() {
+    const stage = CONFIG.stages[this.stageIndex];
+    const fill = this.field.getFillRate();
+    const target = stage.targetFillRate ?? CONFIG.game.targetFillRate;
+
+    if (fill >= target) {
+      this.state = GAME_STATES.STAGE_CLEAR;
+      this.score += CONFIG.scoring.stageClearBonus + this.lives * CONFIG.scoring.lifeBonus;
+      this.audio.playClear();
+      this.syncHud();
+
+      if (this.stageIndex >= CONFIG.stages.length - 1) {
+        this.ui.showModal('All Clear!', '全ステージクリア！', [
+          { label: 'Title', onClick: () => this.showTitle() },
+          { label: 'Replay', secondary: true, onClick: () => this.startNewGame() },
+        ]);
+      } else {
+        this.ui.showModal('Stage Clear!', '次のステージへ進みます。', [
+          { label: 'Next', onClick: () => { this.stageIndex += 1; this.startStage(); } },
+        ]);
+      }
+    }
+  }
+
+  toGameOver() {
+    this.state = GAME_STATES.GAME_OVER;
+    if (this.score > this.highScore) {
+      this.highScore = this.score;
+      localStorage.setItem(STORAGE_KEYS.HIGH_SCORE, String(this.highScore));
+    }
+
+    this.syncHud();
+    this.ui.showModal('Game Over', `Score: ${this.score} / High: ${this.highScore}`, [
+      { label: 'Retry', onClick: () => this.startNewGame() },
+      { label: 'Title', secondary: true, onClick: () => this.showTitle() },
+    ]);
+  }
+
+  syncHud() {
+    const stage = CONFIG.stages[this.stageIndex] ?? CONFIG.stages[CONFIG.stages.length - 1];
+    this.ui.updateHud({
+      stage: this.stageIndex + 1,
+      score: this.score,
+      lives: this.lives,
+      filled: this.field.getFillRate(),
+      target: stage.targetFillRate ?? CONFIG.game.targetFillRate,
+    });
+  }
+}

--- a/game62/js/main.js
+++ b/game62/js/main.js
@@ -1,0 +1,32 @@
+import { Game } from './game.js';
+import { UI } from './ui.js';
+import { AudioManager } from './audio.js';
+
+function boot() {
+  const elements = {
+    stage: document.getElementById('hud-stage'),
+    score: document.getElementById('hud-score'),
+    lives: document.getElementById('hud-lives'),
+    filled: document.getElementById('hud-filled'),
+    target: document.getElementById('hud-target'),
+    pauseBtn: document.getElementById('pause-btn'),
+    controls: document.getElementById('controls'),
+    modal: document.getElementById('modal'),
+    modalTitle: document.getElementById('modal-title'),
+    modalMessage: document.getElementById('modal-message'),
+    modalActions: document.getElementById('modal-actions'),
+  };
+
+  const canvas = document.getElementById('game-canvas');
+  const ui = new UI(elements);
+  const audio = new AudioManager();
+  const game = new Game(canvas, ui, audio);
+
+  document.addEventListener('touchmove', (event) => {
+    event.preventDefault();
+  }, { passive: false });
+
+  game.init();
+}
+
+window.addEventListener('DOMContentLoaded', boot);

--- a/game62/js/player.js
+++ b/game62/js/player.js
@@ -1,0 +1,86 @@
+import { CELL } from './config.js';
+
+const DIRS = {
+  up: { x: 0, y: -1 },
+  down: { x: 0, y: 1 },
+  left: { x: -1, y: 0 },
+  right: { x: 1, y: 0 },
+};
+
+export class Player {
+  constructor(field, trail, config) {
+    this.field = field;
+    this.trail = trail;
+    this.moveIntervalMs = config.moveIntervalMs;
+    this.moveTimer = 0;
+    this.direction = 'right';
+    this.pendingDirection = 'right';
+    this.x = Math.floor(field.cols / 2);
+    this.y = 0;
+    this.drawing = false;
+  }
+
+  resetPosition() {
+    this.x = Math.floor(this.field.cols / 2);
+    this.y = 0;
+    this.direction = 'right';
+    this.pendingDirection = 'right';
+    this.moveTimer = 0;
+    this.drawing = false;
+    this.trail.clear(this.field);
+  }
+
+  setDirection(dir) {
+    if (DIRS[dir]) this.pendingDirection = dir;
+  }
+
+  update(deltaMs) {
+    this.moveTimer += deltaMs;
+    let moved = false;
+
+    while (this.moveTimer >= this.moveIntervalMs) {
+      this.moveTimer -= this.moveIntervalMs;
+      moved = this.step() || moved;
+    }
+
+    return moved;
+  }
+
+  step() {
+    this.direction = this.pendingDirection;
+    const v = DIRS[this.direction];
+    const nx = this.x + v.x;
+    const ny = this.y + v.y;
+
+    if (!this.field.inBounds(nx, ny)) {
+      return false;
+    }
+
+    const nextCell = this.field.getCell(nx, ny);
+    const movingIntoUncaptured = nextCell === CELL.UNCAPTURED;
+
+    if (movingIntoUncaptured && !this.drawing) {
+      this.trail.start();
+      this.drawing = true;
+    }
+
+    if (this.drawing) {
+      if (this.trail.has(nx, ny)) {
+        // TODO: 交差ルールをさらに厳密化できる余地あり（v1は自己踏みでミス扱い）。
+        return { selfCollision: true };
+      }
+      if (!this.field.isSafe(nx, ny)) {
+        this.trail.add(nx, ny, this.field);
+      }
+    }
+
+    this.x = nx;
+    this.y = ny;
+
+    if (this.drawing && this.field.isSafe(this.x, this.y)) {
+      return { closed: true };
+    }
+
+    return true;
+  }
+}

--- a/game62/js/trail.js
+++ b/game62/js/trail.js
@@ -1,0 +1,48 @@
+import { CELL } from './config.js';
+
+export class Trail {
+  constructor() {
+    this.active = false;
+    this.order = [];
+    this.set = new Set();
+  }
+
+  start() {
+    this.active = true;
+    this.order.length = 0;
+    this.set.clear();
+  }
+
+  add(x, y, field) {
+    const key = `${x},${y}`;
+    if (this.set.has(key)) return false;
+    this.set.add(key);
+    this.order.push({ x, y });
+    field.setCell(x, y, CELL.TRAIL);
+    return true;
+  }
+
+  has(x, y) {
+    return this.set.has(`${x},${y}`);
+  }
+
+  clear(field) {
+    for (const p of this.order) {
+      if (field.getCell(p.x, p.y) === CELL.TRAIL) {
+        field.setCell(p.x, p.y, CELL.UNCAPTURED);
+      }
+    }
+    this.active = false;
+    this.order.length = 0;
+    this.set.clear();
+  }
+
+  commit(field) {
+    for (const p of this.order) {
+      field.setCell(p.x, p.y, CELL.CAPTURED);
+    }
+    this.active = false;
+    this.order.length = 0;
+    this.set.clear();
+  }
+}

--- a/game62/js/ui.js
+++ b/game62/js/ui.js
@@ -1,0 +1,53 @@
+export class UI {
+  constructor(elements) {
+    this.els = elements;
+  }
+
+  bindDirectionButtons(onDirection, onFirstInteraction) {
+    const buttons = this.els.controls.querySelectorAll('.dir');
+    buttons.forEach((btn) => {
+      const handler = (e) => {
+        e.preventDefault();
+        onFirstInteraction();
+        onDirection(btn.dataset.dir);
+      };
+      btn.addEventListener('pointerdown', handler, { passive: false });
+      btn.addEventListener('click', handler);
+    });
+  }
+
+  bindPause(onPause, onFirstInteraction) {
+    this.els.pauseBtn.addEventListener('click', () => {
+      onFirstInteraction();
+      onPause();
+    });
+  }
+
+  updateHud({ stage, score, lives, filled, target }) {
+    this.els.stage.textContent = String(stage);
+    this.els.score.textContent = String(score);
+    this.els.lives.textContent = String(lives);
+    this.els.filled.textContent = `${Math.floor(filled * 100)}%`;
+    this.els.target.textContent = `${Math.floor(target * 100)}%`;
+  }
+
+  showModal(title, message, actions) {
+    this.els.modalTitle.textContent = title;
+    this.els.modalMessage.textContent = message;
+    this.els.modalActions.textContent = '';
+
+    actions.forEach((action) => {
+      const btn = document.createElement('button');
+      btn.textContent = action.label;
+      if (action.secondary) btn.classList.add('secondary');
+      btn.addEventListener('click', action.onClick);
+      this.els.modalActions.appendChild(btn);
+    });
+
+    this.els.modal.classList.remove('hidden');
+  }
+
+  hideModal() {
+    this.els.modal.classList.add('hidden');
+  }
+}

--- a/game62/style.css
+++ b/game62/style.css
@@ -1,0 +1,143 @@
+:root {
+  --bg: #071220;
+  --panel: #0f1d32;
+  --text: #f2f4f8;
+  --accent: #38e0a7;
+  --danger: #ff5c7a;
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-top: env(safe-area-inset-top, 0px);
+}
+
+* {
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  touch-action: none;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+#app {
+  height: 100dvh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  padding: calc(8px + var(--safe-top)) 8px calc(8px + var(--safe-bottom));
+  gap: 8px;
+}
+
+.hud {
+  background: var(--panel);
+  border-radius: 10px;
+  padding: 8px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 4px 8px;
+  font-size: 13px;
+  align-items: center;
+}
+
+.small-btn {
+  grid-column: 3;
+  justify-self: end;
+  border: 1px solid #3f5f8b;
+  border-radius: 8px;
+  padding: 6px 10px;
+  color: var(--text);
+  background: #183052;
+  font-weight: 600;
+}
+
+.game-area {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#game-canvas {
+  width: min(96vw, 420px);
+  height: min(58dvh, 620px);
+  image-rendering: pixelated;
+  border: 2px solid #27466f;
+  border-radius: 10px;
+  background: #09101a;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(70px, 1fr));
+  grid-template-rows: repeat(2, minmax(52px, 1fr));
+  max-width: 420px;
+  margin: 0 auto;
+  gap: 8px;
+  width: 100%;
+}
+
+.dir {
+  border: 1px solid #44668f;
+  border-radius: 12px;
+  background: #163255;
+  color: var(--text);
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.dir:active {
+  transform: scale(0.98);
+  background: #244d7f;
+}
+
+.up { grid-column: 2; grid-row: 1; }
+.left { grid-column: 1; grid-row: 2; }
+.right { grid-column: 3; grid-row: 2; }
+.down { grid-column: 2; grid-row: 2; }
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 16px;
+}
+
+.hidden { display: none; }
+
+.modal-card {
+  width: min(92vw, 360px);
+  background: #101f37;
+  border-radius: 14px;
+  border: 1px solid #42648f;
+  padding: 18px;
+  text-align: center;
+}
+
+.modal-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.modal-actions button {
+  border: none;
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #041021;
+  background: var(--accent);
+}
+
+.modal-actions button.secondary {
+  background: #94a4bd;
+}


### PR DESCRIPTION
### Motivation
- Provide a small, mobile‑first, Qix‑inspired territory capture mini game that runs as a static web app in iPhone Safari with clear, testable capture logic. 
- Keep the implementation modular and debuggable by splitting responsibilities across ES module files and centralizing tunable parameters in `config.js`. 
- Ensure the capture algorithm is deterministic and safe by using enemy‑origin BFS to decide which uncaptured region to convert to captured. 

### Description
- Added a new `game62/` static web app with the following files: `index.html`, `style.css`, and ES module scripts under `js/` (`config.js`, `main.js`, `game.js`, `field.js`, `player.js`, `enemy.js`, `trail.js`, `collision.js`, `capture.js`, `ui.js`, `audio.js`).
- Implemented grid‑based `Field`, player movement and trail handling (`Player`, `Trail`), enemy movement with reflection (`Enemy`), and collision checks in `collision.js`, keeping responsibilities separated. 
- Implemented the required capture algorithm in `capture.js` using enemy‑origin BFS to mark reachable uncaptured cells and convert unreachable uncaptured cells (and the trail) to captured; trail commit/clear flows are included. 
- Implemented HUD, modal flows (title/ready/paused/stageClear/gameOver), iPhone‑friendly virtual D‑pad input (touch prevention and safe area padding), stage definitions and scoring in `config.js`, and a small `AudioManager` that unlocks WebAudio on first interaction. 

### Testing
- Attempted a static syntax check with `node --check js/*.js`, which failed because Node treated files as CommonJS rather than browser ES modules (this is expected for browser‑target ES module code and does not indicate runtime browser errors). 
- Verified files were added and committed to the repository via Git; files are present under `game62/`. 
- No headless browser automation was run; runtime validation is intended to be performed in a browser (open `game62/index.html` on iPhone Safari to play and validate behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2e9c8d4483259884ba58597ad2e6)