### PR TITLE
Add Continuity Protocol and Prompt Bridge workflow for NEXT_PROMPT persistence

### DIFF
--- a/harness/00_README.md
+++ b/harness/00_README.md
@@ -9,6 +9,18 @@
 
 ---
 
+
+## 用語整理（Harness vs Project Management）
+
+このフォルダは名前としては `harness` が適切。
+理由は、実体が「プロジェクト管理ドキュメント単体」ではなく、**実行規律 + モード + 学習 + PM運用テンプレート**の複合基盤だから。
+
+- 呼称（推奨）: **Codex Execution Harness**
+- 補助説明: **with Project Management Kit**
+
+> つまり「ハーネス」が主語で、「プロジェクトマネジメント」は内包機能として説明するのが一貫する。
+
+---
 ## v2の考え方（重要）
 
 従来は、実行のたびに多くのテンプレートを都度注入する前提だった。
@@ -30,6 +42,8 @@ v2では逆に、次を標準化する。
 4. `templates/10_SESSION_BOOT_TEMPLATE.md`（必要時のみ詳細化）
 5. `templates/30_PROJECT_PROGRESS_BOARD_TEMPLATE.md`（残件・進捗の見える化）
 6. `templates/70_NEXT_PROMPT_TEMPLATE.md`（引き継ぎ）
+7. `04_CONTINUITY_PROTOCOL.md`（連続プロンプト運用）
+8. `templates/72_PROMPT_BRIDGE_WORKFLOW.md`（NEXT_PROMPTの保存/再注入手順）
 
 > 原則、最初は 1 行コマンドで開始し、情報不足時だけ SESSION_BOOT を展開する。
 
@@ -51,6 +65,7 @@ harness/
   01_SOUL.md
   02_RUN_MODES.md
   03_LEARNING_SYSTEM.md
+  04_CONTINUITY_PROTOCOL.md
   templates/
     05_ONE_LINE_PROMPTS.md
     10_SESSION_BOOT_TEMPLATE.md
@@ -59,6 +74,7 @@ harness/
     50_SPRINT_REVIEW_TEMPLATE.md
     60_PROJECT_COMPLETION_GATE_TEMPLATE.md
     70_NEXT_PROMPT_TEMPLATE.md
+    72_PROMPT_BRIDGE_WORKFLOW.md
     80_JOURNEY_LEARNING_ENTRY_TEMPLATE.md
   learning/
     90_AGENT_GROWTH_LEDGER.md
@@ -74,6 +90,8 @@ harness/
 4. 実行・検証（進捗はBacklogの Status を更新）
 5. SPRINT_REVIEW + NEXT_PROMPT更新
 6. 学習ログ追記
+7. Continuity Protocolで次ターンへの状態契約を固定
+8. 次回実行時は `development/NEXT_PROMPT.md` を読み、ユーザー指示と統合して開始
 
 ---
 
@@ -86,6 +104,22 @@ harness/
 
 ---
 
+
+## NEXT_PROMPTの保存と再注入（Prompt Bridge）
+
+連続実行の精度を上げるため、`templates/70_NEXT_PROMPT_TEMPLATE.md` で作成した内容は
+**対象プロジェクトの開発フォルダ**に保存して次回起動時に再注入する。
+
+- 保存先（推奨）: `<project>/development/NEXT_PROMPT.md`
+- 次回起動時: ユーザープロンプト + `NEXT_PROMPT.md` を合わせて解釈
+- 優先順位:
+  1. ユーザーの今回指示
+  2. AGENTS.md / リポジトリ制約
+  3. NEXT_PROMPT の Carry-over / Risks / Next 1 Action
+
+> これにより、ユーザー意図を優先しつつ、前回の文脈を低コストで継承できる。
+
+---
 ## 使い分け
 
 - 速く進める: `@pm @fast 目標: ...`

--- a/harness/04_CONTINUITY_PROTOCOL.md
+++ b/harness/04_CONTINUITY_PROTOCOL.md
@@ -1,0 +1,111 @@
+# 04_CONTINUITY_PROTOCOL.md（連続プロンプト運用プロトコル）
+
+目的は、複数ターン/複数セッションでもエージェントが**同じ判断基準で継続実行**できる状態を作ること。
+
+---
+
+## 1. 命名方針（推奨）
+
+このフォルダの内容は、以下2層で捉えるのが最も誤解が少ない。
+
+- **Harness（実行基盤）**
+  - 役割: エージェントに毎回適用される共通規律・テンプレート・学習機構
+  - 対象: `01_SOUL.md`, `02_RUN_MODES.md`, `03_LEARNING_SYSTEM.md`, 本ファイル
+- **Project Management Kit（運用資産）**
+  - 役割: プロジェクト進捗・残件・引き継ぎの実務運用
+  - 対象: `templates/30_*`, `templates/50_*`, `templates/70_*`
+
+> 結論: ディレクトリ名は `harness` のまま維持し、説明文で「PM運用を含むHarness」であると定義する。
+
+---
+
+## 2. 連続プロンプトの最小データ契約（State Contract）
+
+各ターンの終端で、次ターンに渡す最小情報を必ず固定フォーマットで残す。
+
+### 必須フィールド
+
+- `Session-ID`
+- `Mode`（@pm/@fast/@safe/@plan）
+- `Goal`
+- `Current Position`（Phase + Step）
+- `Top Risks`（最大3件）
+- `Carry-over IDs`（`30_PROJECT_PROGRESS_BOARD_TEMPLATE.md` のID参照）
+- `Next 1 Action`
+- `Validation Command`（次ターン開始時に再実行する1本）
+
+### ルール
+
+- Carry-overは自然言語ではなく**Backlog IDで参照**する
+- 「残件なし」は `Master Backlog` に `⏳` が無いことを根拠として宣言する
+- 次ターン開始時は、まず `Validation Command` を再実行して状態ドリフトを検出する
+
+---
+
+## 3. セッション開始時プロトコル（3分）
+
+1. `70_NEXT_PROMPT_TEMPLATE.md` の最新エントリを読む
+2. `30_PROJECT_PROGRESS_BOARD_TEMPLATE.md` の `You are here` と `Master Backlog` を同期
+3. `Carry-over IDs` から当ターンの作業集合を確定
+4. 非対象タスクを `Non-Scope` に明記
+
+---
+
+## 4. セッション終了時プロトコル（3分）
+
+1. 実施項目を `✅` に更新
+2. 未完了項目を `⏳` で維持（削除しない）
+3. 保留項目を `🧊` に変更し解除条件を書く
+4. `NEXT_PROMPT` を更新し、`Carry-over IDs` と `Next 1 Action` を1つに絞る
+5. `learning/90_AGENT_GROWTH_LEDGER.md` に1エントリ追記
+
+---
+
+## 5. 典型的な破綻パターンと予防
+
+- 破綻: DoneとCarry-overが混在して次ターンが迷子
+  - 予防: 終了報告を `✅/⏳/🧊` の3区分に固定
+- 破綻: 仕様変更が口頭合意で残らない
+  - 予防: `Decision Log Lite` に1行で必ず記録
+- 破綻: 学習ログが感想化して再利用不能
+  - 予防: Reusable Insight + Evidence + Reuse Plan の3点セットを必須化
+
+---
+
+## 6. 評価指標（継続運用向け）
+
+- 引き継ぎ直後の再計画時間（分）
+- Carry-over取りこぼし件数（件/週）
+- 同一Blockerの再発率（%）
+- 「残件なし」宣言の誤判定件数（件）
+
+この4指標が改善していれば、ハーネスは機能していると判断できる。
+
+
+---
+
+## 7. Prompt Bridge運用（開発フォルダ連携）
+
+### 保存（セッション終了時）
+
+- `templates/70_NEXT_PROMPT_TEMPLATE.md` を埋める
+- 保存先は対象プロジェクトの `development/NEXT_PROMPT.md`（推奨）
+- 追記ではなく「最新エントリを先頭に追加」して履歴を維持する
+
+### 読み込み（次セッション開始時）
+
+1. `development/NEXT_PROMPT.md` の最新エントリを読む
+2. ユーザーの今回プロンプトとの差分を抽出
+3. 優先順位に従って実行計画を確定する
+
+### 解釈の優先順位
+
+1. ユーザーの今回指示（最優先）
+2. AGENTS.md / リポジトリ制約 / 安全要件
+3. NEXT_PROMPTの Carry-over / Risks / Next 1 Action
+
+### 最小実行ルール
+
+- `development/NEXT_PROMPT.md` が無い場合は新規作成し、通常起動する
+- NEXT_PROMPTの内容が今回Goalと衝突する場合は、衝突点を明示して採用/破棄を宣言する
+- 実行開始時の出力に `Loaded NEXT_PROMPT: yes/no` を必ず含める

--- a/harness/templates/70_NEXT_PROMPT_TEMPLATE.md
+++ b/harness/templates/70_NEXT_PROMPT_TEMPLATE.md
@@ -5,12 +5,16 @@
 ```md
 ## PROMPT-XXXX
 - Date: YYYY-MM-DD
+- Session-ID:
+- Project Folder:
+- Output Path: <project>/development/NEXT_PROMPT.md
 - Mode: @pm | @pm @fast | @pm @safe | @pm @plan
 - Goal:
 - Current Position:
 - Done:
-- Carry-over:
-- Risks:
+- Carry-over IDs:
+- Top Risks (max 3):
+- Validation Command:
 - Next 1 Action:
 - Recommended One-liner:
   - `@pm ...`
@@ -19,6 +23,8 @@
 ## チェック
 
 - [ ] Done と Carry-over が分離されている
+- [ ] Carry-over は Backlog ID で参照されている
 - [ ] 次の1アクションが1文で書かれている
 - [ ] 次回起動用の一行コマンドがある
-
+- [ ] Validation Command が1本定義されている
+- [ ] 開始時に `Loaded NEXT_PROMPT: yes / no` を宣言する

--- a/harness/templates/72_PROMPT_BRIDGE_WORKFLOW.md
+++ b/harness/templates/72_PROMPT_BRIDGE_WORKFLOW.md
@@ -1,0 +1,45 @@
+# 72_PROMPT_BRIDGE_WORKFLOW.md
+
+`70_NEXT_PROMPT_TEMPLATE.md` を実運用に落とし込むための最小ワークフロー。
+
+## A. セッション終了時（NEXT_PROMPTを書き出す）
+
+1. `70_NEXT_PROMPT_TEMPLATE.md` を埋める
+2. 対象プロジェクトに `development/` が無ければ作成
+3. `<project>/development/NEXT_PROMPT.md` の先頭に最新エントリを追記
+
+### 推奨プロンプト（終了時）
+
+```md
+このセッションの結果を `harness/templates/70_NEXT_PROMPT_TEMPLATE.md` 形式で
+`<project>/development/NEXT_PROMPT.md` の先頭に追記してください。
+最後に `Loaded NEXT_PROMPT: yes` を次回用メモとして1行で出力してください。
+```
+
+---
+
+## B. 次セッション開始時（NEXT_PROMPTを読み込む）
+
+1. `<project>/development/NEXT_PROMPT.md` の最新エントリを読む
+2. 今回のユーザープロンプトと統合
+3. 優先順位（ユーザー指示 > 制約 > NEXT_PROMPT）で実行計画を確定
+
+### 推奨プロンプト（開始時）
+
+```md
+開始前に `<project>/development/NEXT_PROMPT.md` の最新エントリを読み、
+今回のユーザー指示と統合した実行計画を提示してください。
+冒頭で `Loaded NEXT_PROMPT: yes/no` を明示してください。
+```
+
+---
+
+## C. 競合時の宣言フォーマット
+
+```md
+- Conflict:
+- Decision: Adopt / Partial / Discard
+- Reason:
+```
+
+競合を曖昧にせず、毎回この形式で明示する。


### PR DESCRIPTION
### Motivation

- Provide a formal protocol so multi-turn sessions can reliably carry context between runs using a minimal, machine-friendly state contract. 
- Define a simple, reproducible workflow to persist and re-inject `NEXT_PROMPT` entries into project folders to reduce context loss. 
- Update the harness README to document terminology and the new continuity/bridge workflow so operators follow a consistent process.

### Description

- Introduce `harness/04_CONTINUITY_PROTOCOL.md` which defines the state contract, session start/end protocols, failure modes, metrics, and `Prompt Bridge` rules for saving/loading next-turn state. 
- Add `harness/templates/72_PROMPT_BRIDGE_WORKFLOW.md` with step-by-step instructions and recommended prompts for writing `NEXT_PROMPT` to `<project>/development/NEXT_PROMPT.md` and for reading it at session start. 
- Expand `harness/templates/70_NEXT_PROMPT_TEMPLATE.md` with additional fields (`Session-ID`, `Project Folder`, `Output Path`, `Carry-over IDs`, `Top Risks`, `Validation Command`) and checklist items (`Loaded NEXT_PROMPT` and `Validation Command`). 
- Update `harness/00_README.md` to include terminology clarifications, the new files in the v2 directory listing, operational flow updates (Prompt Bridge and Continuity Protocol), and rules to avoid losing backlog items.

### Testing

- No automated tests were added or modified for these documentation-only changes, and no automated test suite was executed as part of this change. 
- Manual verification consisted of reviewing the updated templates and README for consistency and internal references, which completed without detected issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eafe81bee883258d22cb846b4395f4)