### PR TITLE
game69: fullscreen canvas, compact settings panel, and gradient/rainbow string styles

### DIFF
--- a/game69/index.html
+++ b/game69/index.html
@@ -8,14 +8,17 @@
   </head>
   <body>
     <main class="app-shell">
-      <section class="canvas-stage">
+      <section id="canvasStage" class="canvas-stage">
         <div class="canvas-toolbar row1">
           <div class="toolbar-left">
             <button id="undoBtn">Undo</button>
             <button id="redoBtn">Redo</button>
             <button id="clearBtn">Clear</button>
           </div>
-          <button id="togglePanelBtn" class="icon-btn">⚙ Settings</button>
+          <div class="toolbar-right">
+            <button id="togglePanelBtn" class="icon-btn">⚙ Settings</button>
+            <button id="fullscreenBtn">⛶ Fullscreen</button>
+          </div>
         </div>
         <div class="canvas-toolbar row2">
           <div class="toolbar-left">
@@ -24,89 +27,96 @@
           </div>
         </div>
         <canvas id="canvas" width="1000" height="700" aria-label="string art canvas"></canvas>
+
+        <aside id="settingsPanel" class="panel hidden">
+          <section class="compact-grid">
+            <label>
+              Segment A
+              <select id="segmentASelect"></select>
+            </label>
+            <label>
+              Direction A
+              <select id="directionASelect">
+                <option value="start_to_end">start → end</option>
+                <option value="end_to_start">end → start</option>
+              </select>
+            </label>
+            <label>
+              Segment B
+              <select id="segmentBSelect"></select>
+            </label>
+            <label>
+              Direction B
+              <select id="directionBSelect">
+                <option value="start_to_end">start → end</option>
+                <option value="end_to_start">end → start</option>
+              </select>
+            </label>
+          </section>
+
+          <section class="slider-grid">
+            <label>
+              Divisions: <strong id="divisionsValue">10</strong>
+              <input id="divisionsInput" type="range" min="2" max="300" value="10" />
+            </label>
+            <label>
+              Interval (ms): <strong id="intervalValue">100</strong>
+              <input id="intervalInput" type="range" min="5" max="1000" step="5" value="100" />
+            </label>
+            <label>
+              Grid mesh: <strong id="gridSizeValue">40</strong>
+              <input id="gridSizeInput" type="range" min="10" max="100" step="2" value="40" />
+            </label>
+          </section>
+
+          <section class="compact-grid">
+            <label>
+              Mode
+              <select id="modeSelect">
+                <option value="sequential" selected>Sequential</option>
+                <option value="instant">Instant</option>
+              </select>
+            </label>
+            <label>
+              String style
+              <select id="stringStyleSelect">
+                <option value="solid" selected>Solid</option>
+                <option value="gradient">Gradient</option>
+                <option value="rainbow">Rainbow</option>
+              </select>
+            </label>
+            <label>
+              Color A
+              <input id="stringColorInput" type="color" value="#8c3f2d" />
+            </label>
+            <label>
+              Color B
+              <input id="stringColor2Input" type="color" value="#22d3ee" />
+            </label>
+            <label>
+              String Width
+              <input id="stringWidthInput" type="number" min="1" max="4" step="0.5" value="1.2" />
+            </label>
+            <label class="inline-toggle">
+              <input id="shapeAssistCheckbox" type="checkbox" checked />
+              図形入力補助
+            </label>
+          </section>
+
+          <section>
+            <div class="topbar-actions">
+              <button id="exportBtn">Export PNG</button>
+            </div>
+            <p id="shapeHint" class="hint">形状判定: まだ候補はありません</p>
+            <div class="legend">
+              <span><i class="dot start"></i>start点</span>
+              <span><i class="dot end"></i>end点</span>
+            </div>
+            <ul id="segmentList" class="segment-list"></ul>
+            <ul id="pairQueueList" class="segment-list"></ul>
+          </section>
+        </aside>
       </section>
-
-      <aside id="settingsPanel" class="panel">
-        <section class="compact-grid">
-          <label>
-            Segment A
-            <select id="segmentASelect"></select>
-          </label>
-          <label>
-            Direction A
-            <select id="directionASelect">
-              <option value="start_to_end">start → end</option>
-              <option value="end_to_start">end → start</option>
-            </select>
-          </label>
-          <label>
-            Segment B
-            <select id="segmentBSelect"></select>
-          </label>
-          <label>
-            Direction B
-            <select id="directionBSelect">
-              <option value="start_to_end">start → end</option>
-              <option value="end_to_start">end → start</option>
-            </select>
-          </label>
-        </section>
-
-        <section class="slider-grid">
-          <label>
-            Divisions: <strong id="divisionsValue">10</strong>
-            <input id="divisionsInput" type="range" min="2" max="300" value="10" />
-          </label>
-          <label>
-            Interval (ms): <strong id="intervalValue">100</strong>
-            <input id="intervalInput" type="range" min="5" max="1000" step="5" value="100" />
-          </label>
-          <label>
-            Grid mesh: <strong id="gridSizeValue">40</strong>
-            <input id="gridSizeInput" type="range" min="10" max="100" step="2" value="40" />
-          </label>
-        </section>
-
-        <section class="compact-grid">
-          <label>
-            Mode
-            <select id="modeSelect">
-              <option value="sequential" selected>Sequential</option>
-              <option value="instant">Instant</option>
-            </select>
-          </label>
-          <label>
-            String Color
-            <input id="stringColorInput" type="color" value="#8c3f2d" />
-          </label>
-          <label>
-            String Width
-            <input id="stringWidthInput" type="number" min="1" max="4" step="0.5" value="1.2" />
-          </label>
-          <label class="inline-toggle">
-            <input id="shapeAssistCheckbox" type="checkbox" checked />
-            図形入力補助
-          </label>
-        </section>
-
-        <section>
-          <div class="topbar-actions">
-            <button id="stopBtn">Stop</button>
-            <button id="clearQueueBtn">Clear Queue</button>
-            <button id="metricsBtn">Run Metrics</button>
-            <button id="exportBtn">Export PNG</button>
-          </div>
-          <p id="shapeHint" class="hint">形状判定: まだ候補はありません</p>
-          <div class="legend">
-            <span><i class="dot start"></i>start点</span>
-            <span><i class="dot end"></i>end点</span>
-          </div>
-          <ul id="segmentList" class="segment-list"></ul>
-          <ul id="pairQueueList" class="segment-list"></ul>
-        </section>
-
-        <pre id="metricsOutput" class="metrics">Metrics: not run</pre>
-      </aside>
     </main>
 
     <footer id="statusBar" class="status">Ready</footer>

--- a/game69/script.js
+++ b/game69/script.js
@@ -13,25 +13,25 @@ const gridSizeInput = document.getElementById('gridSizeInput');
 const divisionsValue = document.getElementById('divisionsValue');
 const intervalValue = document.getElementById('intervalValue');
 const gridSizeValue = document.getElementById('gridSizeValue');
+const stringStyleSelect = document.getElementById('stringStyleSelect');
 const stringColorInput = document.getElementById('stringColorInput');
+const stringColor2Input = document.getElementById('stringColor2Input');
 const stringWidthInput = document.getElementById('stringWidthInput');
 const statusBar = document.getElementById('statusBar');
-const metricsOutput = document.getElementById('metricsOutput');
-const clearQueueBtn = document.getElementById('clearQueueBtn');
 const pairQueueList = document.getElementById('pairQueueList');
 const shapeAssistCheckbox = document.getElementById('shapeAssistCheckbox');
 const shapeHint = document.getElementById('shapeHint');
+const canvasStage = document.getElementById('canvasStage');
 
 const generateBtn = document.getElementById('generateBtn');
-const stopBtn = document.getElementById('stopBtn');
 const resetRenderBtn = document.getElementById('resetRenderBtn');
 const undoBtn = document.getElementById('undoBtn');
 const redoBtn = document.getElementById('redoBtn');
 const clearBtn = document.getElementById('clearBtn');
 const exportBtn = document.getElementById('exportBtn');
-const metricsBtn = document.getElementById('metricsBtn');
 const settingsPanel = document.getElementById('settingsPanel');
 const togglePanelBtn = document.getElementById('togglePanelBtn');
+const fullscreenBtn = document.getElementById('fullscreenBtn');
 
 const core = window.StringArtCore;
 
@@ -181,15 +181,56 @@ function drawGrid() {
 }
 
 function drawInterpolationLines() {
-  ctx.strokeStyle = stringColorInput.value;
   ctx.lineWidth = Number(stringWidthInput.value);
-
-  interpolationLines.slice(0, renderCursor).forEach((line) => {
+  const visibleLines = interpolationLines.slice(0, renderCursor);
+  const lineCount = Math.max(visibleLines.length - 1, 1);
+  visibleLines.forEach((line, index) => {
+    ctx.strokeStyle = resolveStringColor(index / lineCount);
     ctx.beginPath();
     ctx.moveTo(line.p0.x, line.p0.y);
     ctx.lineTo(line.p1.x, line.p1.y);
     ctx.stroke();
   });
+}
+
+function hexToRgb(hex) {
+  const normalized = hex.replace('#', '');
+  const value = normalized.length === 3
+    ? normalized.split('').map((char) => `${char}${char}`).join('')
+    : normalized;
+
+  return {
+    r: Number.parseInt(value.slice(0, 2), 16),
+    g: Number.parseInt(value.slice(2, 4), 16),
+    b: Number.parseInt(value.slice(4, 6), 16),
+  };
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function rgbToCss(color) {
+  return `rgb(${Math.round(color.r)}, ${Math.round(color.g)}, ${Math.round(color.b)})`;
+}
+
+function resolveStringColor(progress) {
+  if (stringStyleSelect.value === 'rainbow') {
+    const hue = (progress * 320 + 280) % 360;
+    return `hsl(${hue} 92% 60%)`;
+  }
+
+  if (stringStyleSelect.value === 'gradient') {
+    const c1 = hexToRgb(stringColorInput.value);
+    const c2 = hexToRgb(stringColor2Input.value);
+    return rgbToCss({
+      r: lerp(c1.r, c2.r, progress),
+      g: lerp(c1.g, c2.g, progress),
+      b: lerp(c1.b, c2.b, progress),
+    });
+  }
+
+  return stringColorInput.value;
 }
 
 function drawShapeRecommendation() {
@@ -237,6 +278,51 @@ function redraw() {
   drawInterpolationLines();
   drawShapeRecommendation();
   drawDraftSegment();
+}
+
+function scalePoint(point, scaleX, scaleY) {
+  return { x: point.x * scaleX, y: point.y * scaleY };
+}
+
+function scaleScene(oldWidth, oldHeight, newWidth, newHeight) {
+  if (!oldWidth || !oldHeight || oldWidth === newWidth && oldHeight === newHeight) return;
+  const scaleX = newWidth / oldWidth;
+  const scaleY = newHeight / oldHeight;
+
+  segments = segments.map((segment) => ({
+    ...segment,
+    start: scalePoint(segment.start, scaleX, scaleY),
+    end: scalePoint(segment.end, scaleX, scaleY),
+  }));
+
+  interpolationLines = interpolationLines.map((line) => ({
+    p0: scalePoint(line.p0, scaleX, scaleY),
+    p1: scalePoint(line.p1, scaleX, scaleY),
+  }));
+
+  if (drawStart) drawStart = scalePoint(drawStart, scaleX, scaleY);
+  if (drawCurrent) drawCurrent = scalePoint(drawCurrent, scaleX, scaleY);
+
+  if (shapeRecommendation?.idealVertices?.length) {
+    shapeRecommendation = {
+      ...shapeRecommendation,
+      idealVertices: shapeRecommendation.idealVertices.map((point) => scalePoint(point, scaleX, scaleY)),
+    };
+  }
+}
+
+function resizeCanvasToStage() {
+  const rect = canvas.getBoundingClientRect();
+  const newWidth = Math.max(640, Math.floor(rect.width));
+  const newHeight = Math.max(360, Math.floor(rect.height));
+  if (canvas.width === newWidth && canvas.height === newHeight) return;
+
+  const oldWidth = canvas.width;
+  const oldHeight = canvas.height;
+  canvas.width = newWidth;
+  canvas.height = newHeight;
+  scaleScene(oldWidth, oldHeight, newWidth, newHeight);
+  redraw();
 }
 
 function renderPairQueue() {
@@ -611,59 +697,12 @@ function onPointerUp(evt) {
   }
 }
 
-function runMetrics() {
-  if (segments.length < 2 || !segmentASelect.value || !segmentBSelect.value) {
-    setStatus('Metrics実行には線分2本以上とA/B選択が必要です。');
-    return;
-  }
-
-  const cases = [50, 100, 200];
-  const output = [];
-
-  cases.forEach((divisions) => {
-    const job = {
-      segmentAId: segmentASelect.value,
-      segmentBId: segmentBSelect.value,
-      directionA: directionASelect.value,
-      directionB: directionBSelect.value,
-      divisions,
-    };
-
-    const t0 = performance.now();
-    const lines = buildInterpolationLines(job);
-    const t1 = performance.now();
-
-    const firstLine = lines[0];
-    const drawStartMs = performance.now();
-    ctx.beginPath();
-    ctx.moveTo(firstLine.p0.x, firstLine.p0.y);
-    ctx.lineTo(firstLine.p1.x, firstLine.p1.y);
-    ctx.stroke();
-    const drawEndMs = performance.now();
-
-    output.push({
-      divisions,
-      buildMs: (t1 - t0).toFixed(2),
-      firstDrawMs: (drawEndMs - drawStartMs).toFixed(2),
-      lineCount: lines.length,
-    });
-  });
-
-  metricsOutput.textContent = [
-    'Metrics Results (local runtime):',
-    ...output.map((r) => `N=${r.divisions}: build=${r.buildMs}ms, firstDraw=${r.firstDrawMs}ms, lines=${r.lineCount}`),
-  ].join('\n');
-
-  redraw();
-  setStatus('Metricsを更新しました。');
-}
-
 canvas.addEventListener('pointerdown', onPointerDown);
 canvas.addEventListener('pointermove', onPointerMove);
 canvas.addEventListener('pointerup', onPointerUp);
 canvas.addEventListener('pointerleave', onPointerUp);
 
-[segmentASelect, segmentBSelect, stringColorInput, stringWidthInput].forEach((el) => {
+[segmentASelect, segmentBSelect, stringColorInput, stringColor2Input, stringStyleSelect, stringWidthInput].forEach((el) => {
   el.addEventListener('change', redraw);
 });
 
@@ -678,20 +717,6 @@ canvas.addEventListener('pointerleave', onPointerUp);
   });
 });
 
-clearQueueBtn.addEventListener('click', () => {
-  if (!segments.length) return;
-  pushHistorySnapshot();
-  stopAnimation();
-  segments = [];
-  interpolationLines = [];
-  renderCursor = 0;
-  pairQueue = [];
-  shapeRecommendation = null;
-  shapeHint.textContent = '形状判定: まだ候補はありません';
-  refreshSegmentUI();
-  setStatus('線分とQueueをクリアしました。');
-});
-
 generateBtn.addEventListener('click', () => {
   try {
     startRender(validateBaseJob());
@@ -700,21 +725,35 @@ generateBtn.addEventListener('click', () => {
   }
 });
 
-stopBtn.addEventListener('click', () => {
-  stopAnimation();
-  setStatus('描画を停止しました。');
-});
-
 resetRenderBtn.addEventListener('click', resetRender);
 undoBtn.addEventListener('click', undo);
 redoBtn.addEventListener('click', redo);
 clearBtn.addEventListener('click', clearAll);
 exportBtn.addEventListener('click', exportPng);
-metricsBtn.addEventListener('click', runMetrics);
 togglePanelBtn.addEventListener('click', () => {
   settingsPanel.classList.toggle('hidden');
   togglePanelBtn.textContent = settingsPanel.classList.contains('hidden') ? '⚙ Settings' : '✕ Close Settings';
 });
+fullscreenBtn.addEventListener('click', async () => {
+  try {
+    if (document.fullscreenElement === canvasStage) {
+      await document.exitFullscreen();
+    } else {
+      await canvasStage.requestFullscreen();
+    }
+  } catch (error) {
+    setStatus(`Fullscreen切り替えに失敗: ${error.message}`);
+  }
+});
+
+document.addEventListener('fullscreenchange', () => {
+  const inFullscreen = document.fullscreenElement === canvasStage;
+  canvasStage.classList.toggle('is-fullscreen', inFullscreen);
+  fullscreenBtn.textContent = inFullscreen ? '🡼 Exit Fullscreen' : '⛶ Fullscreen';
+  resizeCanvasToStage();
+});
+
+window.addEventListener('resize', resizeCanvasToStage);
 
 window.addEventListener('keydown', (evt) => {
   if (evt.key.toLowerCase() === 'g') generateBtn.click();
@@ -731,5 +770,6 @@ window.addEventListener('keydown', (evt) => {
 divisionsValue.textContent = divisionsInput.value;
 intervalValue.textContent = intervalInput.value;
 gridSizeValue.textContent = gridSizeInput.value;
+resizeCanvasToStage();
 refreshSegmentUI();
 setStatus('キャンバスをドラッグして線分を作成してください。');

--- a/game69/style.css
+++ b/game69/style.css
@@ -24,19 +24,18 @@ button {
   background: #fff;
   color: var(--ink);
   border-radius: 9px;
-  padding: 6px 10px;
+  padding: 6px 9px;
   cursor: pointer;
-  font-size: 0.86rem;
+  font-size: 0.8rem;
+  line-height: 1.1;
 }
 
 button.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
 
 .app-shell {
   height: calc(100vh - 46px);
-  display: grid;
-  grid-template-rows: 1fr auto;
+  display: block;
   padding: 10px;
-  gap: 10px;
 }
 
 .canvas-stage {
@@ -44,8 +43,9 @@ button.primary { background: var(--accent); color: #fff; border-color: var(--acc
   background: var(--panel);
   border: 1px solid var(--line);
   border-radius: 12px;
-  padding: 68px 10px 10px;
+  padding: 82px 10px 10px;
   overflow: hidden;
+  height: 100%;
 }
 
 .canvas-toolbar {
@@ -59,7 +59,7 @@ button.primary { background: var(--accent); color: #fff; border-color: var(--acc
 }
 
 .canvas-toolbar.row1 { top: 10px; }
-.canvas-toolbar.row2 { top: 40px; }
+.canvas-toolbar.row2 { top: 46px; }
 
 .toolbar-left,
 .topbar-actions {
@@ -68,7 +68,11 @@ button.primary { background: var(--accent); color: #fff; border-color: var(--acc
   flex-wrap: wrap;
 }
 
-.icon-btn { margin-left: auto; }
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
 
 canvas {
   width: 100%;
@@ -80,25 +84,33 @@ canvas {
 }
 
 .panel {
+  position: absolute;
+  top: 86px;
+  right: 10px;
+  bottom: 10px;
+  width: min(460px, 95vw);
   background: var(--panel);
   border: 1px solid var(--line);
   border-radius: 12px;
   padding: 10px;
   display: grid;
   gap: 10px;
+  overflow: auto;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.22);
+  backdrop-filter: blur(6px);
 }
 
 .panel.hidden { display: none; }
 
 .compact-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 8px;
 }
 
 .slider-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 8px;
 }
 
@@ -149,6 +161,18 @@ input[type='range'] { width: 100%; }
   white-space: pre-wrap;
 }
 
+.canvas-stage:fullscreen,
+.canvas-stage.is-fullscreen {
+  border-radius: 0;
+  border: none;
+  padding-top: 86px;
+}
+
+.canvas-stage:fullscreen canvas,
+.canvas-stage.is-fullscreen canvas {
+  border-radius: 10px;
+}
+
 .status {
   border-top: 1px solid var(--line);
   padding: 10px 14px;
@@ -160,4 +184,8 @@ input[type='range'] { width: 100%; }
 @media (max-width: 800px) {
   .app-shell { height: auto; }
   .canvas-stage { min-height: 55vh; }
+  .panel {
+    left: 10px;
+    width: auto;
+  }
 }


### PR DESCRIPTION
### Motivation
- Provide a fullscreen drawing stage with a two-row toolbar so top-row controls (Undo/Redo/Clear left, Settings/Fullscreen right) and second-row render controls do not overlap.  
- Make the settings UI more compact and overlayed so it is usable in fullscreen, remove unused actions (`Stop`, `Clear Queue`, `Run Metrics`) and replace fiddly numeric inputs with sliders for faster interaction.  
- Add digital-art oriented string styling (solid / gradient / rainbow) and expose a grid-mesh slider so artists can tune mesh density interactively.

### Description
- Updated `game69/index.html` to introduce `id="canvasStage"`, add a `Fullscreen` button, move settings into an in-canvas overlay panel, and add `stringStyleSelect` plus a second color input (`stringColor2Input`).  
- Adjusted `game69/style.css` to implement the two-row toolbar layout, compact control sizing, overlayed settings panel, and fullscreen styling for the `.canvas-stage`.  
- Enhanced `game69/script.js` with per-line color resolution (`hexToRgb`, `lerp`, `rgbToCss`, `resolveStringColor`) to support `solid`, `gradient`, and `rainbow` styles and changed `drawInterpolationLines` to use a computed color per line.  
- Implemented responsive canvas resizing and scene scaling (`resizeCanvasToStage`, `scaleScene`, `scalePoint`) that preserves/ scales existing segments, interpolation lines and guide geometry during window and fullscreen size changes, removed `runMetrics` and clear-queue/stop UI hooks, and added fullscreen toggle handlers and initial resize call.

### Testing
- Ran `node --check game69/script.js` which completed without syntax errors.  
- Ran `node game69/stringArtCore.test.js` which reported `stringArtCore tests: pass`.  
- Ran `node game69/benchmarks/stringArtBenchmark.js` which executed and returned performance data for `N=50/100/200` cases (benchmarks completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c4b338b4832596dfc7f74ae04131)