### PR TITLE
game69: fix fullscreen scaling distortion and mobile overflow

### DIFF
--- a/game69/script.js
+++ b/game69/script.js
@@ -282,41 +282,42 @@ function redraw() {
   drawDraftSegment();
 }
 
-function scalePoint(point, scaleX, scaleY) {
-  return { x: point.x * scaleX, y: point.y * scaleY };
-}
-
 function scaleScene(oldWidth, oldHeight, newWidth, newHeight) {
   if (!oldWidth || !oldHeight || oldWidth === newWidth && oldHeight === newHeight) return;
-  const scaleX = newWidth / oldWidth;
-  const scaleY = newHeight / oldHeight;
+  const uniformScale = Math.min(newWidth / oldWidth, newHeight / oldHeight);
+  const offsetX = (newWidth - oldWidth * uniformScale) / 2;
+  const offsetY = (newHeight - oldHeight * uniformScale) / 2;
+  const scalePointWithOffset = (point) => ({
+    x: point.x * uniformScale + offsetX,
+    y: point.y * uniformScale + offsetY,
+  });
 
   segments = segments.map((segment) => ({
     ...segment,
-    start: scalePoint(segment.start, scaleX, scaleY),
-    end: scalePoint(segment.end, scaleX, scaleY),
+    start: scalePointWithOffset(segment.start),
+    end: scalePointWithOffset(segment.end),
   }));
 
   interpolationLines = interpolationLines.map((line) => ({
-    p0: scalePoint(line.p0, scaleX, scaleY),
-    p1: scalePoint(line.p1, scaleX, scaleY),
+    p0: scalePointWithOffset(line.p0),
+    p1: scalePointWithOffset(line.p1),
   }));
 
-  if (drawStart) drawStart = scalePoint(drawStart, scaleX, scaleY);
-  if (drawCurrent) drawCurrent = scalePoint(drawCurrent, scaleX, scaleY);
+  if (drawStart) drawStart = scalePointWithOffset(drawStart);
+  if (drawCurrent) drawCurrent = scalePointWithOffset(drawCurrent);
 
   if (shapeRecommendation?.idealVertices?.length) {
     shapeRecommendation = {
       ...shapeRecommendation,
-      idealVertices: shapeRecommendation.idealVertices.map((point) => scalePoint(point, scaleX, scaleY)),
+      idealVertices: shapeRecommendation.idealVertices.map((point) => scalePointWithOffset(point)),
     };
   }
 }
 
 function resizeCanvasToStage() {
   const rect = canvas.getBoundingClientRect();
-  const newWidth = Math.max(640, Math.floor(rect.width));
-  const newHeight = Math.max(360, Math.floor(rect.height));
+  const newWidth = Math.max(280, Math.floor(rect.width));
+  const newHeight = Math.max(220, Math.floor(rect.height));
   if (canvas.width === newWidth && canvas.height === newHeight) return;
 
   const oldWidth = canvas.width;

--- a/game69/style.css
+++ b/game69/style.css
@@ -63,6 +63,7 @@ button.primary { background: var(--accent); color: #fff; border-color: var(--acc
   justify-content: space-between;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
   z-index: 3;
 }
 
@@ -74,12 +75,16 @@ button.primary { background: var(--accent); color: #fff; border-color: var(--acc
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
+  min-width: 0;
 }
 
 .toolbar-right {
   display: flex;
   align-items: center;
   gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  min-width: 0;
 }
 
 canvas {
@@ -215,5 +220,15 @@ body.pseudo-fullscreen-active {
     left: 10px;
     width: auto;
     max-height: calc(100dvh - 120px);
+  }
+}
+
+@media (max-width: 560px) {
+  .canvas-stage {
+    padding-top: 118px;
+  }
+
+  .canvas-toolbar.row2 {
+    top: 74px;
   }
 }


### PR DESCRIPTION
### Motivation

- 全画面化するとキャンバスの描画が縦方向に引き伸ばされてしまう問題を修正するため。  
- 狭い画面でツールバーが折り返さず横スクロールを生んでいたため、モバイルでの横スクロールを無くすため。  

### Description

- `game69/script.js`: `scaleScene` を等倍率（uniform scale）＋中央寄せオフセットに差し替え、独立X/Yスケールによる縦横比崩れを防止しました。  
- `game69/script.js`: 最小キャンバスサイズを `640x360` から `280x220` に引き下げ、極小ビューポートでの横スクロール発生を抑制しました。  
- `game69/style.css`: `.canvas-toolbar` と右側ボタン群に `flex-wrap` と `min-width: 0` を追加し、狭い幅でボタンが折り返すようにして横スクロールを防止しました。  
- `game69/style.css`: 小画面向けにメディアクエリ（`@media (max-width: 560px)`）でステージ上部の余白と第2行ツールバー位置を調整して重なりを回避しました。  

### Testing

- 自動テストとして `node game69/stringArtCore.test.js` を実行し、テストは成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50407fd0883259a67b2488bb36f54)