### PR TITLE
game69: Fix fullscreen behavior, toolbar/panel stacking and scroll issues

### DIFF
--- a/game69/script.js
+++ b/game69/script.js
@@ -54,6 +54,8 @@ let animationState = {
   intervalMs: 100,
 };
 
+let pseudoFullscreen = false;
+
 function setStatus(message) {
   statusBar.textContent = message;
 }
@@ -734,22 +736,80 @@ togglePanelBtn.addEventListener('click', () => {
   settingsPanel.classList.toggle('hidden');
   togglePanelBtn.textContent = settingsPanel.classList.contains('hidden') ? '⚙ Settings' : '✕ Close Settings';
 });
+function setPseudoFullscreen(enabled) {
+  pseudoFullscreen = enabled;
+  canvasStage.classList.toggle('is-pseudo-fullscreen', enabled);
+  document.body.classList.toggle('pseudo-fullscreen-active', enabled);
+}
+
+function isCanvasInNativeFullscreen() {
+  return document.fullscreenElement === canvasStage;
+}
+
+async function enterNativeFullscreen() {
+  if (typeof canvasStage.requestFullscreen === 'function') {
+    await canvasStage.requestFullscreen();
+    return true;
+  }
+
+  const webkitRequest = canvasStage.webkitRequestFullscreen || canvasStage.webkitEnterFullscreen;
+  if (typeof webkitRequest === 'function') {
+    webkitRequest.call(canvasStage);
+    return true;
+  }
+
+  return false;
+}
+
+async function exitNativeFullscreen() {
+  if (typeof document.exitFullscreen === 'function' && document.fullscreenElement) {
+    await document.exitFullscreen();
+    return true;
+  }
+
+  if (typeof document.webkitExitFullscreen === 'function') {
+    document.webkitExitFullscreen();
+    return true;
+  }
+
+  return false;
+}
+
 fullscreenBtn.addEventListener('click', async () => {
   try {
-    if (document.fullscreenElement === canvasStage) {
-      await document.exitFullscreen();
-    } else {
-      await canvasStage.requestFullscreen();
+    if (isCanvasInNativeFullscreen()) {
+      await exitNativeFullscreen();
+      return;
+    }
+
+    if (pseudoFullscreen) {
+      setPseudoFullscreen(false);
+      fullscreenBtn.textContent = '⛶ Fullscreen';
+      resizeCanvasToStage();
+      setStatus('全画面表示を終了しました。');
+      return;
+    }
+
+    const entered = await enterNativeFullscreen();
+    if (!entered) {
+      setPseudoFullscreen(true);
+      fullscreenBtn.textContent = '🡼 Exit Fullscreen';
+      resizeCanvasToStage();
+      setStatus('全画面API非対応のため、擬似全画面モードで表示中です。');
     }
   } catch (error) {
-    setStatus(`Fullscreen切り替えに失敗: ${error.message}`);
+    setPseudoFullscreen(true);
+    fullscreenBtn.textContent = '🡼 Exit Fullscreen';
+    resizeCanvasToStage();
+    setStatus(`Fullscreen APIで失敗したため擬似全画面に切替: ${error.message}`);
   }
 });
 
 document.addEventListener('fullscreenchange', () => {
-  const inFullscreen = document.fullscreenElement === canvasStage;
+  const inFullscreen = isCanvasInNativeFullscreen();
+  if (inFullscreen && pseudoFullscreen) setPseudoFullscreen(false);
   canvasStage.classList.toggle('is-fullscreen', inFullscreen);
-  fullscreenBtn.textContent = inFullscreen ? '🡼 Exit Fullscreen' : '⛶ Fullscreen';
+  fullscreenBtn.textContent = (inFullscreen || pseudoFullscreen) ? '🡼 Exit Fullscreen' : '⛶ Fullscreen';
   resizeCanvasToStage();
 });
 

--- a/game69/style.css
+++ b/game69/style.css
@@ -9,6 +9,13 @@
 
 * { box-sizing: border-box; }
 
+html,
+body {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
@@ -56,6 +63,7 @@ button.primary { background: var(--accent); color: #fff; border-color: var(--acc
   justify-content: space-between;
   align-items: center;
   gap: 8px;
+  z-index: 3;
 }
 
 .canvas-toolbar.row1 { top: 10px; }
@@ -77,6 +85,7 @@ button.primary { background: var(--accent); color: #fff; border-color: var(--acc
 canvas {
   width: 100%;
   height: 100%;
+  display: block;
   background: #fff;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
@@ -89,15 +98,19 @@ canvas {
   right: 10px;
   bottom: 10px;
   width: min(460px, 95vw);
+  max-height: calc(100% - 96px);
   background: var(--panel);
   border: 1px solid var(--line);
   border-radius: 12px;
   padding: 10px;
   display: grid;
   gap: 10px;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  z-index: 4;
   box-shadow: 0 16px 40px rgba(15, 23, 42, 0.22);
   backdrop-filter: blur(6px);
+  touch-action: pan-y;
 }
 
 .panel.hidden { display: none; }
@@ -162,15 +175,29 @@ input[type='range'] { width: 100%; }
 }
 
 .canvas-stage:fullscreen,
-.canvas-stage.is-fullscreen {
+.canvas-stage.is-fullscreen,
+.canvas-stage.is-pseudo-fullscreen {
   border-radius: 0;
   border: none;
   padding-top: 86px;
 }
 
 .canvas-stage:fullscreen canvas,
-.canvas-stage.is-fullscreen canvas {
+.canvas-stage.is-fullscreen canvas,
+.canvas-stage.is-pseudo-fullscreen canvas {
   border-radius: 10px;
+}
+
+
+body.pseudo-fullscreen-active {
+  overflow: hidden;
+}
+
+.canvas-stage.is-pseudo-fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: var(--panel);
 }
 
 .status {
@@ -182,10 +209,11 @@ input[type='range'] { width: 100%; }
 }
 
 @media (max-width: 800px) {
-  .app-shell { height: auto; }
+  .app-shell { height: auto; min-height: calc(100dvh - 46px); }
   .canvas-stage { min-height: 55vh; }
   .panel {
     left: 10px;
     width: auto;
+    max-height: calc(100dvh - 120px);
   }
 }


### PR DESCRIPTION
### Motivation
- 全画面ボタンでエラーが出る／全画面時にツールバー（`Clear` 等）が操作できない状態／非全画面で左右スクロールが出る／設定パネルの縦スクロールができず内容が見切れる問題を解消するため。

### Description
- `game69/script.js` に擬似全画面用の状態管理 `pseudoFullscreen` と補助関数 `setPseudoFullscreen`, `enterNativeFullscreen`, `exitNativeFullscreen`, `isCanvasInNativeFullscreen` を追加し、ネイティブ Fullscreen API が使えない／失敗した場合にフォールバックする実装にした。 
- 全画面トグル処理を修正してボタンラベルの整合性を保ち、`fullscreenchange` イベントでネイティブ／擬似の状態を正しく反映するようにした。 
- `game69/style.css` を更新して `html, body { overflow-x: hidden; }` を追加し水平スクロールを抑止し、ツールバーとパネルに `z-index` を与えてボタン重なりを解消した。 
- 設定パネルの `max-height`/`overflow-y`/`overflow-x`/`touch-action` を改善し、モバイル用に `100dvh` ベースの高さ制約を追加、擬似全画面用のスタイル（`.is-pseudo-fullscreen` / `body.pseudo-fullscreen-active`）を導入した。 

### Testing
- `node --check game69/script.js` を実行して構文チェックは成功しました。 
- `node --check game69/stringArtCore.js` を実行して構文チェックは成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ffa3d9a4832580bd587635249de9)