### PR TITLE
game61: stabilize next-button area and show ms stamps immediately

### DIFF
--- a/game61/script.js
+++ b/game61/script.js
@@ -127,6 +127,7 @@ function startNextRound() {
 
   renderScore();
   renderChoices(true);
+  renderStatusNextButton(false);
   startRoundCountdown();
 }
 
@@ -222,6 +223,7 @@ function settleRoundByFirstInput(firstPlayer, firstIsCorrect) {
 
   state.scores[state.winnerOfRound] += 1;
   state.scoreTimeline[state.winnerOfRound].push(formatScoreStamp(state.reactionsMs[state.winnerOfRound]));
+  renderScore();
 
   state.roundTimers.finish = window.setTimeout(() => {
     finishRound();
@@ -322,7 +324,7 @@ function renderPlayerChoices(container, player, hiddenUntilStart) {
 
 function renderCountdown(value) {
   ui.topicShape.innerHTML = `<p class="countdown-number" aria-label="カウントダウン ${value}">${value}</p>`;
-  ui.statusPanel.innerHTML = '';
+  renderStatusNextButton(false);
 }
 
 function renderStatusWaiting() {
@@ -330,26 +332,13 @@ function renderStatusWaiting() {
     return;
   }
 
-  ui.statusPanel.innerHTML = '';
+  renderStatusNextButton(false);
 }
 
 function renderStatusRoundResult(showNextButton = false) {
-  ui.statusPanel.innerHTML = showNextButton
-    ? `<button class="control-btn" id="next-round-btn" type="button">次へ</button>`
-    : '';
+  renderStatusNextButton(showNextButton);
 
   paintChoiceFeedback();
-
-  if (showNextButton) {
-    const nextBtn = document.getElementById('next-round-btn');
-    nextBtn.addEventListener(
-      'click',
-      () => {
-        startNextRound();
-      },
-      { once: true }
-    );
-  }
 }
 
 function renderGameFinished() {
@@ -370,6 +359,23 @@ function renderGameFinished() {
 
   const restartBtn = document.getElementById('restart-btn');
   restartBtn.addEventListener('click', startNewGame, { once: true });
+}
+
+function renderStatusNextButton(enabled) {
+  ui.statusPanel.innerHTML = `<button class="control-btn" id="next-round-btn" type="button" ${enabled ? '' : 'disabled'}>次へ</button>`;
+
+  const nextBtn = document.getElementById('next-round-btn');
+  if (!nextBtn || !enabled) {
+    return;
+  }
+
+  nextBtn.addEventListener(
+    'click',
+    () => {
+      startNextRound();
+    },
+    { once: true }
+  );
 }
 
 function paintChoiceFeedback() {

--- a/game61/style.css
+++ b/game61/style.css
@@ -279,6 +279,14 @@ body {
   font-size: 1rem;
   text-align: center;
   text-decoration: none;
+  transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.control-btn:disabled {
+  background: var(--muted-btn-bg);
+  color: var(--muted);
+  border: 1px solid var(--muted-btn-border);
+  cursor: not-allowed;
 }
 
 .control-btn--secondary {


### PR DESCRIPTION
### Motivation
- Prevent the status panel height from jumping when the 「次へ」 button appears after a round. 
- Make the next-button visual stable by showing it from the start and only changing its enabled state (gray when disabled). 
- Ensure score timeline ms stamps are recorded and displayed at the exact moment the round winner is decided, not after advancing to the next round.

### Description
- Added `renderStatusNextButton(enabled)` and replaced inline status markup with calls to this helper from `startNextRound`, `renderCountdown`, `renderStatusWaiting`, and `renderStatusRoundResult` so the next-button area is always rendered but can be disabled. 
- Enabled the next-button click handler only when `enabled` is true so the button appears gray/disabled until advancing is allowed. 
- Call `renderScore()` immediately inside `settleRoundByFirstInput` after updating `state.scoreTimeline` so the ms stamps in the score log show at the decision time. 
- Added disabled styling and a small transition for `.control-btn` in `style.css` so disabled buttons appear gray and have a smooth color change.

### Testing
- Ran `node --check game61/script.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2357097b88325973f09c5a15d44de)