### PR TITLE
Add game71: 四方観察トレーニング Webゲーム (Three.js, OrthographicCamera)

### DIFF
--- a/game71/app.js
+++ b/game71/app.js
@@ -1,0 +1,447 @@
+(() => {
+  const DIRECTION_SYMBOLS = { front: '○', right: '△', left: '□', back: '×', top: '☆' };
+  const LEVELS = [
+    { cubes: [2, 4], maxHeight: 2, directions: ['front', 'right'], options: [2, 2], black: [1, 1] },
+    { cubes: [4, 6], maxHeight: 3, directions: ['front', 'right', 'left'], options: [3, 4], black: [1, 2] },
+    { cubes: [6, 9], maxHeight: 3, directions: ['front', 'right', 'left', 'back'], options: [4, 4], black: [2, 3] },
+    { cubes: [7, 10], maxHeight: 4, directions: ['front', 'right', 'left', 'back', 'top'], options: [4, 5], black: [2, 3] },
+    { cubes: [8, 12], maxHeight: 4, directions: ['front', 'right', 'left', 'back', 'top'], options: [5, 6], black: [2, 4] }
+  ];
+
+  const sceneEl = document.getElementById('scene');
+  const promptEl = document.getElementById('prompt');
+  const feedbackEl = document.getElementById('feedback');
+  const analysisEl = document.getElementById('analysis');
+  const choicesEl = document.getElementById('choices');
+  const nextBtn = document.getElementById('nextBtn');
+  const levelLabel = document.getElementById('levelLabel');
+  const scoreLabel = document.getElementById('scoreLabel');
+  const normalModeBtn = document.getElementById('normalMode');
+  const hintModeBtn = document.getElementById('hintMode');
+  const hintRotateBtn = document.getElementById('hintRotate');
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+  const scene = new THREE.Scene();
+  const camera = new THREE.OrthographicCamera(-4.8, 4.8, 3.7, -3.7, 0.1, 100);
+  const board = new THREE.Group();
+  const raycaster = new THREE.Raycaster();
+  const ambient = new THREE.AmbientLight(0xffffff, 0.7);
+  const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+  directional.position.set(6, 10, 8);
+  scene.add(ambient, directional, board);
+
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+  sceneEl.appendChild(renderer.domElement);
+
+  const state = {
+    level: 1,
+    score: 0,
+    total: 0,
+    hintMode: false,
+    locked: false,
+    cubes: [],
+    targetDirection: 'right',
+    options: [],
+    correctOptionId: '',
+    answerDirection: 'right',
+    cameraTween: null,
+  };
+
+  const INITIAL_CAMERA = new THREE.Vector3(4.5, 3.2, 5.5);
+  const LOOK_AT = new THREE.Vector3(0, 0.8, 0);
+
+  function resize() {
+    const w = sceneEl.clientWidth;
+    const h = sceneEl.clientHeight;
+    renderer.setSize(w, h);
+    const aspect = w / h;
+    const view = 4.5;
+    camera.left = -view * aspect;
+    camera.right = view * aspect;
+    camera.top = view;
+    camera.bottom = -view;
+    camera.updateProjectionMatrix();
+  }
+
+  function randInt(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+
+  function keyOf({ x, y, z }) {
+    return `${x},${y},${z}`;
+  }
+
+  function generateCubes(level) {
+    const cfg = LEVELS[level - 1];
+    const cubeTarget = randInt(cfg.cubes[0], cfg.cubes[1]);
+    const gridRange = Math.max(2, Math.ceil(Math.sqrt(cubeTarget)));
+    const occupied = new Map();
+
+    function addCube(cube) { occupied.set(keyOf(cube), cube); }
+
+    addCube({ x: 0, y: 0, z: 0, color: 'white' });
+    while (occupied.size < cubeTarget) {
+      if (Math.random() < 0.45) {
+        const x = randInt(-gridRange, gridRange);
+        const z = randInt(-gridRange, gridRange);
+        const y = 0;
+        const k = keyOf({ x, y, z });
+        if (!occupied.has(k)) addCube({ x, y, z, color: 'white' });
+      } else {
+        const arr = [...occupied.values()];
+        const base = arr[randInt(0, arr.length - 1)];
+        const y = base.y + 1;
+        if (y > cfg.maxHeight - 1) continue;
+        const k = keyOf({ x: base.x, y, z: base.z });
+        if (!occupied.has(k)) addCube({ x: base.x, y, z: base.z, color: 'white' });
+      }
+    }
+
+    const cubes = [...occupied.values()];
+    const visible = getVisibleFromInitial(cubes);
+    const blackCount = Math.min(visible.length, randInt(cfg.black[0], cfg.black[1]));
+    shuffle(visible).slice(0, blackCount).forEach((cube) => {
+      const item = cubes.find((c) => c.x === cube.x && c.y === cube.y && c.z === cube.z);
+      if (item) item.color = 'black';
+    });
+
+    return cubes;
+  }
+
+  function getVisibleFromInitial(cubes) {
+    const front = new Map();
+    const right = new Map();
+    const top = new Map();
+
+    cubes.forEach((c) => {
+      const f = `${c.x},${c.y}`;
+      const r = `${c.z},${c.y}`;
+      const t = `${c.x},${c.z}`;
+      if (!front.has(f) || c.z < front.get(f).z) front.set(f, c);
+      if (!right.has(r) || c.x > right.get(r).x) right.set(r, c);
+      if (!top.has(t) || c.y > top.get(t).y) top.set(t, c);
+    });
+
+    const merged = new Map();
+    [...front.values(), ...right.values(), ...top.values()].forEach((c) => merged.set(keyOf(c), c));
+    return [...merged.values()];
+  }
+
+  function projection(cubes, direction) {
+    const picked = new Map();
+
+    cubes.forEach((c) => {
+      let key;
+      if (direction === 'front' || direction === 'back') key = `${c.x},${c.y}`;
+      else if (direction === 'right' || direction === 'left') key = `${c.z},${c.y}`;
+      else key = `${c.x},${c.z}`;
+
+      const curr = picked.get(key);
+      if (!curr) return picked.set(key, c);
+
+      if (direction === 'front' && c.z < curr.z) picked.set(key, c);
+      if (direction === 'back' && c.z > curr.z) picked.set(key, c);
+      if (direction === 'right' && c.x > curr.x) picked.set(key, c);
+      if (direction === 'left' && c.x < curr.x) picked.set(key, c);
+      if (direction === 'top' && c.y > curr.y) picked.set(key, c);
+    });
+
+    const coords = [];
+    picked.forEach((cube) => {
+      if (direction === 'front' || direction === 'back') coords.push({ u: cube.x, v: cube.y, color: cube.color });
+      if (direction === 'right' || direction === 'left') coords.push({ u: cube.z, v: cube.y, color: cube.color });
+      if (direction === 'top') coords.push({ u: cube.x, v: cube.z, color: cube.color });
+    });
+
+    let mapped = coords;
+    if (direction === 'left' || direction === 'back') {
+      mapped = coords.map((c) => ({ ...c, u: -c.u }));
+    }
+
+    const minU = Math.min(...mapped.map((c) => c.u));
+    const maxU = Math.max(...mapped.map((c) => c.u));
+    const minV = Math.min(...mapped.map((c) => c.v));
+    const maxV = Math.max(...mapped.map((c) => c.v));
+    const width = maxU - minU + 1;
+    const height = maxV - minV + 1;
+    const data = Array.from({ length: height }, () => Array(width).fill(0));
+
+    mapped.forEach((c) => {
+      const x = c.u - minU;
+      const y = maxV - c.v;
+      data[y][x] = c.color === 'black' ? 2 : 1;
+    });
+
+    return { width, height, data };
+  }
+
+  function serializeGrid(grid) {
+    return grid.data.map((row) => row.join('')).join('|');
+  }
+
+  function cloneGrid(grid) {
+    return { width: grid.width, height: grid.height, data: grid.data.map((r) => [...r]) };
+  }
+
+  function mirrorGrid(grid) {
+    const out = cloneGrid(grid);
+    out.data = out.data.map((row) => [...row].reverse());
+    return out;
+  }
+
+  function swapColors(grid) {
+    const out = cloneGrid(grid);
+    out.data = out.data.map((row) => row.map((v) => (v === 2 ? 1 : v === 1 ? 2 : 0)));
+    return out;
+  }
+
+  function makeOptions(cubes, direction, level) {
+    const cfg = LEVELS[level - 1];
+    const optionCount = randInt(cfg.options[0], cfg.options[1]);
+    const correct = projection(cubes, direction);
+    const pool = [{ id: crypto.randomUUID(), grid: correct, correct: true }];
+    const signatures = new Set([serializeGrid(correct)]);
+
+    const distractorSeeds = [];
+    cfg.directions.forEach((d) => {
+      if (d !== direction) distractorSeeds.push(projection(cubes, d));
+    });
+    distractorSeeds.push(mirrorGrid(correct));
+    distractorSeeds.push(swapColors(correct));
+
+    while (pool.length < optionCount && distractorSeeds.length > 0) {
+      const seed = distractorSeeds.shift();
+      const sig = serializeGrid(seed);
+      if (signatures.has(sig)) continue;
+      signatures.add(sig);
+      pool.push({ id: crypto.randomUUID(), grid: seed, correct: false });
+      if (pool.length < optionCount) {
+        const mut = Math.random() < 0.5 ? mirrorGrid(seed) : swapColors(seed);
+        const ms = serializeGrid(mut);
+        if (!signatures.has(ms)) {
+          signatures.add(ms);
+          pool.push({ id: crypto.randomUUID(), grid: mut, correct: false });
+        }
+      }
+    }
+
+    while (pool.length < optionCount) {
+      const fake = cloneGrid(correct);
+      const y = randInt(0, fake.height - 1);
+      const x = randInt(0, fake.width - 1);
+      fake.data[y][x] = fake.data[y][x] === 2 ? 1 : 2;
+      const sig = serializeGrid(fake);
+      if (signatures.has(sig)) continue;
+      signatures.add(sig);
+      pool.push({ id: crypto.randomUUID(), grid: fake, correct: false });
+    }
+
+    return shuffle(pool).slice(0, optionCount);
+  }
+
+  function shuffle(arr) {
+    const a = [...arr];
+    for (let i = a.length - 1; i > 0; i--) {
+      const j = randInt(0, i);
+      [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+  }
+
+  function renderChoices(options) {
+    choicesEl.innerHTML = '';
+    options.forEach((option, idx) => {
+      const btn = document.createElement('button');
+      btn.className = 'choice';
+      btn.dataset.id = option.id;
+      btn.setAttribute('aria-label', `選択肢${idx + 1}`);
+
+      const grid = document.createElement('div');
+      grid.className = 'option-grid';
+      grid.style.gridTemplateColumns = `repeat(${option.grid.width}, 16px)`;
+
+      option.grid.data.forEach((row) => {
+        row.forEach((cellVal) => {
+          const cell = document.createElement('span');
+          cell.className = 'cell';
+          if (cellVal === 2) cell.classList.add('black');
+          if (cellVal === 0) cell.classList.add('empty');
+          grid.appendChild(cell);
+        });
+      });
+
+      btn.appendChild(grid);
+      btn.addEventListener('click', () => submitAnswer(option.id));
+      choicesEl.appendChild(btn);
+    });
+  }
+
+  function mountCubes(cubes) {
+    board.clear();
+    const geo = new THREE.BoxGeometry(1, 1, 1);
+
+    cubes.forEach((cube) => {
+      const material = new THREE.MeshLambertMaterial({
+        color: cube.color === 'black' ? 0x3d3d3d : 0xf8f8f8,
+      });
+      const mesh = new THREE.Mesh(geo, material);
+      mesh.position.set(cube.x, cube.y + 0.5, cube.z);
+      board.add(mesh);
+
+      const line = new THREE.LineSegments(
+        new THREE.EdgesGeometry(geo),
+        new THREE.LineBasicMaterial({ color: 0x7a86a8 })
+      );
+      line.position.copy(mesh.position);
+      board.add(line);
+    });
+
+    const box = new THREE.Box3().setFromObject(board);
+    const center = box.getCenter(new THREE.Vector3());
+    board.position.sub(center);
+  }
+
+  function setCameraInstant(direction) {
+    const p = directionToPosition(direction);
+    camera.position.copy(p);
+    camera.lookAt(LOOK_AT);
+  }
+
+  function rotateToDirection(direction, duration = 1000) {
+    state.cameraTween = {
+      from: camera.position.clone(),
+      to: directionToPosition(direction),
+      start: performance.now(),
+      duration,
+    };
+  }
+
+  function directionToPosition(direction) {
+    if (direction === 'init') return INITIAL_CAMERA.clone();
+    if (direction === 'front') return new THREE.Vector3(0, 2.4, 6.8);
+    if (direction === 'right') return new THREE.Vector3(6.8, 2.4, 0);
+    if (direction === 'left') return new THREE.Vector3(-6.8, 2.4, 0);
+    if (direction === 'back') return new THREE.Vector3(0, 2.4, -6.8);
+    return new THREE.Vector3(0, 7.2, 0.001);
+  }
+
+  function submitAnswer(optionId) {
+    if (state.locked) return;
+    state.locked = true;
+    state.total += 1;
+
+    const isCorrect = optionId === state.correctOptionId;
+    if (isCorrect) state.score += 1;
+    scoreLabel.textContent = `${state.score} / ${state.total}`;
+
+    const reason = pickAnalysis(isCorrect);
+    analysisEl.textContent = reason;
+    feedbackEl.textContent = isCorrect ? 'せいかい！ くるっと見るとこうなるよ' : 'おしい！ くるっと回して見てみよう';
+    feedbackEl.className = `feedback ${isCorrect ? 'ok' : 'bad'}`;
+
+    [...choicesEl.children].forEach((choice) => {
+      const id = choice.dataset.id;
+      choice.disabled = true;
+      if (id === optionId) choice.classList.add('selected');
+      if (id === state.correctOptionId) choice.classList.add('correct');
+      if (id === optionId && !isCorrect) choice.classList.add('wrong');
+    });
+
+    rotateToDirection(state.answerDirection, randInt(800, 1200));
+    nextBtn.disabled = false;
+  }
+
+  function pickAnalysis(correct) {
+    if (correct) return 'いい観察！ 手前と高さを正しく読めたね。';
+    const tips = ['左右逆だったかも', '高さを見間違えたかも', '黒の位置が違ったかも'];
+    return tips[randInt(0, tips.length - 1)];
+  }
+
+  function newQuestion() {
+    state.locked = false;
+    const lvl = LEVELS[state.level - 1];
+
+    state.cubes = generateCubes(state.level);
+    mountCubes(state.cubes);
+    camera.position.copy(INITIAL_CAMERA);
+    camera.lookAt(LOOK_AT);
+
+    state.targetDirection = lvl.directions[randInt(0, lvl.directions.length - 1)];
+    state.answerDirection = state.targetDirection;
+    state.options = makeOptions(state.cubes, state.targetDirection, state.level);
+    const correct = state.options.find((o) => o.correct);
+    state.correctOptionId = correct.id;
+
+    promptEl.textContent = `${DIRECTION_SYMBOLS[state.targetDirection]}のほうから見るとどれかな？`;
+    feedbackEl.textContent = 'テンポよくいこう！';
+    feedbackEl.className = 'feedback';
+    analysisEl.textContent = '';
+    nextBtn.disabled = true;
+
+    renderChoices(state.options);
+  }
+
+  function advanceLevel() {
+    if (state.total > 0 && state.total % 5 === 0 && state.level < 5) {
+      state.level += 1;
+    }
+    levelLabel.textContent = `Lv${state.level}`;
+  }
+
+  function animate(now) {
+    if (state.cameraTween) {
+      const t = Math.min(1, (now - state.cameraTween.start) / state.cameraTween.duration);
+      camera.position.lerpVectors(state.cameraTween.from, state.cameraTween.to, t);
+      camera.lookAt(LOOK_AT);
+      if (t >= 1) state.cameraTween = null;
+    }
+    renderer.render(scene, camera);
+    requestAnimationFrame(animate);
+  }
+
+  normalModeBtn.addEventListener('click', () => {
+    state.hintMode = false;
+    normalModeBtn.classList.add('active');
+    hintModeBtn.classList.remove('active');
+    hintRotateBtn.disabled = true;
+  });
+
+  hintModeBtn.addEventListener('click', () => {
+    state.hintMode = true;
+    hintModeBtn.classList.add('active');
+    normalModeBtn.classList.remove('active');
+    hintRotateBtn.disabled = false;
+  });
+
+  hintRotateBtn.addEventListener('click', () => {
+    if (!state.hintMode || state.locked) return;
+    const dirs = ['front', 'right', 'left', 'back', 'top'];
+    const d = dirs[randInt(0, dirs.length - 1)];
+    rotateToDirection(d, 450);
+    setTimeout(() => {
+      rotateToDirection('init', 450);
+      setTimeout(() => {
+        camera.position.copy(INITIAL_CAMERA);
+        camera.lookAt(LOOK_AT);
+      }, 460);
+    }, 500);
+  });
+
+  nextBtn.addEventListener('click', () => {
+    advanceLevel();
+    newQuestion();
+  });
+
+  sceneEl.addEventListener('pointermove', (event) => {
+    if (!state.hintMode || state.locked || !event.buttons) return;
+    const rect = renderer.domElement.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    const y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    raycaster.setFromCamera({ x, y }, camera);
+  });
+
+  window.addEventListener('resize', resize);
+  resize();
+  newQuestion();
+  animate(performance.now());
+})();

--- a/game71/index.html
+++ b/game71/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>game71 | 四方観察トレーニング</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="topbar">
+        <h1>四方観察トレーニング</h1>
+        <div class="stats">
+          <span id="levelLabel">Lv1</span>
+          <span id="scoreLabel">0 / 0</span>
+        </div>
+      </header>
+
+      <section class="viewer-card">
+        <p id="prompt" class="prompt">△のほうから見るとどれかな？</p>
+        <div id="scene" class="scene" aria-label="3Dキューブ表示"></div>
+        <p id="feedback" class="feedback">テンポよくいこう！</p>
+      </section>
+
+      <section class="controls">
+        <div class="mode-row">
+          <button id="normalMode" class="mode active">通常</button>
+          <button id="hintMode" class="mode">ヒント</button>
+          <button id="hintRotate" class="mode" disabled>軽く回す</button>
+        </div>
+        <div id="analysis" class="analysis"> </div>
+      </section>
+
+      <section>
+        <div id="choices" class="choices" aria-label="選択肢"></div>
+      </section>
+
+      <footer class="footer">
+        <button id="nextBtn" class="next" disabled>つぎの問題へ</button>
+      </footer>
+    </main>
+
+    <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/game71/style.css
+++ b/game71/style.css
@@ -1,0 +1,118 @@
+:root {
+  --bg: #f5f7ff;
+  --card: #ffffff;
+  --line: #d5dcf3;
+  --ink: #1d2a4a;
+  --accent: #4c6fff;
+  --ok: #1e9f5a;
+  --bad: #d24c4c;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+  background: linear-gradient(180deg, #f9fbff 0%, #edf2ff 100%);
+  color: var(--ink);
+}
+.app {
+  max-width: 480px;
+  margin: 0 auto;
+  min-height: 100dvh;
+  padding: 12px;
+  display: grid;
+  grid-template-rows: auto auto auto 1fr auto;
+  gap: 10px;
+}
+.topbar,
+.viewer-card,
+.controls,
+.footer {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+}
+.topbar {
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+h1 { font-size: 1.1rem; margin: 0; }
+.stats { display: flex; gap: 10px; font-weight: 700; font-size: 0.92rem; }
+.viewer-card { padding: 8px; }
+.prompt {
+  margin: 2px 2px 8px;
+  font-weight: 700;
+  text-align: center;
+}
+.scene {
+  width: 100%;
+  aspect-ratio: 1.4 / 1;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: linear-gradient(180deg, #fefeff, #f4f7ff);
+}
+.feedback {
+  min-height: 1.4rem;
+  margin: 8px 0 2px;
+  text-align: center;
+  font-weight: 700;
+}
+.feedback.ok { color: var(--ok); }
+.feedback.bad { color: var(--bad); }
+.controls { padding: 8px; }
+.mode-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }
+.mode,
+.next,
+.choice {
+  border-radius: 10px;
+  border: 1px solid #b8c4ea;
+  background: #fff;
+  color: var(--ink);
+  font-weight: 700;
+}
+.mode,
+.next { padding: 10px; }
+.mode.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.mode:disabled { opacity: 0.45; }
+.analysis {
+  margin-top: 8px;
+  min-height: 1.2rem;
+  font-size: 0.86rem;
+  text-align: center;
+  color: #5a6790;
+}
+.choices {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.choice {
+  padding: 6px;
+  min-height: 116px;
+}
+.choice.selected { border-color: var(--accent); box-shadow: inset 0 0 0 2px #8ea3ff; }
+.choice.correct { border-color: #35b36f; box-shadow: inset 0 0 0 2px #70d69a; }
+.choice.wrong { border-color: #d96565; box-shadow: inset 0 0 0 2px #e9a0a0; }
+.option-grid {
+  width: 100%;
+  display: grid;
+  gap: 2px;
+  justify-content: center;
+}
+.cell {
+  width: 16px;
+  height: 16px;
+  border: 1px solid #9caad8;
+  background: #fff;
+}
+.cell.black { background: #2d3347; }
+.cell.empty { opacity: 0.1; }
+.footer { padding: 8px; }
+.next {
+  width: 100%;
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+.next:disabled { opacity: 0.4; }


### PR DESCRIPTION
### Motivation
- 学習目標に基づき、紙教材の「右前上」斜め俯瞰の見え方を再現した四方観察トレーニングをWebで提供するため。 
- iPhone縦画面でテンポよく反復練習できるUIと学習ループ（出題→内的回転→回答→回転確認）を実装するため。 

### Description
- 新規追加: `game71/index.html`, `game71/style.css`, `game71/app.js` による縦スマホ向けUIとThree.js実装を追加しました。 
- 描画と視点: `OrthographicCamera` を採用し初期カメラ位置を `camera.position = (4.5, 3.2, 5.5)` 相当で教材準拠の右前上斜め俯瞰を再現し、回答後は0.8〜1.2秒で指定方向へ回転するアニメーションを実装しました。 
- キューブ生成と制約: 浮遊禁止（上段は必ず下に支えあり）を守る配置ロジックと、初期視点で見えているキューブのみを黒にできる制約を実装しました（初期視点で見えない位置に黒を置かない）。 
- 見え方生成と選択肢: `front/right/left/back/top` の投影ロジック（手前優先圧縮、left/back の左右反転）を実装し、正解図と左右反転・色スワップ・別方向などのダミーから2〜6択の選択肢を生成するロジックを追加しました。 
- レベル・モード・フィードバック: レベル1〜5の段階的難易度設定、通常/ヒントモード（軽い回転）と誤答時の簡易分析メッセージを用意しました。 

### Testing
- 実行構文の静的チェックとして `node --check game71/app.js` を実行して成功しました。 
- 自動化されたブラウザ上のレンダリング/タッチ操作確認は行っておらず、実機（iPhone 15 Pro）での最終表示・操作感の確認が残件です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf3a79234832598388cdd395ed3f7)