### PR TITLE
Rename game62 to Jintori; tighten trail collisions; add progressive enemy difficulty

### DIFF
--- a/game62/index.html
+++ b/game62/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no" />
-    <title>Area Trace 62</title>
+    <title>Jintori</title>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -31,7 +31,7 @@
 
     <div id="modal" class="modal hidden" role="dialog" aria-modal="true">
       <div class="modal-card">
-        <h1 id="modal-title">Area Trace 62</h1>
+        <h1 id="modal-title">Jintori</h1>
         <p id="modal-message">境界を走って、内側へ切り込み、陣地を広げよう。</p>
         <div id="modal-actions" class="modal-actions"></div>
       </div>

--- a/game62/js/collision.js
+++ b/game62/js/collision.js
@@ -17,11 +17,25 @@ export function checkPlayerEnemyCollision(player, enemies, cellSize) {
 
 export function checkTrailEnemyCollision(trail, enemies, cellSize) {
   if (!trail.active) return false;
+
   for (const enemy of enemies) {
-    const cx = Math.floor(enemy.x / cellSize);
-    const cy = Math.floor(enemy.y / cellSize);
-    if (trail.has(cx, cy)) {
-      return true;
+    const minX = Math.floor((enemy.x - enemy.radius) / cellSize);
+    const maxX = Math.floor((enemy.x + enemy.radius) / cellSize);
+    const minY = Math.floor((enemy.y - enemy.radius) / cellSize);
+    const maxY = Math.floor((enemy.y + enemy.radius) / cellSize);
+
+    for (let cy = minY; cy <= maxY; cy++) {
+      for (let cx = minX; cx <= maxX; cx++) {
+        if (!trail.has(cx, cy)) continue;
+
+        const nearestX = Math.max(cx * cellSize, Math.min(enemy.x, (cx + 1) * cellSize));
+        const nearestY = Math.max(cy * cellSize, Math.min(enemy.y, (cy + 1) * cellSize));
+        const dx = enemy.x - nearestX;
+        const dy = enemy.y - nearestY;
+        if (dx * dx + dy * dy <= enemy.radius * enemy.radius) {
+          return true;
+        }
+      }
     }
   }
   return false;

--- a/game62/js/config.js
+++ b/game62/js/config.js
@@ -30,18 +30,18 @@ export const CONFIG = {
     initialLives: 3,
     missInvincibleMs: 800,
   },
+  difficulty: {
+    initialEnemies: 1,
+    initialEnemySpeed: 52,
+    speedUpPerOddClear: 10,
+    enemyIncreasePerEvenClear: 1,
+    maxEnemySpeed: 180,
+  },
   scoring: {
     capturePerCell: 8,
     stageClearBonus: 1200,
     lifeBonus: 400,
   },
-  stages: [
-    { enemies: 1, speed: 48, targetFillRate: 0.75 },
-    { enemies: 1, speed: 64, targetFillRate: 0.75 },
-    { enemies: 2, speed: 58, targetFillRate: 0.75 },
-    { enemies: 2, speed: 72, targetFillRate: 0.75 },
-    { enemies: 2, speed: 88, targetFillRate: 0.8 },
-  ],
   colors: {
     uncaptured: '#0a1423',
     captured: '#1f7a6f',

--- a/game62/js/game.js
+++ b/game62/js/game.js
@@ -27,6 +27,8 @@ export class Game {
     this.state = GAME_STATES.BOOT;
     this.lastTs = 0;
     this.stageIndex = 0;
+    this.enemyCount = CONFIG.difficulty.initialEnemies;
+    this.enemySpeed = CONFIG.difficulty.initialEnemySpeed;
     this.score = 0;
     this.highScore = Number(localStorage.getItem(STORAGE_KEYS.HIGH_SCORE) || 0);
     this.lives = CONFIG.game.initialLives;
@@ -134,13 +136,15 @@ export class Game {
 
   showTitle() {
     this.state = GAME_STATES.TITLE;
-    this.ui.showModal('Area Trace 62', `High Score: ${this.highScore}`, [
+    this.ui.showModal('Jintori', `High Score: ${this.highScore}`, [
       { label: 'Start Game', onClick: () => this.startNewGame() },
     ]);
   }
 
   startNewGame() {
     this.stageIndex = 0;
+    this.enemyCount = CONFIG.difficulty.initialEnemies;
+    this.enemySpeed = CONFIG.difficulty.initialEnemySpeed;
     this.score = 0;
     this.lives = CONFIG.game.initialLives;
     this.startStage();
@@ -151,9 +155,8 @@ export class Game {
     this.trail.clear(this.field);
     this.player.resetPosition();
 
-    const stage = CONFIG.stages[this.stageIndex];
-    const spawns = createEnemySpawns(this.field, stage.enemies);
-    this.enemies = spawns.map((s) => new Enemy(this.field, stage.speed, this.cellSize, s));
+    const spawns = createEnemySpawns(this.field, this.enemyCount);
+    this.enemies = spawns.map((s) => new Enemy(this.field, this.enemySpeed, this.cellSize, s));
 
     this.state = GAME_STATES.READY;
     this.syncHud();
@@ -206,26 +209,27 @@ export class Game {
   }
 
   checkStageClear() {
-    const stage = CONFIG.stages[this.stageIndex];
     const fill = this.field.getFillRate();
-    const target = stage.targetFillRate ?? CONFIG.game.targetFillRate;
+    const target = CONFIG.game.targetFillRate;
 
     if (fill >= target) {
       this.state = GAME_STATES.STAGE_CLEAR;
       this.score += CONFIG.scoring.stageClearBonus + this.lives * CONFIG.scoring.lifeBonus;
       this.audio.playClear();
       this.syncHud();
-
-      if (this.stageIndex >= CONFIG.stages.length - 1) {
-        this.ui.showModal('All Clear!', '全ステージクリア！', [
-          { label: 'Title', onClick: () => this.showTitle() },
-          { label: 'Replay', secondary: true, onClick: () => this.startNewGame() },
-        ]);
+      const clearedStageNumber = this.stageIndex + 1;
+      if (clearedStageNumber % 2 === 1) {
+        this.enemySpeed = Math.min(
+          CONFIG.difficulty.maxEnemySpeed,
+          this.enemySpeed + CONFIG.difficulty.speedUpPerOddClear,
+        );
       } else {
-        this.ui.showModal('Stage Clear!', '次のステージへ進みます。', [
-          { label: 'Next', onClick: () => { this.stageIndex += 1; this.startStage(); } },
-        ]);
+        this.enemyCount += CONFIG.difficulty.enemyIncreasePerEvenClear;
       }
+
+      this.ui.showModal('Stage Clear!', '次のステージへ進みます。', [
+        { label: 'Next', onClick: () => { this.stageIndex += 1; this.startStage(); } },
+      ]);
     }
   }
 
@@ -244,13 +248,12 @@ export class Game {
   }
 
   syncHud() {
-    const stage = CONFIG.stages[this.stageIndex] ?? CONFIG.stages[CONFIG.stages.length - 1];
     this.ui.updateHud({
       stage: this.stageIndex + 1,
       score: this.score,
       lives: this.lives,
       filled: this.field.getFillRate(),
-      target: stage.targetFillRate ?? CONFIG.game.targetFillRate,
+      target: CONFIG.game.targetFillRate,
     });
   }
 }


### PR DESCRIPTION
### Motivation
- Change the game's display name from `Area Trace 62` to `Jintori` and remove the old title wording so the product shows the requested name. 
- Make trail-capture collision detection stricter so enemies touching the active yellow trail cause a player miss, increasing difficulty. 
- Replace the small fixed stage table with a dynamic progression so enemy speed and count increase over time to raise difficulty as stages progress. 

### Description
- Updated the page title and initial modal title from `Area Trace 62` to `Jintori` in `game62/index.html`. 
- Added a `difficulty` block to `game62/js/config.js` with `initialEnemies`, `initialEnemySpeed`, `speedUpPerOddClear`, `enemyIncreasePerEvenClear`, and `maxEnemySpeed`. 
- Reworked `Game` in `game62/js/game.js` to track `enemyCount` and `enemySpeed`, spawn enemies using those dynamic values in `startStage`, reset them in `startNewGame`, and on stage clear increase speed for odd-numbered clears or increase enemy count for even-numbered clears. 
- Replaced the previous center-cell trail hit test in `game62/js/collision.js` with a nearest-point rectangle-vs-circle check across the enemy's radius to detect when an enemy touches any trail cell. 
- Adjusted HUD/target logic to use `CONFIG.game.targetFillRate` so the dynamic progression does not depend on the removed fixed `stages` table. 

### Testing
- Ran a workspace whitespace check via `git diff --check` which reported no issues. 
- Verified by searching repository strings that `Area Trace 62` occurrences in the game files were removed. 
- Attempted static module checks via Node (`node --check` / dynamic import), but these failed to run meaningfully in this environment because the project files are browser ESM `.js` modules and Node module resolution is not configured here. 
- Committed the changes after local verification of diffs and basic runtime file edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db35c28c648325a2a79355fb794e1d)