### PR TITLE
game69: canvas-first full-screen layout, grid snapping, sliders, and redo

### DIFF
--- a/game69/index.html
+++ b/game69/index.html
@@ -7,29 +7,27 @@
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
-    <header class="topbar">
-      <h1>String Art Studio</h1>
-      <div class="topbar-actions">
-        <button id="undoBtn">Undo</button>
-        <button id="clearBtn">Clear</button>
-        <button id="exportBtn">Export PNG</button>
-      </div>
-    </header>
-
-    <main class="layout">
-      <aside class="panel">
-        <section>
-          <h2>Segments</h2>
-          <p class="hint">キャンバスでドラッグして線分を作成</p>
-          <div class="legend">
-            <span><i class="dot start"></i>start点</span>
-            <span><i class="dot end"></i>end点</span>
+    <main class="app-shell">
+      <section class="canvas-stage">
+        <div class="canvas-toolbar row1">
+          <div class="toolbar-left">
+            <button id="undoBtn">Undo</button>
+            <button id="redoBtn">Redo</button>
+            <button id="clearBtn">Clear</button>
           </div>
-          <ul id="segmentList" class="segment-list"></ul>
-        </section>
+          <button id="togglePanelBtn" class="icon-btn">⚙ Settings</button>
+        </div>
+        <div class="canvas-toolbar row2">
+          <div class="toolbar-left">
+            <button id="generateBtn" class="primary">Render Start</button>
+            <button id="resetRenderBtn">Render Reset</button>
+          </div>
+        </div>
+        <canvas id="canvas" width="1000" height="700" aria-label="string art canvas"></canvas>
+      </section>
 
-        <section>
-          <h2>Pair Settings</h2>
+      <aside id="settingsPanel" class="panel">
+        <section class="compact-grid">
           <label>
             Segment A
             <select id="segmentASelect"></select>
@@ -52,29 +50,30 @@
               <option value="end_to_start">end → start</option>
             </select>
           </label>
-          <label>
-            Divisions (2-300)
-            <input id="divisionsInput" type="number" min="2" max="300" value="30" />
-          </label>
-          <div class="pair-queue-actions">
-            <button id="clearQueueBtn" type="button">Clear Queue</button>
-          </div>
-          <p class="hint">線分を描いた順に 2 本ずつ自動ペア化（S01-S02, S03-S04, ...）</p>
-          <ul id="pairQueueList" class="segment-list"></ul>
         </section>
 
-        <section>
-          <h2>Render Settings</h2>
+        <section class="slider-grid">
+          <label>
+            Divisions: <strong id="divisionsValue">10</strong>
+            <input id="divisionsInput" type="range" min="2" max="300" value="10" />
+          </label>
+          <label>
+            Interval (ms): <strong id="intervalValue">100</strong>
+            <input id="intervalInput" type="range" min="5" max="1000" step="5" value="100" />
+          </label>
+          <label>
+            Grid mesh: <strong id="gridSizeValue">40</strong>
+            <input id="gridSizeInput" type="range" min="10" max="100" step="2" value="40" />
+          </label>
+        </section>
+
+        <section class="compact-grid">
           <label>
             Mode
             <select id="modeSelect">
+              <option value="sequential" selected>Sequential</option>
               <option value="instant">Instant</option>
-              <option value="sequential">Sequential</option>
             </select>
-          </label>
-          <label>
-            Interval (ms)
-            <input id="intervalInput" type="number" min="5" max="1000" value="30" />
           </label>
           <label>
             String Color
@@ -86,23 +85,28 @@
           </label>
           <label class="inline-toggle">
             <input id="shapeAssistCheckbox" type="checkbox" checked />
-            図形入力補助（頂点揃え＋正図形レコメンド）
+            図形入力補助
           </label>
-          <p id="shapeHint" class="hint">形状判定: まだ候補はありません</p>
         </section>
 
-        <section class="panel-actions">
-          <button id="generateBtn" class="primary">Generate</button>
-          <button id="stopBtn">Stop</button>
-          <button id="resetRenderBtn">Reset Render</button>
-          <button id="metricsBtn">Run Metrics</button>
+        <section>
+          <div class="topbar-actions">
+            <button id="stopBtn">Stop</button>
+            <button id="clearQueueBtn">Clear Queue</button>
+            <button id="metricsBtn">Run Metrics</button>
+            <button id="exportBtn">Export PNG</button>
+          </div>
+          <p id="shapeHint" class="hint">形状判定: まだ候補はありません</p>
+          <div class="legend">
+            <span><i class="dot start"></i>start点</span>
+            <span><i class="dot end"></i>end点</span>
+          </div>
+          <ul id="segmentList" class="segment-list"></ul>
+          <ul id="pairQueueList" class="segment-list"></ul>
         </section>
+
         <pre id="metricsOutput" class="metrics">Metrics: not run</pre>
       </aside>
-
-      <section class="canvas-wrap">
-        <canvas id="canvas" width="1000" height="700" aria-label="string art canvas"></canvas>
-      </section>
     </main>
 
     <footer id="statusBar" class="status">Ready</footer>

--- a/game69/script.js
+++ b/game69/script.js
@@ -9,6 +9,10 @@ const directionBSelect = document.getElementById('directionBSelect');
 const divisionsInput = document.getElementById('divisionsInput');
 const modeSelect = document.getElementById('modeSelect');
 const intervalInput = document.getElementById('intervalInput');
+const gridSizeInput = document.getElementById('gridSizeInput');
+const divisionsValue = document.getElementById('divisionsValue');
+const intervalValue = document.getElementById('intervalValue');
+const gridSizeValue = document.getElementById('gridSizeValue');
 const stringColorInput = document.getElementById('stringColorInput');
 const stringWidthInput = document.getElementById('stringWidthInput');
 const statusBar = document.getElementById('statusBar');
@@ -22,14 +26,18 @@ const generateBtn = document.getElementById('generateBtn');
 const stopBtn = document.getElementById('stopBtn');
 const resetRenderBtn = document.getElementById('resetRenderBtn');
 const undoBtn = document.getElementById('undoBtn');
+const redoBtn = document.getElementById('redoBtn');
 const clearBtn = document.getElementById('clearBtn');
 const exportBtn = document.getElementById('exportBtn');
 const metricsBtn = document.getElementById('metricsBtn');
+const settingsPanel = document.getElementById('settingsPanel');
+const togglePanelBtn = document.getElementById('togglePanelBtn');
 
 const core = window.StringArtCore;
 
 let segments = [];
 let history = [];
+let redoHistory = [];
 let interpolationLines = [];
 let renderCursor = 0;
 let pairQueue = [];
@@ -43,7 +51,7 @@ let animationState = {
   running: false,
   rafId: null,
   lastTick: 0,
-  intervalMs: 30,
+  intervalMs: 100,
 };
 
 function setStatus(message) {
@@ -52,7 +60,13 @@ function setStatus(message) {
 
 function pushHistorySnapshot() {
   history.push(JSON.stringify({ segments, pairQueue }));
+  redoHistory = [];
   if (history.length > 100) history.shift();
+}
+
+function pushRedoSnapshot() {
+  redoHistory.push(JSON.stringify({ segments, pairQueue }));
+  if (redoHistory.length > 100) redoHistory.shift();
 }
 
 function stopAnimation() {
@@ -72,6 +86,18 @@ function getPointerPos(evt) {
   return {
     x: ((evt.clientX - rect.left) / rect.width) * canvas.width,
     y: ((evt.clientY - rect.top) / rect.height) * canvas.height,
+  };
+}
+
+function getGridSize() {
+  return Math.max(10, Number(gridSizeInput.value) || 40);
+}
+
+function snapToGrid(point) {
+  const size = getGridSize();
+  return {
+    x: Math.round(point.x / size) * size,
+    y: Math.round(point.y / size) * size,
   };
 }
 
@@ -131,6 +157,29 @@ function drawBaseSegments() {
   });
 }
 
+function drawGrid() {
+  const step = getGridSize();
+  ctx.save();
+  ctx.strokeStyle = '#e5e7eb';
+  ctx.lineWidth = 0.8;
+
+  for (let x = 0; x <= canvas.width; x += step) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, canvas.height);
+    ctx.stroke();
+  }
+
+  for (let y = 0; y <= canvas.height; y += step) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(canvas.width, y);
+    ctx.stroke();
+  }
+
+  ctx.restore();
+}
+
 function drawInterpolationLines() {
   ctx.strokeStyle = stringColorInput.value;
   ctx.lineWidth = Number(stringWidthInput.value);
@@ -183,6 +232,7 @@ function drawDraftSegment() {
 
 function redraw() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawGrid();
   drawBaseSegments();
   drawInterpolationLines();
   drawShapeRecommendation();
@@ -398,7 +448,7 @@ function validateBaseJob() {
     directionB: directionBSelect.value,
     divisions,
     mode: modeSelect.value,
-    intervalMs: Math.max(5, Number(intervalInput.value) || 30),
+    intervalMs: Math.max(5, Number(intervalInput.value) || 100),
   };
 }
 
@@ -457,6 +507,7 @@ function undo() {
     return;
   }
   stopAnimation();
+  pushRedoSnapshot();
   const previous = JSON.parse(history.pop());
   segments = previous.segments;
   pairQueue = previous.pairQueue || [];
@@ -466,6 +517,24 @@ function undo() {
   shapeHint.textContent = '形状判定: まだ候補はありません';
   refreshSegmentUI();
   setStatus('1操作戻しました。');
+}
+
+function redo() {
+  if (!redoHistory.length) {
+    setStatus('Redoできる操作がありません。');
+    return;
+  }
+  stopAnimation();
+  history.push(JSON.stringify({ segments, pairQueue }));
+  const next = JSON.parse(redoHistory.pop());
+  segments = next.segments;
+  pairQueue = next.pairQueue || [];
+  interpolationLines = [];
+  renderCursor = 0;
+  shapeRecommendation = null;
+  shapeHint.textContent = '形状判定: まだ候補はありません';
+  refreshSegmentUI();
+  setStatus('1操作進めました。');
 }
 
 function clearAll() {
@@ -501,7 +570,7 @@ function exportPng() {
 
 function onPointerDown(evt) {
   canvas.setPointerCapture(evt.pointerId);
-  drawStart = getPointerPos(evt);
+  drawStart = snapToGrid(getPointerPos(evt));
   drawCurrent = drawStart;
   drawing = true;
   redraw();
@@ -509,13 +578,13 @@ function onPointerDown(evt) {
 
 function onPointerMove(evt) {
   if (!drawing) return;
-  drawCurrent = getPointerPos(evt);
+  drawCurrent = snapToGrid(getPointerPos(evt));
   redraw();
 }
 
 function onPointerUp(evt) {
   if (!drawing) return;
-  const end = getPointerPos(evt);
+  const end = snapToGrid(getPointerPos(evt));
   drawing = false;
 
   const length = Math.hypot(end.x - drawStart.x, end.y - drawStart.y);
@@ -598,6 +667,17 @@ canvas.addEventListener('pointerleave', onPointerUp);
   el.addEventListener('change', redraw);
 });
 
+[divisionsInput, intervalInput, gridSizeInput].forEach((input) => {
+  input.addEventListener('input', () => {
+    divisionsValue.textContent = divisionsInput.value;
+    intervalValue.textContent = intervalInput.value;
+    gridSizeValue.textContent = gridSizeInput.value;
+    rebuildAutoPairQueue();
+    renderPairQueue();
+    redraw();
+  });
+});
+
 clearQueueBtn.addEventListener('click', () => {
   if (!segments.length) return;
   pushHistorySnapshot();
@@ -627,9 +707,14 @@ stopBtn.addEventListener('click', () => {
 
 resetRenderBtn.addEventListener('click', resetRender);
 undoBtn.addEventListener('click', undo);
+redoBtn.addEventListener('click', redo);
 clearBtn.addEventListener('click', clearAll);
 exportBtn.addEventListener('click', exportPng);
 metricsBtn.addEventListener('click', runMetrics);
+togglePanelBtn.addEventListener('click', () => {
+  settingsPanel.classList.toggle('hidden');
+  togglePanelBtn.textContent = settingsPanel.classList.contains('hidden') ? '⚙ Settings' : '✕ Close Settings';
+});
 
 window.addEventListener('keydown', (evt) => {
   if (evt.key.toLowerCase() === 'g') generateBtn.click();
@@ -643,5 +728,8 @@ window.addEventListener('keydown', (evt) => {
   });
 });
 
+divisionsValue.textContent = divisionsInput.value;
+intervalValue.textContent = intervalInput.value;
+gridSizeValue.textContent = gridSizeInput.value;
 refreshSegmentUI();
 setStatus('キャンバスをドラッグして線分を作成してください。');

--- a/game69/style.css
+++ b/game69/style.css
@@ -1,10 +1,10 @@
 :root {
-  --bg: #f2f3f5;
+  --bg: #eef1f6;
   --panel: #ffffff;
   --ink: #1f2937;
   --muted: #6b7280;
   --accent: #2256d8;
-  --line: #d1d5db;
+  --line: #d7dce5;
 }
 
 * { box-sizing: border-box; }
@@ -17,54 +17,107 @@ body {
   color: var(--ink);
 }
 
-.topbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 18px;
-  border-bottom: 1px solid var(--line);
-  background: var(--panel);
-}
-
-.topbar h1 { margin: 0; font-size: 1.1rem; }
-.topbar-actions, .panel-actions, .pair-queue-actions { display: flex; gap: 8px; flex-wrap: wrap; }
 button, input, select { font: inherit; }
 
 button {
   border: 1px solid #c3cad8;
   background: #fff;
   color: var(--ink);
-  border-radius: 8px;
-  padding: 7px 11px;
+  border-radius: 9px;
+  padding: 6px 10px;
   cursor: pointer;
+  font-size: 0.86rem;
 }
 
 button.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
 
-.layout {
+.app-shell {
+  height: calc(100vh - 46px);
   display: grid;
-  grid-template-columns: 340px 1fr;
-  gap: 14px;
-  padding: 14px;
+  grid-template-rows: 1fr auto;
+  padding: 10px;
+  gap: 10px;
+}
+
+.canvas-stage {
+  position: relative;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 68px 10px 10px;
+  overflow: hidden;
+}
+
+.canvas-toolbar {
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.canvas-toolbar.row1 { top: 10px; }
+.canvas-toolbar.row2 { top: 40px; }
+
+.toolbar-left,
+.topbar-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.icon-btn { margin-left: auto; }
+
+canvas {
+  width: 100%;
+  height: 100%;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  touch-action: none;
 }
 
 .panel {
   background: var(--panel);
   border: 1px solid var(--line);
   border-radius: 12px;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  max-height: calc(100vh - 128px);
-  overflow: auto;
+  padding: 10px;
+  display: grid;
+  gap: 10px;
 }
 
-.panel section { display: flex; flex-direction: column; gap: 8px; }
-.panel h2 { margin: 0; font-size: 0.95rem; }
-.hint { margin: 0; font-size: 0.8rem; color: var(--muted); }
+.panel.hidden { display: none; }
 
-.legend { display: flex; gap: 10px; font-size: 0.8rem; color: #374151; }
+.compact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 8px;
+}
+
+.slider-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px;
+}
+
+label { display: grid; gap: 4px; font-size: 0.82rem; }
+
+.inline-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid #e6e9ef;
+  border-radius: 8px;
+  padding: 7px;
+}
+
+input[type='range'] { width: 100%; }
+
+.hint { margin: 0; font-size: 0.78rem; color: var(--muted); }
+
+.legend { display: flex; gap: 10px; font-size: 0.78rem; color: #374151; }
 .dot {
   display: inline-block;
   width: 10px;
@@ -75,38 +128,14 @@ button.primary { background: var(--accent); color: #fff; border-color: var(--acc
 .dot.start { background: #2563eb; }
 .dot.end { background: #db2777; }
 
-label { display: grid; gap: 4px; font-size: 0.88rem; }
-
-.inline-toggle {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 0.82rem;
-}
-
 .segment-list {
   margin: 0;
   padding-left: 18px;
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   display: grid;
-  gap: 4px;
-}
-
-.canvas-wrap {
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  padding: 10px;
+  gap: 2px;
+  max-height: 86px;
   overflow: auto;
-}
-
-canvas {
-  width: 100%;
-  max-width: 1000px;
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-  touch-action: none;
 }
 
 .metrics {
@@ -115,8 +144,8 @@ canvas {
   border: 1px solid var(--line);
   border-radius: 8px;
   background: #f9fafb;
-  font-size: 0.75rem;
-  min-height: 80px;
+  font-size: 0.74rem;
+  min-height: 74px;
   white-space: pre-wrap;
 }
 
@@ -125,9 +154,10 @@ canvas {
   padding: 10px 14px;
   background: var(--panel);
   color: #111827;
+  font-size: 0.88rem;
 }
 
-@media (max-width: 980px) {
-  .layout { grid-template-columns: 1fr; }
-  .panel { max-height: none; }
+@media (max-width: 800px) {
+  .app-shell { height: auto; }
+  .canvas-stage { min-height: 55vh; }
 }


### PR DESCRIPTION
### Motivation
- Make the drawing experience canvas-first by placing the canvas at the top and moving controls/settings below so users can draw full-screen and see results immediately.
- Improve symmetry-friendly drawing by adding a visible grid and snapping endpoints to grid intersections for neater, left-right symmetric segments.
- Reduce UI friction by replacing number inputs with sliders for `Divisions` and `Interval`, set sensible defaults (`Mode=sequential`, `Divisions=10`, `Interval=100ms`), and make controls more compact.
- Add basic history navigation with `Redo` and a settings toggle so common actions are available at the canvas top-left/right.

### Description
- Reworked layout in `game69/index.html` to a canvas-first `app-shell` with a two-row canvas toolbar: row 1 contains left-aligned `Undo / Redo / Clear` and a right-aligned `Settings` toggle, row 2 contains `Render Start / Render Reset`, and the settings panel is collapsible.
- Replaced number inputs with sliders and live labels for `Divisions` and `Interval`, added a `Grid mesh` slider, and set defaults to `Divisions=10`, `Interval=100ms`, and `Mode=sequential` in `index.html` and `script.js`.
- Implemented canvas grid rendering and grid-snapping for segment endpoints in `game69/script.js` via `drawGrid()`, `snapToGrid()`, and `getGridSize()` using the `gridSizeInput` slider.
- Added `Redo` support and a redo stack (`redoHistory`) with corresponding UI hookup for the new `redoBtn` and snapshot management in `script.js`.
- Adjusted styling in `game69/style.css` to make the controls more compact, introduce layout for the canvas toolbar and settings panel (`.app-shell`, `.canvas-stage`, `.compact-grid`, `.slider-grid`), and tuned visual tokens (colors, spacing, font sizes).

### Testing
- Ran unit tests: `node game69/stringArtCore.test.js` — passed.
- Performed static checks: `node --check game69/script.js` — no syntax errors.
- Performed static checks: `node --check game69/stringArtCore.js` — no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bf8018348325ba6841ec2c791daa)