### PR TITLE
Add game72: 5-button memory (Simon-like) game with 5-pad layout and celebration effects

### DIFF
--- a/game72/app.js
+++ b/game72/app.js
@@ -1,0 +1,164 @@
+(() => {
+  const stageEl = document.getElementById('stage');
+  const bestStageEl = document.getElementById('bestStage');
+  const statusEl = document.getElementById('status');
+  const scoreEl = document.getElementById('score');
+  const startBtn = document.getElementById('startBtn');
+  const replayBtn = document.getElementById('replayBtn');
+  const resetBtn = document.getElementById('resetBtn');
+  const celebrateEl = document.getElementById('celebrate');
+  const pads = [...document.querySelectorAll('.pad')];
+
+  const freqs = [261.63, 329.63, 392.0, 523.25, 659.25];
+  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  const state = {
+    sequence: [],
+    inputIndex: 0,
+    stage: 0,
+    bestStage: 0,
+    score: 0,
+    playingBack: false,
+    started: false,
+    audioCtx: null,
+  };
+
+  function updateStatus(text) { statusEl.textContent = text; }
+
+  function updateHud() {
+    stageEl.textContent = String(state.stage);
+    bestStageEl.textContent = String(state.bestStage);
+    scoreEl.textContent = String(state.score);
+  }
+
+  function ensureAudio() {
+    if (!state.audioCtx) {
+      const AC = window.AudioContext || window.webkitAudioContext;
+      state.audioCtx = new AC();
+    }
+    if (state.audioCtx.state === 'suspended') state.audioCtx.resume();
+  }
+
+  function playTone(index, dur = 220, gainV = 0.08) {
+    if (!state.audioCtx) return;
+    const now = state.audioCtx.currentTime;
+    const osc = state.audioCtx.createOscillator();
+    const gain = state.audioCtx.createGain();
+    osc.type = 'sine';
+    osc.frequency.value = freqs[index];
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(gainV, now + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + dur / 1000);
+    osc.connect(gain).connect(state.audioCtx.destination);
+    osc.start(now);
+    osc.stop(now + dur / 1000 + 0.03);
+  }
+
+  function lightPad(index, ms = 280) {
+    const pad = pads[index];
+    pad.classList.add('active');
+    playTone(index);
+    setTimeout(() => pad.classList.remove('active'), ms);
+  }
+
+  async function playbackSequence() {
+    if (!state.sequence.length) return;
+    state.playingBack = true;
+    updateStatus('再生中');
+    for (const idx of state.sequence) {
+      lightPad(idx);
+      await wait(520);
+    }
+    state.playingBack = false;
+    state.inputIndex = 0;
+    updateStatus('入力してください');
+  }
+
+  async function onCorrectStage() {
+    state.score += state.stage * 10;
+    updateStatus('正解！');
+    if (state.stage % 5 === 0) {
+      celebrateEl.classList.add('show');
+      playClap();
+      updateStatus(`${state.stage}ステージクリア！`);
+      setTimeout(() => celebrateEl.classList.remove('show'), 900);
+      await wait(900);
+    } else {
+      await wait(420);
+    }
+    state.stage += 1;
+    state.bestStage = Math.max(state.bestStage, state.stage - 1);
+    state.sequence.push(Math.floor(Math.random() * 5));
+    updateHud();
+    playbackSequence();
+  }
+
+  function playClap() {
+    if (!state.audioCtx) return;
+    const noiseBuffer = state.audioCtx.createBuffer(1, state.audioCtx.sampleRate * 0.25, state.audioCtx.sampleRate);
+    const data = noiseBuffer.getChannelData(0);
+    for (let i = 0; i < data.length; i++) data[i] = (Math.random() * 2 - 1) * (1 - i / data.length);
+    const src = state.audioCtx.createBufferSource();
+    const filter = state.audioCtx.createBiquadFilter();
+    const gain = state.audioCtx.createGain();
+    src.buffer = noiseBuffer;
+    filter.type = 'highpass';
+    filter.frequency.value = 900;
+    gain.gain.value = 0.06;
+    src.connect(filter).connect(gain).connect(state.audioCtx.destination);
+    src.start();
+  }
+
+  function onMistake() {
+    updateStatus('ミス！ もう一度再生できます');
+    state.playingBack = true;
+    setTimeout(() => { state.playingBack = false; }, 350);
+  }
+
+  async function handlePadPress(index) {
+    if (!state.started || state.playingBack || state.stage === 0) return;
+    lightPad(index, 180);
+    const expected = state.sequence[state.inputIndex];
+    if (index !== expected) {
+      onMistake();
+      return;
+    }
+    state.inputIndex += 1;
+    if (state.inputIndex >= state.sequence.length) {
+      await onCorrectStage();
+    }
+  }
+
+  async function startGame() {
+    ensureAudio();
+    state.started = true;
+    state.sequence = [Math.floor(Math.random() * 5)];
+    state.inputIndex = 0;
+    state.stage = 1;
+    state.score = 0;
+    updateHud();
+    await playbackSequence();
+  }
+
+  function resetGame() {
+    state.sequence = [];
+    state.inputIndex = 0;
+    state.stage = 0;
+    state.score = 0;
+    state.playingBack = false;
+    state.started = false;
+    pads.forEach((p) => p.classList.remove('active'));
+    updateHud();
+    updateStatus('スタートを押してください');
+  }
+
+  startBtn.addEventListener('click', startGame);
+  replayBtn.addEventListener('click', () => {
+    if (!state.started || state.playingBack || state.stage === 0) return;
+    playbackSequence();
+  });
+  resetBtn.addEventListener('click', resetGame);
+  pads.forEach((pad, i) => pad.addEventListener('click', () => handlePadPress(i)));
+
+  updateHud();
+})();

--- a/game72/index.html
+++ b/game72/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>game72 暗記ゲーム</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="app">
+    <header class="header">
+      <h1>game72 暗記ゲーム</h1>
+      <p class="howto">遊び方: 光った順番を覚えて、同じ順番でボタンを押そう！</p>
+    </header>
+
+    <section class="status-panel" aria-live="polite">
+      <p>現在のステージ: <strong id="stage">0</strong></p>
+      <p>最高到達ステージ: <strong id="bestStage">0</strong></p>
+      <p>状態: <strong id="status">スタートを押してください</strong></p>
+      <p>スコア: <strong id="score">0</strong></p>
+    </section>
+
+    <section class="pad-wrap" aria-label="暗記ボタンエリア">
+      <button class="pad pad-0" data-id="0" aria-label="左上"></button>
+      <button class="pad pad-1" data-id="1" aria-label="右上"></button>
+      <button class="pad pad-2" data-id="2" aria-label="中央"></button>
+      <button class="pad pad-3" data-id="3" aria-label="左下"></button>
+      <button class="pad pad-4" data-id="4" aria-label="右下"></button>
+      <div id="celebrate" class="celebrate" aria-hidden="true"></div>
+    </section>
+
+    <section class="controls">
+      <button id="startBtn" class="btn btn-primary">スタート</button>
+      <button id="replayBtn" class="btn">もう一度再生</button>
+      <button id="resetBtn" class="btn btn-subtle">リセット</button>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/game72/style.css
+++ b/game72/style.css
@@ -1,0 +1,104 @@
+:root {
+  --bg: #0f172a;
+  --panel: #111827;
+  --text: #e5e7eb;
+  --primary: #22d3ee;
+  --danger: #f87171;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", system-ui, sans-serif;
+  background: radial-gradient(circle at top, #1e293b 0%, var(--bg) 60%);
+  color: var(--text);
+}
+
+.app {
+  max-width: 440px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.header h1 { margin: 0 0 8px; font-size: 1.5rem; }
+.howto { margin: 0 0 14px; color: #cbd5e1; font-size: 0.95rem; }
+
+.status-panel {
+  background: #0b1220cc;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 10px 12px;
+  margin-bottom: 14px;
+}
+.status-panel p { margin: 6px 0; }
+
+.pad-wrap {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 84px);
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.pad {
+  border: none;
+  border-radius: 16px;
+  background: #1e293b;
+  box-shadow: inset 0 -3px 0 #0f172a, 0 2px 8px #00000055;
+  transition: transform 0.08s ease, background 0.15s ease;
+}
+.pad:active { transform: scale(0.96); }
+.pad.active {
+  background: #67e8f9;
+  box-shadow: 0 0 0 3px #a5f3fc, 0 0 20px #67e8f9aa;
+}
+
+.pad-0 { grid-column: 1; grid-row: 1; }
+.pad-1 { grid-column: 3; grid-row: 1; }
+.pad-2 { grid-column: 2; grid-row: 2; }
+.pad-3 { grid-column: 1; grid-row: 3; }
+.pad-4 { grid-column: 3; grid-row: 3; }
+
+.controls { display: grid; gap: 10px; }
+.btn {
+  border: none;
+  border-radius: 12px;
+  min-height: 48px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #f8fafc;
+  background: #334155;
+}
+.btn-primary { background: #0891b2; }
+.btn-subtle {
+  background: transparent;
+  color: #94a3b8;
+  border: 1px solid #334155;
+  min-height: 38px;
+  font-size: 0.9rem;
+}
+
+.celebrate {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+}
+.celebrate.show {
+  opacity: 1;
+  animation: pop 700ms ease-out;
+  background:
+    radial-gradient(circle at 10% 20%, #fde047 0 4px, transparent 5px),
+    radial-gradient(circle at 30% 80%, #fb7185 0 4px, transparent 5px),
+    radial-gradient(circle at 70% 20%, #4ade80 0 4px, transparent 5px),
+    radial-gradient(circle at 90% 70%, #a78bfa 0 4px, transparent 5px),
+    radial-gradient(circle at 50% 50%, #67e8f9 0 4px, transparent 5px);
+}
+@keyframes pop {
+  0% { transform: scale(0.95); }
+  60% { transform: scale(1.02); }
+  100% { transform: scale(1); }
+}


### PR DESCRIPTION
### Motivation
- Add a new, standalone memory/sequencing game following the existing per-game pattern to avoid touching existing games. 
- Provide a mobile-friendly, child-friendly Simon-like experience using a 5-pad (dice-5) layout. 
- Keep the implementation minimal and stable with no external dependencies and predictable behavior (random selections may repeat by design).

### Description
- Create a new `game72/` folder with `index.html`, `style.css`, and `app.js` implementing the UI, layout, and game logic. 
- Implement the dice-5 pad layout (top-left, top-right, center, bottom-left, bottom-right) and large, clear button visuals with active/light effects. 
- Implement gameplay: per-stage sequence that appends one random pad each cleared stage, input locking during playback, correct/incorrect handling, replay and reset controls, and HUD showing current stage, best stage, status, and score. 
- Add audio via the Web Audio API (five distinct tones mapped to pads), ensure audio is enabled after the initial start, and add celebration effects every 5 stages with a generated clap-like sound and confetti-style visual.

### Testing
- Ran a static check on the game script with `node --check game72/app.js`, which completed successfully. 
- Verified the new files exist under `game72/` and the implementation is confined to that directory. 
- Per-harness expectations followed and UI/logic were exercised via code inspection; no external automated UI tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ad047f6c8325825c686338822fcc)