### PR TITLE
game74: disable tap-triggered page zoom on mobile

### DIFF
--- a/game74/index.html
+++ b/game74/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>game74 | なわとびBPMチェッカー</title>
     <style>
       :root {
@@ -74,6 +74,7 @@
       }
 
       .pad {
+        touch-action: manipulation;
         margin: clamp(18px, 4vh, 30px) auto clamp(16px, 3vh, 24px);
         width: min(430px, 68vw);
         aspect-ratio: 1;
@@ -109,6 +110,7 @@
 
       .action-btn,
       .reset-btn {
+        touch-action: manipulation;
         width: 100%;
         border-radius: 26px;
         padding: clamp(12px, 2.2vh, 18px) 18px;


### PR DESCRIPTION
### Motivation
- Prevent mobile browsers from zooming the page when users tap the TAP pad or buttons so the app's tap interaction remains stable on touch devices.

### Description
- Updated `game74/index.html` to add `maximum-scale=1.0, user-scalable=no` to the viewport meta and applied `touch-action: manipulation;` to the `.pad` element and the `.action-btn`/`.reset-btn` styles to suppress tap-triggered zoom/gesture handling.

### Testing
- Ran `git diff -- game74/index.html`, committed the change with `git commit -m "game74: disable tap-triggered page zoom on mobile"`, and inspected the file with `nl -ba game74/index.html`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065068bc5c8325814eb75d05e3dfe8)