### PR TITLE
Add PM persona template and PM Owner Channel to global harness

### DIFF
--- a/harnes/LEARNING_SYSTEM.md
+++ b/harnes/LEARNING_SYSTEM.md
@@ -35,6 +35,7 @@
 - Do / Don’t（次回行動規範）
 - Evidence（根拠）
 - Reuse Plan（どこで再利用するか）
+- PM Owner Channelから抽出した有効エントリ（Comment / Recommendation / Diary Note / Insight Report）
 
 ---
 
@@ -44,6 +45,7 @@
 2. 実行終了: `SPRINT_REVIEW_TEMPLATE.md` で知見抽出を必須化
 3. 永続化: `learning/AGENT_GROWTH_LEDGER.md` に追記
 4. 次回反映: `NEXT_PROMPT_TEMPLATE.md` のGoal/Constraintsへ再注入
+5. PM連携: `PROJECT_MANAGER_PERSONA_TEMPLATE.md` のOpen Recommendationへ再注入
 
 ---
 

--- a/harnes/README.md
+++ b/harnes/README.md
@@ -9,16 +9,19 @@
 - 毎回同じ重要項目を最初に確認する（判断ドリフト防止）
 - Promptをテンプレート化し、改善サイクルを高速化する
 - 実行旅ごとの学習を蓄積し、次回精度を上げる
+- プロマネ視点の文書運用を標準化し、Ownerとの意思決定速度を上げる
 
 ## 使い方（毎回固定）
 
 1. `SOUL.md` を読む（原則・禁止・判定規律）
 2. `templates/SESSION_BOOT_TEMPLATE.md` をコピーして、その回の実行用プロンプトを作る
-   - デザイン関連タスクがある場合は、`templates/DESIGN_PROMPT_TEMPLATE.md` をそのまま各プロジェクト要件に注入する（末尾の `[ここに具体的なプロジェクト要件を入れる]` だけ差し替え）
-3. 実装後は `templates/SPRINT_REVIEW_TEMPLATE.md` で検証を出力する
-4. `templates/JOURNEY_LEARNING_ENTRY_TEMPLATE.md` で学習エントリを作成し、`learning/AGENT_GROWTH_LEDGER.md` に追記する
-5. 次回継続がある場合は `templates/NEXT_PROMPT_TEMPLATE.md` で次指示を作成する
-6. 残タスクはバックログに `✅ / ⏳` で明示し、次回Promptへ carry-over する
+   - デザイン関連タスクがある場合は、`templates/DESIGN_PROMPT_TEMPLATE.md` を各プロジェクト要件に注入する
+3. `templates/PROJECT_MANAGER_PERSONA_TEMPLATE.md` を使って、プロマネ・ペルソナを定義する
+   - Owner向けのコメント/提案/日記/気づき報告を `PM Owner Channel` に記録する
+4. 実装後は `templates/SPRINT_REVIEW_TEMPLATE.md` で検証を出力する
+5. `templates/JOURNEY_LEARNING_ENTRY_TEMPLATE.md` で学習エントリを作成し、`learning/AGENT_GROWTH_LEDGER.md` に追記する
+6. 次回継続がある場合は `templates/NEXT_PROMPT_TEMPLATE.md` で次指示を作成する
+7. 残タスクはバックログに `✅ / ⏳` で明示し、次回Promptへ carry-over する
 
 ## ディレクトリ構造
 
@@ -30,6 +33,7 @@ harnes/
   templates/
     DESIGN_PROMPT_TEMPLATE.md
     SESSION_BOOT_TEMPLATE.md
+    PROJECT_MANAGER_PERSONA_TEMPLATE.md
     NEXT_PROMPT_TEMPLATE.md
     SPRINT_REVIEW_TEMPLATE.md
     JOURNEY_LEARNING_ENTRY_TEMPLATE.md
@@ -37,10 +41,30 @@ harnes/
     AGENT_GROWTH_LEDGER.md
 ```
 
+## 構造化アーキテクチャ
+
+### 1) Execution Layer
+- `SESSION_BOOT_TEMPLATE.md`
+- `SPRINT_REVIEW_TEMPLATE.md`
+- `NEXT_PROMPT_TEMPLATE.md`
+
+### 2) PM Governance Layer
+- `PROJECT_MANAGER_PERSONA_TEMPLATE.md`
+- Ownerとの非同期コミュニケーション（Comment / Recommendation / Diary Note / Insight Report）
+
+### 3) Learning Layer
+- `JOURNEY_LEARNING_ENTRY_TEMPLATE.md`
+- `learning/AGENT_GROWTH_LEDGER.md`
+
+### 4) Principle Layer
+- `SOUL.md`
+- `LEARNING_SYSTEM.md`
+
 ## 設計方針
 
 - 本ハーネスは「運用時に毎回使う薄い実行層」とする
 - ドメイン固有ルールはテンプレート内の「Project Invariants」に注入する
 - 最低限の必須項目（Fail Fast / Metrics Plan / Non-Scope）を全テンプレートで強制する
+- プロマネ・ペルソナで意思決定ログとOwner通知を運用し、進行停滞を早期解消する
 - 学習ログは追記専用で、次回Promptに再注入する
 - 「テンプレートを使った/使わなかった理由」と「残タスクの所在」を毎スプリントで明文化する

--- a/harnes/templates/NEXT_PROMPT_TEMPLATE.md
+++ b/harnes/templates/NEXT_PROMPT_TEMPLATE.md
@@ -11,6 +11,10 @@
   -
 - Prior Learning Import:
   - ENTRY-XXXX から再利用する知見
+- PM Persona Carry-over:
+  - Persona Name:
+  - Open Recommendations:
+  - Latest Insight Report:
 - Goal:
   -
 - Scope:
@@ -29,6 +33,11 @@
   - 観測:
 - Deliverables:
   -
+- PM Owner Channel Plan:
+  - Comment:
+  - Recommendation:
+  - Diary Note:
+  - Insight Report:
 - Next:
   -
 - Carry-over Backlog:
@@ -42,6 +51,7 @@
 - [ ] 既存エントリ本文を編集していない
 - [ ] latest ポインタ/状態を更新した
 - [ ] Non-Scope / Fail Fast / Metrics Plan / Project Invariants を含めた
+- [ ] PM Persona Carry-over を更新した
 - [ ] デザイン関連タスクがある場合、`DESIGN_PROMPT_TEMPLATE.md` を注入した
 - [ ] Learning Ledgerから再利用知見を1つ以上注入した
 - [ ] `Carry-over Backlog` に `✅ / ⏳ / 残タスク所在` を記入した

--- a/harnes/templates/PROJECT_MANAGER_PERSONA_TEMPLATE.md
+++ b/harnes/templates/PROJECT_MANAGER_PERSONA_TEMPLATE.md
@@ -1,0 +1,94 @@
+# PROJECT_MANAGER_PERSONA_TEMPLATE.md
+
+プロジェクト進行を支える「プロマネ・ペルソナ」を定義するテンプレート。  
+曖昧語（例: 抜群の、いい感じ）を使わず、文書能力を運用可能な粒度で定義する。
+
+---
+
+## 1) Persona Definition
+- Persona Name:
+- Mission:
+- Owner（意思決定者）:
+- Product / Sprint:
+- Decision Boundary（このペルソナが決めること / Owner承認が必要なこと）:
+
+## 2) Core Documentation Capabilities（必須）
+
+以下を「能力要件」として明示する。
+
+1. **要件構造化能力**
+   - 依頼文を Goal / Scope / Non-Scope / Constraints / DoD に分解する。
+   - 曖昧な要件を検出し、確認質問に変換する。
+2. **論点分離能力**
+   - 事実（Fact）・解釈（Interpretation）・提案（Proposal）・意思決定事項（Decision）を分離して記述する。
+3. **意思決定記録能力**
+   - 代替案・採用理由・棄却理由・影響範囲・リスクを1セットで残す。
+4. **進行可視化能力**
+   - 依存関係、期限、担当、進捗率、ブロッカー、次アクションを短い定型で更新する。
+5. **レビュー編集能力**
+   - 文書を「読む順番」で再編集し、見出し・箇条書き・要約・差分表示で認知負荷を下げる。
+6. **品質監査能力**
+   - Project Invariants / Fail Fast / Metrics Plan / DoD の欠落を検知して差し戻す。
+7. **エスカレーション能力**
+   - 進行遅延・品質低下・仕様衝突を閾値ベースで通知し、打ち手を添えて報告する。
+
+## 3) Voice & Writing Rules
+- 1段落1論点、1文40〜70文字を目安にする。
+- 主語と責任主体（誰が/いつまでに）を省略しない。
+- 推奨表現: 「理由」「影響」「次アクション」を必ずセットで書く。
+- 禁止: 感覚語だけで評価する（例: 良い/悪い、重い/軽い）
+
+## 4) Deliverables Owned by Persona
+- 進行計画（Sprint Plan）
+- 意思決定ログ（Decision Log）
+- リスクログ（Risk Log）
+- 週次/スプリント報告（Status Report）
+- Owner向けコメントログ（下記 PM Owner Channel）
+
+## 5) PM Owner Channel（プロジェクト進行の1要素として必須）
+
+Ownerと非同期コミュニケーションを取るための記録欄。  
+この欄は「雑談」ではなく、進行品質を上げるための運用ログとして扱う。
+
+### Entry Types
+1. **Comment（状況コメント）**
+   - 現状の事実整理 + 影響 + 依頼事項
+2. **Recommendation（提案）**
+   - 選択肢A/B + 推奨案 + 判断期限
+3. **Diary Note（運用日記）**
+   - 当日の進行で起きた学び・違和感・判断メモ
+4. **Insight Report（気づき報告）**
+   - 再発防止・効率化に効く知見を抽象化して記録
+
+### PM Owner Channel Template
+```md
+## PM-ENTRY-XXXX
+- Date: YYYY-MM-DD
+- Type: Comment | Recommendation | Diary Note | Insight Report
+- Topic:
+- Fact:
+- Interpretation:
+- Proposal / Ask:
+- Impact (Scope / Schedule / Quality / Cost):
+- Owner Action Needed: Yes / No
+- Deadline:
+- Status: Open / Closed
+```
+
+## 6) Weekly Operating Cadence（推奨）
+- 月: Sprint Goalと依存関係を再確認
+- 水: ブロッカー棚卸し + Recommendation発行
+- 金: Insight Reportを1件以上作成
+
+## 7) Quality Gates
+- [ ] Goal / Scope / Non-Scope が更新されている
+- [ ] Decision Log と矛盾がない
+- [ ] Fail Fast 条件に触れていない
+- [ ] Metrics の観測結果が添付されている
+- [ ] PM Owner Channelに週3件以上の記録がある
+
+## 8) Handoff to NEXT_PROMPT
+- 次回Promptへ引き継ぐ項目:
+  - OpenなRecommendation
+  - 未解決リスク
+  - 最優先Insight（1件）

--- a/harnes/templates/SESSION_BOOT_TEMPLATE.md
+++ b/harnes/templates/SESSION_BOOT_TEMPLATE.md
@@ -6,6 +6,7 @@
 - 参照必須（必要に応じて置換）:
   - `<PROJECT>/harnes/SOUL.md`
   - `<PROJECT>/harnes/LEARNING_SYSTEM.md`
+  - `<PROJECT>/harnes/templates/PROJECT_MANAGER_PERSONA_TEMPLATE.md`
   - `<PROJECT>/PROJECT_CONTEXT.md`（任意）
   - `<PROJECT>/PROCESS_PLAYBOOK.md`（任意）
 - 対象スプリント:
@@ -29,45 +30,55 @@
 
 ## 6) Constraints
 -
-- デザイン関連タスクがある場合は `templates/DESIGN_PROMPT_TEMPLATE.md` をそのまま注入し、`[ここに具体的なプロジェクト要件を入れる]` のみ差し替える
+- デザイン関連タスクがある場合は `templates/DESIGN_PROMPT_TEMPLATE.md` を注入し、要件部分のみ差し替える
 
-## 7) DoD
+## 7) PM Persona Activation（必須）
+- Persona Name:
+- 文書能力フォーカス（例: 要件構造化 / 意思決定記録 / レビュー編集）:
+- Owner:
+- Decision Boundary:
+- PM Owner Channel運用頻度（例: 週3件）:
+
+## 8) DoD
 -
 
-## 8) Fail Fast（必須）
+## 9) Fail Fast（必須）
 - 条件1:
 - 条件2:
 - 条件3:
 
-## 9) Metrics Plan（必須）
+## 10) Metrics Plan（必須）
 - 指標:
 - 指標（任意）: 多人数同時タップで全入力が到達可能
 - 閾値:
 - 観測単位（例: セッション数）:
 - 判定:
 
-## 10) Deliverables
+## 11) Deliverables
 - 変更内容
 - 検証結果
 - 次回Prompt草案
 - 学習エントリ（`AGENT_GROWTH_LEDGER.md` 追記）
 - バックログ更新（`✅/⏳` と残タスク所在）
+- PM Owner Channelログ（Comment / Recommendation / Diary Note / Insight Report）
 
-## 11) 検証コマンド
+## 12) 検証コマンド
 - `...`
 - 期待結果:
 
-## 12) テンプレート適用方針（必須）
+## 13) テンプレート適用方針（必須）
 - 使用するテンプレート:
   - `SESSION_BOOT_TEMPLATE`: Use / Skip（理由）
+  - `PROJECT_MANAGER_PERSONA_TEMPLATE`: Use / Skip（理由）
   - `DESIGN_PROMPT_TEMPLATE`（デザイン対象時必須）: Use / Skip（理由）
   - `SPRINT_REVIEW_TEMPLATE`: Use / Skip（理由）
   - `NEXT_PROMPT_TEMPLATE`: Use / Skip（理由）
   - `JOURNEY_LEARNING_ENTRY_TEMPLATE`: Use / Skip（理由）
 - Skipがある場合の代替手段:
 
-## 13) 出力フォーマット指定
+## 14) 出力フォーマット指定
 - Summary（変更点）
 - Testing（コマンドごとの成否）
 - 判定（Adopt / Iterate / Revert）
 - Learning Entry（Reusable Insight / Do / Don’t）
+- PM Owner Channel（Comment / Recommendation / Diary Note / Insight Report）

--- a/harnes/templates/SPRINT_REVIEW_TEMPLATE.md
+++ b/harnes/templates/SPRINT_REVIEW_TEMPLATE.md
@@ -33,11 +33,25 @@
 - 品質要件（可読性/安全性/性能）: Pass / Fail
 - 同時押下到達性（該当時）: Pass / Fail
 
-## 7. 最終判定
+## 7. PM Persona運用レビュー（必須）
+- 要件構造化品質: Good / Needs Work
+- 意思決定ログ品質: Good / Needs Work
+- オーナー通知のタイミング: Good / Needs Work
+- 文書の読みやすさ（見出し・要約・差分）: Good / Needs Work
+
+## 8. PM Owner Channel 実績（必須）
+- Comment件数:
+- Recommendation件数:
+- Diary Note件数:
+- Insight Report件数:
+- 主要エントリID:
+- 進行に効いたエントリ:
+
+## 9. 最終判定
 - Adopt / Iterate / Revert
 - 理由（3行以内）:
 
-## 8. Learning抽出（必須）
+## 10. Learning抽出（必須）
 - Reusable Insight:
 - Reasoning Pivot:
 - Do:
@@ -45,14 +59,16 @@
 - Evidence:
 - Reuse Plan:
 
-## 9. 次回への引き継ぎ
+## 11. 次回への引き継ぎ
 - 続行時の最小タスク:
 - 次回Prompt草案:
 - Learning Ledger追記ID:
+- オープンなRecommendation:
 
-## 10. テンプレート運用レビュー（必須）
+## 12. テンプレート運用レビュー（必須）
 - 使ったテンプレート:
   - SESSION_BOOT_TEMPLATE: Yes / No（理由）
+  - PROJECT_MANAGER_PERSONA_TEMPLATE: Yes / No（理由）
   - DESIGN_PROMPT_TEMPLATE（デザイン対象時必須）: Yes / No（理由）
   - SPRINT_REVIEW_TEMPLATE: Yes / No（理由）
   - NEXT_PROMPT_TEMPLATE: Yes / No（理由）
@@ -60,7 +76,7 @@
 - 使わなかったテンプレートの代替運用:
 - 次回改善したいテンプレート項目:
 
-## 11. バックログ残対応の見える化（必須）
+## 13. バックログ残対応の見える化（必須）
 - 完了項目（✅）:
 - 残項目（⏳）:
 - 残タスクの所在（ファイルパス）:


### PR DESCRIPTION
### Motivation
- Make project-management documentation explicit by replacing vague praise with operationally usable PM persona capabilities and quality gates. 
- Elevate Owner-facing PM communication (comments, recommendations, diary notes, insights) into the harness so those outputs feed the learning and next-prompt flow.

### Description
- Add `harnes/templates/PROJECT_MANAGER_PERSONA_TEMPLATE.md` to define the PM persona, concrete documentation capabilities, voice rules, deliverables, quality gates, and a `PM Owner Channel` entry template. 
- Update `harnes/templates/SESSION_BOOT_TEMPLATE.md` to require PM Persona activation, include the persona template as a required reference, and surface `PM Owner Channel` logs as required deliverables. 
- Update `harnes/templates/SPRINT_REVIEW_TEMPLATE.md` to add PM Persona operation review fields and PM Owner Channel metrics and entries for evaluation. 
- Update `harnes/templates/NEXT_PROMPT_TEMPLATE.md`, `harnes/LEARNING_SYSTEM.md`, and `harnes/README.md` to add PM persona carry-over fields, include PM Owner Channel outputs as learning inputs, and document the harness architecture (Execution / PM Governance / Learning / Principle).

### Testing
- Ran `git diff --check` to verify no whitespace/format issues and it returned clean. 
- Ran `git status --short` to confirm working tree expectations. 
- Packaged changes and created the PR via the repository tooling (PR payload prepared by automation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e23a1ad38083259523b5a9ad061b10)