### PR TITLE
fix(game62): restore trail collision miss + captured-area reconnect close

### DIFF
--- a/game62/js/field.js
+++ b/game62/js/field.js
@@ -53,16 +53,17 @@ export class Field {
     );
   }
 
-  isWalkableForPlayer(x, y) {
+  isWalkableForPlayer(x, y, drawing = false) {
     const cell = this.getCell(x, y);
     if (cell === CELL.UNCAPTURED || cell === CELL.BOUNDARY) return true;
     if (cell !== CELL.CAPTURED) return false;
+    if (drawing) return true;
     return this.isCapturedEdge(x, y);
   }
 
   isSolidForEnemy(x, y) {
     const cell = this.getCell(x, y);
-    return cell === CELL.CAPTURED || cell === CELL.BOUNDARY || cell === CELL.TRAIL;
+    return cell === CELL.CAPTURED || cell === CELL.BOUNDARY;
   }
 
   getFillRate() {

--- a/game62/js/player.js
+++ b/game62/js/player.js
@@ -56,7 +56,7 @@ export class Player {
       return false;
     }
 
-    if (!this.field.isWalkableForPlayer(nx, ny)) {
+    if (!this.field.isWalkableForPlayer(nx, ny, this.drawing)) {
       return false;
     }
 
@@ -81,7 +81,7 @@ export class Player {
     this.x = nx;
     this.y = ny;
 
-    if (this.drawing && this.field.isSafe(this.x, this.y)) {
+    if (this.drawing && (nextCell === CELL.BOUNDARY || nextCell === CELL.CAPTURED)) {
       return { closed: true };
     }
 


### PR DESCRIPTION
### Motivation
- 敵がプレイヤーの黄色いトレイル（`CELL.TRAIL`）を壁として扱ってしまい、トレイルに触れてもアウト（ミス）にならない不具合を修正するため。 
- プレイヤーが占領中（トレイルを引いている最中）に自分の既占領領域へ接続したときにも占領が完了するようにするため。

### Description
- `game62/js/field.js` にて `isWalkableForPlayer(x, y)` を `isWalkableForPlayer(x, y, drawing = false)` に変更し、`drawing` 中は `CELL.CAPTURED` へ移動可能にした。 
- `game62/js/field.js` の `isSolidForEnemy` から `CELL.TRAIL` を除外し、敵がトレイル上を通過してトレイルに触れられるように戻した。 
- `game62/js/player.js` で歩行可能判定に `this.drawing` を渡すようにし、占領完了判定を境界への再接続だけでなく `CELL.CAPTURED` への再接続でも `closed` を返すように変更した。

### Testing
- 実行チェックとして `cd /workspace/games && node --check game62/js/field.js && node --check game62/js/player.js` を実行したが、本リポジトリはブラウザ向けESMの構成のため `import` を含むファイルに対してNodeの直接チェックが失敗する（`SyntaxError: Cannot use import statement outside a module`）。（失敗）
- `cd /workspace/games && node --input-type=module -e "await import('./game62/js/field.js'); await import('./game62/js/player.js');"` を試行したが同様にESMロードエラーで読み込み検証ができなかった（失敗）。
- ローカルでの差分確認と静的レビューは行い、変更は `game62/js/field.js` と `game62/js/player.js` に限定して適用・コミット済みである（自動テストはブラウザ実行環境での動作確認が必要）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e30de880c08325bd1eccd54ff6ad88)