### PR TITLE
game67: simplify UI and adjust timing for mobile

### DIFF
--- a/game67/app.js
+++ b/game67/app.js
@@ -2,9 +2,12 @@ const ROWS = 4;
 const COLS = 3;
 const TOTAL_CELLS = ROWS * COLS;
 const MAX_ROUND = 8;
-const BASE_DISPLAY_MS = 1000;
-const DISPLAY_RATIO = 0.8;
+const BASE_DISPLAY_MS = 800;
+const DISPLAY_RATIO = 0.7;
+const MIN_DISPLAY_MS = 10;
 const HIDE_BETWEEN_MS = 260;
+const MIN_SHOW_COUNT = 6;
+const MAX_SHOW_COUNT = 15;
 
 const state = {
   round: 1,
@@ -21,10 +24,8 @@ const elements = {
   maxRound: document.getElementById("max-round"),
   score: document.getElementById("score"),
   displayMs: document.getElementById("display-ms"),
-  message: document.getElementById("message"),
   grid: document.getElementById("grid"),
-  startBtn: document.getElementById("start-btn"),
-  nextBtn: document.getElementById("next-btn"),
+  actionBtn: document.getElementById("action-btn"),
   resetBtn: document.getElementById("reset-btn"),
 };
 
@@ -37,7 +38,7 @@ function createGrid() {
     btn.className = "cell";
     btn.dataset.index = String(index);
     btn.ariaLabel = `マス ${index + 1}`;
-    btn.textContent = String(index + 1);
+    btn.textContent = "";
     btn.disabled = true;
     btn.addEventListener("click", onAnswerClick);
     elements.grid.appendChild(btn);
@@ -47,10 +48,6 @@ function createGrid() {
 
 function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function setMessage(text) {
-  elements.message.textContent = text;
 }
 
 function syncStatus() {
@@ -71,7 +68,7 @@ function clearCat() {
     return;
   }
   const cell = cells[state.currentVisibleCellIndex];
-  cell.textContent = String(state.currentVisibleCellIndex + 1);
+  cell.textContent = "";
   state.currentVisibleCellIndex = null;
 }
 
@@ -94,12 +91,14 @@ function truncateToTwoDecimals(value) {
   return Math.floor(value * 100) / 100;
 }
 
-function updateButtonStates() {
-  const canStart = !state.isAnimating && !state.isAnswering && state.round === 1;
-  elements.startBtn.disabled = !canStart;
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
 
-  const canNext = !state.isAnimating && !state.isAnswering && state.round > 1 && state.round <= MAX_ROUND;
-  elements.nextBtn.disabled = !canNext;
+function updateButtonStates() {
+  const canRunRound = !state.isAnimating && !state.isAnswering && state.round <= MAX_ROUND;
+  elements.actionBtn.disabled = !canRunRound;
+  elements.actionBtn.textContent = state.round === 1 ? "開始" : "次のラウンド";
 
   cells.forEach((cell) => {
     cell.disabled = !state.isAnswering;
@@ -112,27 +111,23 @@ async function runRound() {
   clearHighlights();
   updateButtonStates();
 
-  const hopCount = 2 + state.round;
+  const showCount = randomInt(MIN_SHOW_COUNT, MAX_SHOW_COUNT);
   let current = Math.floor(Math.random() * TOTAL_CELLS);
 
-  setMessage(`ラウンド ${state.round}: 猫の移動を追跡中...`);
-
-  for (let hop = 0; hop < hopCount; hop += 1) {
+  for (let show = 0; show < showCount; show += 1) {
     showCat(current);
     await wait(state.currentDisplayMs);
     clearCat();
-    await wait(HIDE_BETWEEN_MS);
-    current = randomNextIndex(current);
+    if (show < showCount - 1) {
+      await wait(HIDE_BETWEEN_MS);
+      current = randomNextIndex(current);
+    }
   }
 
-  state.finalCellIndex = randomNextIndex(current);
-  showCat(state.finalCellIndex);
-  await wait(state.currentDisplayMs);
-  clearCat();
+  state.finalCellIndex = current;
 
   state.isAnimating = false;
   state.isAnswering = true;
-  setMessage("最後に🐈がいたマス番号をクリックしてください");
   updateButtonStates();
 }
 
@@ -141,17 +136,16 @@ function completeRound(correct) {
 
   if (correct) {
     state.score += 1;
-    setMessage("正解！次のラウンドへ進めます。");
-  } else {
-    setMessage(`不正解。正しいマスは ${state.finalCellIndex + 1} でした。`);
   }
 
   if (state.round >= MAX_ROUND) {
-    setMessage(`終了！スコアは ${state.score}/${MAX_ROUND} です。リセットで再挑戦。`);
-    elements.nextBtn.disabled = true;
+    elements.actionBtn.disabled = true;
   } else {
     state.round += 1;
-    state.currentDisplayMs = truncateToTwoDecimals(state.currentDisplayMs * DISPLAY_RATIO);
+    state.currentDisplayMs = Math.max(
+      MIN_DISPLAY_MS,
+      truncateToTwoDecimals(state.currentDisplayMs * DISPLAY_RATIO),
+    );
   }
 
   syncStatus();
@@ -185,19 +179,11 @@ function resetGame() {
   state.isAnswering = false;
   state.currentDisplayMs = BASE_DISPLAY_MS;
   state.finalCellIndex = null;
-  setMessage("「開始」でスタート");
   syncStatus();
   updateButtonStates();
 }
 
-elements.startBtn.addEventListener("click", async () => {
-  if (state.round !== 1 || state.isAnimating || state.isAnswering) {
-    return;
-  }
-  await runRound();
-});
-
-elements.nextBtn.addEventListener("click", async () => {
+elements.actionBtn.addEventListener("click", async () => {
   if (state.round > MAX_ROUND || state.isAnimating || state.isAnswering) {
     return;
   }

--- a/game67/index.html
+++ b/game67/index.html
@@ -3,29 +3,26 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>Cat Tracker 4x3</title>
+    <title>猫を探せ</title>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <main class="app">
       <header class="header">
-        <h1>🐈 Cat Tracker 4x3</h1>
-        <p class="subtitle">最後に猫がいたマスを当てよう</p>
+        <h1>🐈 猫を探せ</h1>
+        <button id="reset-btn" class="reset-btn" type="button">リセット</button>
       </header>
 
       <section class="status-panel" aria-live="polite">
         <p><strong>ラウンド:</strong> <span id="round">1</span> / <span id="max-round">8</span></p>
         <p><strong>スコア:</strong> <span id="score">0</span></p>
-        <p><strong>表示時間:</strong> <span id="display-ms">1000</span>ms</p>
-        <p id="message">「開始」でスタート</p>
+        <p><strong>表示時間:</strong> <span id="display-ms">800</span>ms</p>
       </section>
 
       <section class="grid" id="grid" aria-label="3列4行のマス"></section>
 
       <section class="controls">
-        <button id="start-btn" type="button">開始</button>
-        <button id="next-btn" type="button" disabled>次のラウンド</button>
-        <button id="reset-btn" type="button">リセット</button>
+        <button id="action-btn" type="button">開始</button>
       </section>
 
       <section class="help">

--- a/game67/style.css
+++ b/game67/style.css
@@ -26,14 +26,31 @@ body {
   padding: 20px 0 28px;
 }
 
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .header h1 {
   margin: 0;
   font-size: clamp(1.4rem, 3.5vw, 2rem);
 }
 
-.subtitle {
-  margin-top: 6px;
-  opacity: 0.9;
+.reset-btn {
+  border: none;
+  border-radius: 10px;
+  padding: 9px 14px;
+  background: #7a1f2a;
+  color: #f9fafb;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.reset-btn:hover:not(:disabled),
+.reset-btn:focus-visible:not(:disabled) {
+  background: #922737;
 }
 
 .status-panel {
@@ -44,13 +61,7 @@ body {
   margin: 14px 0;
 }
 
-.status-panel p {
-  margin: 5px 0;
-}
-
-#message {
-  font-weight: 700;
-}
+.status-panel p { margin: 5px 0; }
 
 .grid {
   display: grid;
@@ -90,7 +101,7 @@ body {
 
 .controls {
   display: flex;
-  gap: 10px;
+  justify-content: flex-end;
   margin: 16px 0;
 }
 
@@ -102,6 +113,7 @@ body {
   color: #f9fafb;
   font-weight: 700;
   cursor: pointer;
+  min-width: 130px;
 }
 
 .controls button:disabled {


### PR DESCRIPTION
### Motivation
- Reduce visual noise by preventing text elements from moving during gameplay so only the cat animation is visible. 
- Improve one-handed mobile usability by moving the reset control to the header and consolidating `開始`/`次のラウンド` into a single, right-aligned action button with a stable touch target. 
- Make timing and repetition behavior match new gameplay requirements for faster starts and stronger per-round reduction.

### Description
- Renamed the page title to `猫を探せ` and moved the reset button into the header as `#reset-btn` with a darker red style. 
- Removed the dynamic message area and related DOM/text updates so no non-cat elements animate during rounds. 
- Replaced `#start-btn`/`#next-btn` with a single right-aligned `#action-btn` whose label toggles between `開始` and `次のラウンド`, and set a fixed `min-width` for stable button size. 
- Hid numeric labels inside grid cells (cells are blank unless the cat is visible via `🐈`), and adjusted timing/randomness: `BASE_DISPLAY_MS = 800`, `DISPLAY_RATIO = 0.7`, `MIN_DISPLAY_MS = 10`, and randomized per-round show counts with `MIN_SHOW_COUNT = 6` and `MAX_SHOW_COUNT = 15`.

### Testing
- Ran `node --check game67/app.js` and it completed successfully. 
- Searched the `game67` files for removed selectors with `rg "start-btn|next-btn|message|subtitle" game67` to ensure no stale references remain and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2df31a8c48325a28740f1a3350e9b)