### PR TITLE
game67: prevent advancement on wrong answer and add round controls

### DIFF
--- a/game67/app.js
+++ b/game67/app.js
@@ -22,6 +22,7 @@ const state = {
   currentDisplayMs: BASE_DISPLAY_MS,
   finalCellIndex: null,
   entities: [],
+  needsRetry: false,
 };
 
 const elements = {
@@ -33,6 +34,7 @@ const elements = {
   actionBtn: document.getElementById("action-btn"),
   resetBtn: document.getElementById("reset-btn"),
   prevRoundBtn: document.getElementById("prev-round-btn"),
+  nextRoundBtn: document.getElementById("next-round-btn"),
   disturbanceBtn: document.getElementById("disturbance-btn"),
 };
 
@@ -181,10 +183,18 @@ function moveEntities(currentEntities) {
 function updateButtonStates() {
   const canRunRound = !state.isAnimating && !state.isAnswering && state.round <= MAX_ROUND;
   elements.actionBtn.disabled = !canRunRound;
-  elements.actionBtn.textContent = state.round === 1 ? "スタート" : "つぎへ";
+  if (state.round === 1 && !state.needsRetry) {
+    elements.actionBtn.textContent = "スタート";
+  } else if (state.needsRetry) {
+    elements.actionBtn.textContent = "もういちど";
+  } else {
+    elements.actionBtn.textContent = "もういちど";
+  }
 
   elements.prevRoundBtn.disabled =
     state.isAnimating || state.isAnswering || state.round <= 1;
+  elements.nextRoundBtn.disabled =
+    state.isAnimating || state.isAnswering || state.round >= MAX_ROUND;
 
   elements.disturbanceBtn.disabled = state.isAnimating || state.isAnswering;
   elements.disturbanceBtn.textContent = state.isDisturbanceMode ? "お邪魔あり" : "お邪魔なし";
@@ -234,18 +244,21 @@ function completeRound(correct) {
 
   if (correct) {
     state.score += 1;
-  }
+    state.needsRetry = false;
 
-  if (state.round >= MAX_ROUND) {
-    elements.actionBtn.disabled = true;
+    if (state.round >= MAX_ROUND) {
+      elements.actionBtn.disabled = true;
+    } else {
+      const nextRound = state.round + 1;
+      const nextRoundRatio = getRoundDisplayRatio(nextRound);
+      state.round = nextRound;
+      state.currentDisplayMs = Math.max(
+        MIN_DISPLAY_MS,
+        truncateToTwoDecimals(state.currentDisplayMs * nextRoundRatio),
+      );
+    }
   } else {
-    const nextRound = state.round + 1;
-    const nextRoundRatio = getRoundDisplayRatio(nextRound);
-    state.round = nextRound;
-    state.currentDisplayMs = Math.max(
-      MIN_DISPLAY_MS,
-      truncateToTwoDecimals(state.currentDisplayMs * nextRoundRatio),
-    );
+    state.needsRetry = true;
   }
 
   syncStatus();
@@ -280,6 +293,23 @@ function stepBackRound() {
   state.currentDisplayMs = computeDisplayMsForRound(state.round);
   state.finalCellIndex = null;
   state.entities = [];
+  state.needsRetry = false;
+  clearEntities();
+  clearHighlights();
+  syncStatus();
+  updateButtonStates();
+}
+
+function stepForwardRound() {
+  if (state.isAnimating || state.isAnswering || state.round >= MAX_ROUND) {
+    return;
+  }
+
+  state.round += 1;
+  state.currentDisplayMs = computeDisplayMsForRound(state.round);
+  state.finalCellIndex = null;
+  state.entities = [];
+  state.needsRetry = false;
   clearEntities();
   clearHighlights();
   syncStatus();
@@ -296,6 +326,7 @@ function resetGame() {
   state.currentDisplayMs = BASE_DISPLAY_MS;
   state.finalCellIndex = null;
   state.entities = [];
+  state.needsRetry = false;
   syncStatus();
   updateButtonStates();
 }
@@ -309,6 +340,7 @@ elements.actionBtn.addEventListener("click", async () => {
 
 elements.resetBtn.addEventListener("click", resetGame);
 elements.prevRoundBtn.addEventListener("click", stepBackRound);
+elements.nextRoundBtn.addEventListener("click", stepForwardRound);
 elements.disturbanceBtn.addEventListener("click", () => {
   if (state.isAnimating || state.isAnswering) {
     return;

--- a/game67/index.html
+++ b/game67/index.html
@@ -16,7 +16,10 @@
       <section class="status-panel" aria-live="polite">
         <p class="round-row">
           <span><strong>ラウンド:</strong> <span id="round">1</span> / <span id="max-round">25</span></span>
-          <button id="prev-round-btn" class="small-btn" type="button">ラウンド戻る</button>
+          <div class="round-buttons">
+            <button id="next-round-btn" class="small-btn" type="button">ラウンドすすむ</button>
+            <button id="prev-round-btn" class="small-btn" type="button">ラウンドもどる</button>
+          </div>
         </p>
         <p><strong>スコア:</strong> <span id="score">0</span></p>
         <p><strong>表示時間:</strong> <span id="display-ms">600</span>ms</p>

--- a/game67/style.css
+++ b/game67/style.css
@@ -72,6 +72,11 @@ body {
   gap: 10px;
 }
 
+.round-buttons {
+  display: flex;
+  gap: 8px;
+}
+
 .small-btn {
   border: none;
   border-radius: 9px;


### PR DESCRIPTION
### Motivation
- Players were able to advance to the next round even after answering incorrectly, and the UI labels for progressing rounds needed to be changed to match desired Japanese wording and flow.
- The intent is to keep the display time unchanged on incorrect answers and require an explicit retry or manual next-round action to continue.

### Description
- Added a `needsRetry` flag to the game state to track incorrect-answer retries in `game67/app.js`.
- Modified the main action button label logic so the button shows `スタート` only on the first start and `もういちど` otherwise (replacing the previous `つぎへ`).
- Updated `completeRound` so an incorrect answer sets `needsRetry = true` and does not advance the round or change `currentDisplayMs`; a correct answer advances the round and updates display time as before.
- Added a new `ラウンドすすむ` button beside the round display and renamed `ラウンド戻る` to `ラウンドもどる` in `game67/index.html`, wired the new button to a `stepForwardRound` function, and added supporting layout styles in `game67/style.css`.

### Testing
- Ran `node --check game67/app.js` to validate syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e31d082b1883258f56611bb672604a)