### PR TITLE
game74: remove top spacer/back button and tighten mobile layout

### DIFF
--- a/game74/index.html
+++ b/game74/index.html
@@ -18,70 +18,49 @@
       body {
         margin: 0;
         font-family: "Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-        background: #000;
+        background: var(--bg);
         color: var(--ink);
       }
 
-      .top-space {
-        height: 176px;
-        position: relative;
-      }
-
-      .back-btn {
-        position: absolute;
-        left: 24px;
-        top: 84px;
-        width: 116px;
-        height: 116px;
-        border-radius: 50%;
-        border: 0;
-        background: rgba(42, 44, 52, 0.7);
-        color: #f0f2f6;
-        font-size: 76px;
-        line-height: 0;
-        cursor: pointer;
-      }
-
       .app {
-        background: var(--bg);
-        min-height: calc(100vh - 176px);
-        padding-bottom: 52px;
+        min-height: 100vh;
+        padding-bottom: 18px;
       }
 
       .titlebar {
-        height: 96px;
+        height: clamp(58px, 10vh, 80px);
         background: #fff;
         border-bottom: 1px solid #e5e6ea;
         display: flex;
         align-items: center;
         justify-content: center;
         gap: 14px;
-        font-size: clamp(24px, 4vw, 56px);
+        font-size: clamp(20px, 4.8vw, 40px);
         font-weight: 800;
         color: #384156;
       }
 
       .titlebar .wave {
         color: var(--accent);
-        font-size: 40px;
+        font-size: clamp(18px, 5vw, 30px);
       }
 
       main {
-        width: min(890px, 100vw - 44px);
+        width: min(760px, 100vw - 28px);
         margin: 0 auto;
         text-align: center;
-        padding-top: 90px;
+        padding-top: clamp(18px, 4vh, 34px);
       }
 
       .label {
-        font-size: clamp(24px, 3.8vw, 68px);
+        font-size: clamp(18px, 4vw, 34px);
         color: #727b8f;
         font-weight: 700;
       }
 
       .bpm {
-        margin-top: 22px;
-        font-size: clamp(86px, 21vw, 176px);
+        margin-top: clamp(8px, 1.6vh, 14px);
+        font-size: clamp(54px, 16vw, 112px);
         font-weight: 900;
         letter-spacing: 0.01em;
         color: #0b1630;
@@ -95,8 +74,8 @@
       }
 
       .pad {
-        margin: 84px auto 72px;
-        width: min(680px, 84vw);
+        margin: clamp(18px, 4vh, 30px) auto clamp(16px, 3vh, 24px);
+        width: min(430px, 68vw);
         aspect-ratio: 1;
         border-radius: 50%;
         border: 0;
@@ -105,7 +84,7 @@
         box-shadow: 0 22px 34px rgba(58, 63, 173, 0.22);
         display: grid;
         place-content: center;
-        gap: 18px;
+        gap: 10px;
         cursor: pointer;
         transition: transform 80ms ease, filter 80ms ease;
       }
@@ -117,13 +96,13 @@
       }
 
       .tap-title {
-        font-size: clamp(58px, 10vw, 114px);
+        font-size: clamp(36px, 9vw, 72px);
         font-weight: 800;
         line-height: 1;
       }
 
       .tap-sub {
-        font-size: clamp(24px, 4.2vw, 50px);
+        font-size: clamp(14px, 3.7vw, 28px);
         color: #ccd0e8;
         font-weight: 700;
       }
@@ -131,9 +110,9 @@
       .action-btn,
       .reset-btn {
         width: 100%;
-        border-radius: 42px;
-        padding: 28px 24px;
-        font-size: clamp(30px, 5.3vw, 54px);
+        border-radius: 26px;
+        padding: clamp(12px, 2.2vh, 18px) 18px;
+        font-size: clamp(19px, 4.5vw, 30px);
         font-weight: 800;
       }
 
@@ -145,17 +124,14 @@
       }
 
       .reset-btn {
-        margin-top: 34px;
-        border: 6px solid #d4d7de;
+        margin-top: 12px;
+        border: 3px solid #d4d7de;
         background: transparent;
         color: #596276;
       }
     </style>
   </head>
   <body>
-    <div class="top-space">
-      <button class="back-btn" aria-label="戻る">‹</button>
-    </div>
     <div class="app">
       <header class="titlebar"><span class="wave">〰</span>なわとびBPMチェッカー</header>
       <main>


### PR DESCRIPTION
### Motivation
- The page had a large top black spacer and a circular back button that reduced usable vertical space on phones, causing unnecessary vertical scrolling.
- Adjust responsive sizes and spacing so the interface fits typical mobile viewports without changing runtime behavior.

### Description
- Modified `game74/index.html` to remove the `.top-space` block and the `.back-btn` element and styles, so the app content starts at the top of the viewport.
- Switched `body` background to `var(--bg)` and changed `.app` to `min-height: 100vh` with reduced bottom padding to eliminate the old 176px offset.
- Tightened responsive typography and layout by updating `titlebar` height to `clamp(58px, 10vh, 80px)`, reducing font sizes (`titlebar`, `.label`, `.bpm`, `.tap-title`, `.tap-sub`), and shrinking `main` top padding.
- Reduced the tappable pad and control sizes by changing `.pad` `margin` and `width`, lowering gaps, and adjusting `.action-btn`/`.reset-btn` `border-radius`, `padding`, and `font-size`, and reduced `.reset-btn` border thickness.

### Testing
- No automated tests were run for this visual/layout-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0638f86fbc8325848858d9a049d782)