### PR TITLE
game62: プレイヤーが獲得エリア内部を進めないように調整

### DIFF
--- a/game62/js/field.js
+++ b/game62/js/field.js
@@ -38,7 +38,26 @@ export class Field {
 
   isSafe(x, y) {
     const cell = this.getCell(x, y);
-    return cell === CELL.CAPTURED || cell === CELL.BOUNDARY;
+    if (cell === CELL.BOUNDARY) return true;
+    if (cell !== CELL.CAPTURED) return false;
+    return this.isCapturedEdge(x, y);
+  }
+
+  isCapturedEdge(x, y) {
+    if (this.getCell(x, y) !== CELL.CAPTURED) return false;
+    return (
+      this.getCell(x + 1, y) === CELL.UNCAPTURED
+      || this.getCell(x - 1, y) === CELL.UNCAPTURED
+      || this.getCell(x, y + 1) === CELL.UNCAPTURED
+      || this.getCell(x, y - 1) === CELL.UNCAPTURED
+    );
+  }
+
+  isWalkableForPlayer(x, y) {
+    const cell = this.getCell(x, y);
+    if (cell === CELL.UNCAPTURED || cell === CELL.BOUNDARY) return true;
+    if (cell !== CELL.CAPTURED) return false;
+    return this.isCapturedEdge(x, y);
   }
 
   isSolidForEnemy(x, y) {

--- a/game62/js/player.js
+++ b/game62/js/player.js
@@ -56,6 +56,10 @@ export class Player {
       return false;
     }
 
+    if (!this.field.isWalkableForPlayer(nx, ny)) {
+      return false;
+    }
+
     const nextCell = this.field.getCell(nx, ny);
     const movingIntoUncaptured = nextCell === CELL.UNCAPTURED;
 


### PR DESCRIPTION
### Motivation
- 獲得済みエリアの内部をプレイヤーが自由に歩けてしまうため、獲得エリアは淵（外周）だけ歩ける仕様に合わせて挙動を修正する必要があった。
- 囲み終了（領域確定）の判定や安全判定も「淵」に基づくようにして、プレイヤーが内部に入ってしまうことで起きる不整合を防止する狙いがある。

### Description
- `Field` に `isCapturedEdge(x,y)` を追加して、`CELL.CAPTURED` のうち未獲得セルに隣接する「淵」セルを判定する機能を実装した。  
- `isSafe(x,y)` を見直し `CELL.BOUNDARY` または `isCapturedEdge` のときのみ安全と判定するよう変更した。  
- プレイヤー向けの移動可否判定 `isWalkableForPlayer(x,y)` を追加し、未獲得セル・外周・捕獲淵のみ移動可能とした。  
- `Player.step()` に移動前のガードを追加して、`isWalkableForPlayer` が `false` の場合は移動を拒否するよう変更した。  
- 変更箇所: `game62/js/field.js`、`game62/js/player.js`。

### Testing
- 試行: `node --check game62/js/field.js && node --check game62/js/player.js` はリポジトリの Node 実行モードにより失敗し、`import` による ESM エラーで構文チェックが通らなかった（失敗）。
- 試行: `node --experimental-default-type=module --check game62/js/field.js && node --experimental-default-type=module --check game62/js/player.js` も同様に ESM 設定に起因するエラーで構文チェックは失敗した（失敗）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e302bb56d48325b6f290fcd3008f80)