### PR TITLE
Add Prompt Activity Log workflow and template; update README and continuity protocol

### DIFF
--- a/harness/00_README.md
+++ b/harness/00_README.md
@@ -41,9 +41,10 @@ v2では逆に、次を標準化する。
 3. `templates/05_ONE_LINE_PROMPTS.md`（起動コマンド）
 4. `templates/10_SESSION_BOOT_TEMPLATE.md`（必要時のみ詳細化）
 5. `templates/30_PROJECT_PROGRESS_BOARD_TEMPLATE.md`（残件・進捗の見える化）
-6. `templates/70_NEXT_PROMPT_TEMPLATE.md`（引き継ぎ）
-7. `04_CONTINUITY_PROTOCOL.md`（連続プロンプト運用）
-8. `templates/72_PROMPT_BRIDGE_WORKFLOW.md`（NEXT_PROMPTの保存/再注入手順）
+6. `templates/32_PROMPT_ACTIVITY_LOG_TEMPLATE.md`（プロンプト単位の活動ログ）
+7. `templates/70_NEXT_PROMPT_TEMPLATE.md`（引き継ぎ）
+8. `04_CONTINUITY_PROTOCOL.md`（連続プロンプト運用）
+9. `templates/72_PROMPT_BRIDGE_WORKFLOW.md`（NEXT_PROMPTの保存/再注入手順）
 
 > 原則、最初は 1 行コマンドで開始し、情報不足時だけ SESSION_BOOT を展開する。
 
@@ -92,6 +93,7 @@ harness/
 6. 学習ログ追記
 7. Continuity Protocolで次ターンへの状態契約を固定
 8. 次回実行時は `development/NEXT_PROMPT.md` を読み、ユーザー指示と統合して開始
+9. `harness/00_README.md` 指示で起動した場合は、指定サブフォルダに `PROMPT_ACTIVITY_LOG.md` を作成/追記し、**プロンプト単位**でアウトライン・進捗・残タスクを残す
 
 ---
 
@@ -101,6 +103,53 @@ harness/
 - 残件ありの場合、`30_PROJECT_PROGRESS_BOARD_TEMPLATE.md` の `Master Backlog` に必ずID付きで列挙する
 - 最終報告では `✅完了` / `⏳残件` / `🧊保留` を分けて記載する
 - `NEXT_PROMPT` には `⏳残件` のみを転記する（DONEは転記しない）
+
+---
+
+## `00_README` 指示時の活動ログ契約（新規）
+
+ユーザーが次のような指示を出した場合を対象とする。
+
+> 「`harness/00_README.md` を読み、そこに書かれている進め方・優先順位・安全重視のルールに従ってください。」
+
+この場合、エージェントは**開始時に明示的に約束**し、指名された**対象プロジェクト配下のサブフォルダ**に活動ログを追記する。
+
+### 必須ルール
+
+1. 対象プロジェクトのルートを確定する（例: `game80/`）
+2. 対象サブフォルダを確定する（例: `development/`）
+3. `<project>/<対象サブフォルダ>/PROMPT_ACTIVITY_LOG.md` を作成（無ければ新規）
+4. 各ユーザープロンプトごとに、以下の3項目を1エントリとして追記する
+   - `Outline`（着手前の作業アウトライン）
+   - `Progress`（実施中/実施後の進捗）
+   - `Remaining`（次ターンに残るタスク）
+5. エントリは時系列で識別可能にする（Date/Prompt-ID/Session-ID）
+6. 最終報告の `⏳残件` とログの `Remaining` を一致させる
+
+### 配置ルール（誤配置防止）
+
+- ✅ 正: `game80/development/PROMPT_ACTIVITY_LOG.md`
+- ❌ 誤: `harness/development/PROMPT_ACTIVITY_LOG.md`
+
+### 追記フォーマット（最小）
+
+```md
+## Prompt Entry: <Prompt-ID> (<YYYY-MM-DD>)
+- Prompt Summary:
+- Mode:
+- Scope Folder:
+
+### Outline
+- ...
+
+### Progress
+- ...
+
+### Remaining
+- [ ] ...
+```
+
+> これにより「どのプロンプトで何を約束し、どこまで進んだか」をサブフォルダ内で監査可能に保てる。
 
 ---
 

--- a/harness/04_CONTINUITY_PROTOCOL.md
+++ b/harness/04_CONTINUITY_PROTOCOL.md
@@ -61,6 +61,7 @@
 2. `30_PROJECT_PROGRESS_BOARD_TEMPLATE.md` の `You are here` と `Master Backlog` を同期
 3. `Carry-over IDs` から当ターンの作業集合を確定
 4. 非対象タスクを `Non-Scope` に明記
+5. `00_README` 指示で開始した場合は、対象サブフォルダの `PROMPT_ACTIVITY_LOG.md` を読んで最新エントリを確認
 
 ### 開始時ワンライン宣言（必須）
 
@@ -77,6 +78,7 @@
 3. 保留項目を `🧊` に変更し解除条件を書く
 4. `NEXT_PROMPT` を更新し、`Carry-over IDs` と `Next 1 Action` を1つに絞る
 5. `learning/90_AGENT_GROWTH_LEDGER.md` に1エントリ追記
+6. `PROMPT_ACTIVITY_LOG.md` の当該Promptエントリに `Progress` と `Remaining` を追記/更新
 
 ### 終了時ワンライン宣言（必須）
 
@@ -134,3 +136,20 @@
 - `development/NEXT_PROMPT.md` が無い場合は新規作成し、通常起動する
 - NEXT_PROMPTの内容が今回Goalと衝突する場合は、衝突点を明示して採用/破棄を宣言する
 - 実行開始時の出力に `Loaded NEXT_PROMPT: yes/no` を必ず含める
+
+---
+
+## 8. Prompt Activity Log運用（プロンプト単位の進捗契約）
+
+`00_README` 準拠を明示するプロンプトで起動した場合、以下を必須とする。
+
+1. ログ先は**対象プロジェクト配下**のユーザー指定サブフォルダ（未指定時は `<project>/development/`）
+2. ファイル名は `PROMPT_ACTIVITY_LOG.md` に統一
+3. 各ターンで `Outline -> Progress -> Remaining` を同一Prompt-IDで追記
+4. `Remaining` は `Master Backlog` の `⏳` と整合させる
+5. 次ターン開始時は最新 `Remaining` をCarry-over候補として評価する
+
+### 例
+
+- 対象プロジェクトが `game80` の場合、ログ先は `game80/development/PROMPT_ACTIVITY_LOG.md`
+- `harness/` 配下にログを書かない（テンプレート置き場と実ログ置き場を分離）

--- a/harness/templates/05_ONE_LINE_PROMPTS.md
+++ b/harness/templates/05_ONE_LINE_PROMPTS.md
@@ -32,8 +32,14 @@
 - `対象:` 変更対象のフォルダ/ファイル
 - `非対象:` 今回触らない範囲
 - `期限:` YYYY-MM-DD
+- `活動ログ先:` 対象プロジェクト配下でプロンプト単位ログを追記するサブフォルダ（例: `development`）
 
 例:
 
 `@pm @safe 目標: 検索精度改善 対象: app/search 制約: 期限 2026-04-20`
 
+### `00_README`準拠 + 活動ログ強制の例
+
+`@pm @safe 目標: checkout不具合の切り分け 対象: services/checkout 活動ログ先: development 指示: harness/00_README.md準拠`
+
+> この形式で起動した場合、`<project>/development/PROMPT_ACTIVITY_LOG.md` へのプロンプト単位追記（Outline/Progress/Remaining）を必須にする。

--- a/harness/templates/32_PROMPT_ACTIVITY_LOG_TEMPLATE.md
+++ b/harness/templates/32_PROMPT_ACTIVITY_LOG_TEMPLATE.md
@@ -1,0 +1,40 @@
+# 32_PROMPT_ACTIVITY_LOG_TEMPLATE.md
+
+`harness/00_README.md` 準拠で実行したときに、対象サブフォルダへ配置するログテンプレート。
+
+- 推奨配置: `<project>/<scope-folder>/PROMPT_ACTIVITY_LOG.md`
+- 目的: プロンプト単位で `Outline / Progress / Remaining` を追跡する
+
+---
+
+## Prompt Entry: <Prompt-ID> (<YYYY-MM-DD HH:mm UTC>)
+- Session-ID:
+- Prompt Summary:
+- Mode: @pm / @fast / @safe / @plan
+- Scope Folder:
+- Reference Prompt: `harness/00_README.md` 準拠
+
+### Outline
+- [ ]
+- [ ]
+
+### Progress
+- ✅
+- ✅
+
+### Remaining
+- [ ]
+- [ ]
+
+### Link to Backlog IDs
+- `BL-`
+- `BL-`
+
+---
+
+## 運用ルール（最小）
+
+1. 1プロンプトにつき1エントリを追加する
+2. `Remaining` は `30_PROJECT_PROGRESS_BOARD_TEMPLATE.md` の `⏳` と一致させる
+3. 次回開始時は最新エントリの `Remaining` から着手候補を選ぶ
+4. 実ログは対象プロジェクト配下に保存し、`harness/` 配下には保存しない


### PR DESCRIPTION
### Motivation

- Introduce a lightweight, auditable per-prompt activity log to prevent lost/orphaned tasks during multi-turn sessions when `harness/00_README.md` is used as the operating contract. 
- Ensure continuity between sessions by making `PROMPT_ACTIVITY_LOG.md` part of the carry-over workflow and aligning it with the existing `NEXT_PROMPT` / `Master Backlog` mechanism. 
- Provide a clear, minimal template and one-line prompt option so agents consistently record `Outline / Progress / Remaining` entries in the target project folder.

### Description

- Added a new template `templates/32_PROMPT_ACTIVITY_LOG_TEMPLATE.md` that defines the per-prompt log entry format and minimal運用 rules. 
- Updated `harness/00_README.md` to document the new activity-log contract, placement rules, minimal entry format, and when agents must create/append `PROMPT_ACTIVITY_LOG.md` under the target project folder. 
- Updated `harness/04_CONTINUITY_PROTOCOL.md` to include reading/updating `PROMPT_ACTIVITY_LOG.md` during session start/end protocols and to require `Progress`/`Remaining` updates on session completion. 
- Extended `harness/templates/05_ONE_LINE_PROMPTS.md` to add an `活動ログ先:` option and an example that forces `00_README`-compliant activity-log behavior. 

### Testing

- No automated tests were added or modified for these documentation and workflow changes. 
- No automated tests were executed as part of this PR because the changes are documentation and policy templates only. 
- Basic repository formatting and markdown linting were not changed by this PR and therefore were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b42b37148325a98e6a0203ffac33)