### PR TITLE
game67: じゃまもの表示を追加しボタン表記を調整、総ラウンドを40に変更

### DIFF
--- a/game67/app.js
+++ b/game67/app.js
@@ -1,7 +1,7 @@
 const ROWS = 4;
 const COLS = 3;
 const TOTAL_CELLS = ROWS * COLS;
-const MAX_ROUND = 25;
+const MAX_ROUND = 40;
 const BASE_DISPLAY_MS = 600;
 const EARLY_ROUND_DISPLAY_RATIO = 0.8;
 const LATE_ROUND_DISPLAY_RATIO = 0.9;
@@ -36,6 +36,7 @@ const elements = {
   prevRoundBtn: document.getElementById("prev-round-btn"),
   nextRoundBtn: document.getElementById("next-round-btn"),
   disturbanceBtn: document.getElementById("disturbance-btn"),
+  disturbanceIndicator: document.getElementById("disturbance-indicator"),
 };
 
 const cells = [];
@@ -109,6 +110,10 @@ function syncStatus() {
   elements.maxRound.textContent = String(MAX_ROUND);
   elements.score.textContent = String(state.score);
   elements.displayMs.textContent = String(state.currentDisplayMs);
+  elements.disturbanceIndicator.textContent = state.isDisturbanceMode
+    ? "おじゃま中"
+    : "通常モード";
+  elements.disturbanceIndicator.classList.toggle("is-on", state.isDisturbanceMode);
 }
 
 function clearHighlights() {
@@ -183,13 +188,7 @@ function moveEntities(currentEntities) {
 function updateButtonStates() {
   const canRunRound = !state.isAnimating && !state.isAnswering && state.round <= MAX_ROUND;
   elements.actionBtn.disabled = !canRunRound;
-  if (state.round === 1 && !state.needsRetry) {
-    elements.actionBtn.textContent = "スタート";
-  } else if (state.needsRetry) {
-    elements.actionBtn.textContent = "もういちど";
-  } else {
-    elements.actionBtn.textContent = "もういちど";
-  }
+  elements.actionBtn.textContent = "スタート";
 
   elements.prevRoundBtn.disabled =
     state.isAnimating || state.isAnswering || state.round <= 1;
@@ -197,8 +196,12 @@ function updateButtonStates() {
     state.isAnimating || state.isAnswering || state.round >= MAX_ROUND;
 
   elements.disturbanceBtn.disabled = state.isAnimating || state.isAnswering;
-  elements.disturbanceBtn.textContent = state.isDisturbanceMode ? "お邪魔あり" : "お邪魔なし";
+  elements.disturbanceBtn.textContent = "じゃまもの";
   elements.disturbanceBtn.setAttribute("aria-pressed", String(state.isDisturbanceMode));
+  elements.disturbanceIndicator.textContent = state.isDisturbanceMode
+    ? "おじゃま中"
+    : "通常モード";
+  elements.disturbanceIndicator.classList.toggle("is-on", state.isDisturbanceMode);
 
   cells.forEach((cell) => {
     cell.disabled = !state.isAnswering;
@@ -346,6 +349,7 @@ elements.disturbanceBtn.addEventListener("click", () => {
     return;
   }
   state.isDisturbanceMode = !state.isDisturbanceMode;
+  syncStatus();
   updateButtonStates();
 });
 

--- a/game67/index.html
+++ b/game67/index.html
@@ -15,20 +15,23 @@
 
       <section class="status-panel" aria-live="polite">
         <p class="round-row">
-          <span><strong>ラウンド:</strong> <span id="round">1</span> / <span id="max-round">25</span></span>
+          <span><strong>ラウンド:</strong> <span id="round">1</span> / <span id="max-round">40</span></span>
           <div class="round-buttons">
             <button id="next-round-btn" class="small-btn" type="button">ラウンドすすむ</button>
             <button id="prev-round-btn" class="small-btn" type="button">ラウンドもどる</button>
           </div>
         </p>
-        <p><strong>スコア:</strong> <span id="score">0</span></p>
+        <div class="score-row">
+          <p><strong>スコア:</strong> <span id="score">0</span></p>
+          <p id="disturbance-indicator" class="disturbance-indicator" aria-live="polite">通常モード</p>
+        </div>
         <p><strong>表示時間:</strong> <span id="display-ms">600</span>ms</p>
       </section>
 
       <section class="grid" id="grid" aria-label="3列4行のマス"></section>
 
       <section class="controls">
-        <button id="disturbance-btn" class="disturbance-btn" type="button">お邪魔なし</button>
+        <button id="disturbance-btn" class="disturbance-btn" type="button">じゃまもの</button>
         <button id="action-btn" type="button">スタート</button>
       </section>
     </main>

--- a/game67/style.css
+++ b/game67/style.css
@@ -65,6 +65,13 @@ body {
   margin: 5px 0;
 }
 
+.score-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
 .round-row {
   display: flex;
   align-items: center;
@@ -75,6 +82,21 @@ body {
 .round-buttons {
   display: flex;
   gap: 8px;
+}
+
+.disturbance-indicator {
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #374151;
+  color: #d1d5db;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.disturbance-indicator.is-on {
+  background: #f59e0b;
+  color: #1f2937;
 }
 
 .small-btn {


### PR DESCRIPTION
### Motivation
- お邪魔モードの有無が分かりにくいため、状態を明示するインジケータを追加して操作を分かりやすくするためです。 
- 「もういちど」と「スタート」が切り替わって混乱するため、アクションボタン表記を統一するためです。 
- ゲームを長めにしたい要望に合わせて総ラウンド数を増やすためです。 

### Description
- `game67/index.html` にステータスエリア右側のインジケータ要素 `disturbance-indicator` を追加して初期表示を `通常モード` にしました。 
- `game67/app.js` の定数 `MAX_ROUND` を `25` から `40` に増やし、表示とロジックを同期しました。 
- `game67/app.js` でアクションボタンの文言切替処理を削除して常に `スタート` を表示するようにし、トグルボタンのラベルを `じゃまもの` に変更しました。 
- `game67/app.js` の `syncStatus` と `updateButtonStates` で `disturbance-indicator` を状態に応じて `おじゃま中` / `通常モード` に更新し、CSSクラス `is-on` を切り替えるようにしました。 
- `game67/style.css` に `.score-row` と `.disturbance-indicator` および `.disturbance-indicator.is-on` のスタイルを追加して表示が分かりやすくなるようにしました。 

### Testing
- 実行構文チェックを `node --check game67/app.js` で実行し成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e32325c44c8325ba5b76e2e94f6496)