### PR TITLE
Redesign and localize game74 to Japanese "なわとびテンポチェッカー" with UI overhaul

### DIFF
--- a/game74/index.html
+++ b/game74/index.html
@@ -3,60 +3,174 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>game74 | Tap BPM Detector</title>
+    <title>game74 | なわとびテンポチェッカー</title>
     <style>
-      :root { color-scheme: dark; }
+      :root {
+        --bg: #e9eaee;
+        --ink: #0e1830;
+        --sub: #7e8697;
+        --accent: #6164e3;
+        --accent-2: #4e45db;
+      }
+
+      * { box-sizing: border-box; }
+
       body {
         margin: 0;
-        font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-        background: radial-gradient(circle at top, #253046 0%, #131722 60%, #0b0d13 100%);
-        color: #f1f5ff;
-        min-height: 100vh;
-        display: grid;
-        place-items: center;
+        font-family: "Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        background: #000;
+        color: var(--ink);
       }
-      main { width: min(92vw, 560px); text-align: center; }
-      h1 { margin-bottom: .2rem; }
-      p { opacity: .85; }
-      .pad {
-        width: 100%;
-        margin-top: 1rem;
-        aspect-ratio: 1.8 / 1;
-        border-radius: 20px;
-        border: 2px solid #8ea7ff;
-        background: linear-gradient(180deg, #40518d, #2b3660);
-        color: white;
-        font-size: clamp(1.2rem, 3vw, 1.8rem);
+
+      .top-space {
+        height: 176px;
+        position: relative;
+      }
+
+      .back-btn {
+        position: absolute;
+        left: 24px;
+        top: 84px;
+        width: 116px;
+        height: 116px;
+        border-radius: 50%;
+        border: 0;
+        background: rgba(42, 44, 52, 0.7);
+        color: #f0f2f6;
+        font-size: 76px;
+        line-height: 0;
+        cursor: pointer;
+      }
+
+      .app {
+        background: var(--bg);
+        min-height: calc(100vh - 176px);
+        padding-bottom: 52px;
+      }
+
+      .titlebar {
+        height: 96px;
+        background: #fff;
+        border-bottom: 1px solid #e5e6ea;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 14px;
+        font-size: clamp(24px, 4vw, 56px);
+        font-weight: 800;
+        color: #384156;
+      }
+
+      .titlebar .wave {
+        color: var(--accent);
+        font-size: 40px;
+      }
+
+      main {
+        width: min(890px, 100vw - 44px);
+        margin: 0 auto;
+        text-align: center;
+        padding-top: 90px;
+      }
+
+      .label {
+        font-size: clamp(24px, 3.8vw, 68px);
+        color: #727b8f;
         font-weight: 700;
-        letter-spacing: .08em;
-        user-select: none;
       }
-      .pad:active, .pad.active { transform: scale(0.99); filter: brightness(1.2); }
-      .bpm { font-size: clamp(2rem, 8vw, 4rem); margin: 1rem 0 .5rem; font-weight: 800; }
-      .meta { display: flex; justify-content: center; gap: 1.5rem; font-size: .95rem; opacity: .9; flex-wrap: wrap; }
-      .actions { margin-top: 1rem; display: flex; justify-content: center; }
-      button.copy { padding: .5rem .8rem; border-radius: 9px; border: 1px solid #9db8ff; background:#2a3a6a; color:#f5f7ff; }
-      .reset-wrap { margin-top: 2.5rem; display: flex; justify-content: center; }
-      button.reset { padding: .5rem .8rem; border-radius: 9px; border: 1px solid #8692bb; background:#1f2743; color:#f5f7ff; }
+
+      .bpm {
+        margin-top: 22px;
+        font-size: clamp(86px, 21vw, 176px);
+        font-weight: 900;
+        letter-spacing: 0.01em;
+        color: #0b1630;
+      }
+
+      .bpm span {
+        font-size: 0.38em;
+        color: #99a0af;
+        font-weight: 700;
+        margin-left: 0.12em;
+      }
+
+      .pad {
+        margin: 84px auto 72px;
+        width: min(680px, 84vw);
+        aspect-ratio: 1;
+        border-radius: 50%;
+        border: 0;
+        background: var(--accent);
+        color: #f4f5ff;
+        box-shadow: 0 22px 34px rgba(58, 63, 173, 0.22);
+        display: grid;
+        place-content: center;
+        gap: 18px;
+        cursor: pointer;
+        transition: transform 80ms ease, filter 80ms ease;
+      }
+
+      .pad:active,
+      .pad.active {
+        transform: scale(0.985);
+        filter: brightness(1.06);
+      }
+
+      .tap-title {
+        font-size: clamp(58px, 10vw, 114px);
+        font-weight: 800;
+        line-height: 1;
+      }
+
+      .tap-sub {
+        font-size: clamp(24px, 4.2vw, 50px);
+        color: #ccd0e8;
+        font-weight: 700;
+      }
+
+      .action-btn,
+      .reset-btn {
+        width: 100%;
+        border-radius: 42px;
+        padding: 28px 24px;
+        font-size: clamp(30px, 5.3vw, 54px);
+        font-weight: 800;
+      }
+
+      .action-btn {
+        border: 0;
+        background: linear-gradient(90deg, var(--accent), var(--accent-2));
+        color: #f0f2ff;
+        box-shadow: 0 8px 20px rgba(46, 41, 142, 0.28);
+      }
+
+      .reset-btn {
+        margin-top: 34px;
+        border: 6px solid #d4d7de;
+        background: transparent;
+        color: #596276;
+      }
     </style>
   </head>
   <body>
-    <main>
-      <h1>Tap BPM Detector</h1>
-      <p>同じリズムでタップすると、直近の間隔からBPMを推定します。</p>
-      <div class="bpm" id="bpm">-- BPM</div>
-      <div class="meta">
-        <span id="tapCount">タップ数: 0</span>
-        <span id="stability">安定度: --</span>
-      </div>
-      <button class="pad" id="tapPad" aria-label="tap area">TAP</button>
-      <div class="actions">
-        <button class="copy" id="copyBpmBtn">BPMコピー</button>
-      </div>
-      <div class="reset-wrap">
-        <button class="reset" id="resetBtn">リセット</button>
-      </div>
-    </main>
+    <div class="top-space">
+      <button class="back-btn" aria-label="戻る">‹</button>
+    </div>
+    <div class="app">
+      <header class="titlebar"><span class="wave">〰</span>なわとびテンポチェッカー</header>
+      <main>
+        <div class="label">現在のテンポ</div>
+        <div class="bpm" id="bpm">--<span>BPM</span></div>
+
+        <button class="pad" id="tapPad" aria-label="tap area">
+          <div class="tap-title">TAP</div>
+          <div class="tap-sub">ジャンプに合わせて押す</div>
+        </button>
+
+        <button class="action-btn" id="copyBpmBtn">⧉ テンポをコピーする</button>
+        <button class="reset-btn" id="resetBtn">⟲ リセット</button>
+      </main>
+    </div>
 
     <script>
       const taps = [];
@@ -67,26 +181,22 @@
       let timeoutId;
 
       const bpmEl = document.getElementById('bpm');
-      const tapCountEl = document.getElementById('tapCount');
-      const stabilityEl = document.getElementById('stability');
       const tapPad = document.getElementById('tapPad');
       const copyBpmBtn = document.getElementById('copyBpmBtn');
       let currentBpm = null;
 
       const median = (arr) => {
-        const sorted = [...arr].sort((a,b)=>a-b);
+        const sorted = [...arr].sort((a, b) => a - b);
         const m = Math.floor(sorted.length / 2);
-        return sorted.length % 2 ? sorted[m] : (sorted[m-1] + sorted[m]) / 2;
+        return sorted.length % 2 ? sorted[m] : (sorted[m - 1] + sorted[m]) / 2;
       };
 
       function clearState() {
         taps.length = 0;
         intervals.length = 0;
         lastTap = 0;
-        bpmEl.textContent = '-- BPM';
+        bpmEl.innerHTML = '--<span>BPM</span>';
         currentBpm = null;
-        tapCountEl.textContent = 'タップ数: 0';
-        stabilityEl.textContent = '安定度: --';
       }
 
       function scheduleAutoReset() {
@@ -95,18 +205,11 @@
       }
 
       function updateView() {
-        tapCountEl.textContent = `タップ数: ${taps.length}`;
         if (intervals.length < 2) return;
-
         const med = median(intervals);
         const bpm = Math.round(60000 / med);
-        const deviation = intervals.map(v => Math.abs(v - med));
-        const mad = median(deviation);
-        const stability = Math.max(0, 100 - Math.round((mad / med) * 200));
-
-        bpmEl.textContent = `${bpm} BPM`;
+        bpmEl.innerHTML = `${bpm}<span>BPM</span>`;
         currentBpm = bpm;
-        stabilityEl.textContent = `安定度: ${stability}%`;
       }
 
       function onTap() {
@@ -136,10 +239,12 @@
 
       copyBpmBtn.addEventListener('click', async () => {
         if (!Number.isFinite(currentBpm)) return;
-        const text = `BPM ${currentBpm}`;
+        const text = `テンポ ${currentBpm} BPM`;
         await navigator.clipboard.writeText(text);
-        copyBpmBtn.textContent = 'コピー済み';
-        setTimeout(() => { copyBpmBtn.textContent = 'BPMコピー'; }, 1000);
+        copyBpmBtn.textContent = '✓ コピーしました';
+        setTimeout(() => {
+          copyBpmBtn.textContent = '⧉ テンポをコピーする';
+        }, 1000);
       });
 
       document.getElementById('resetBtn').addEventListener('click', clearState);

--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@
     <a href="game67/" target="_blank">遊ぶ</a>
   </div>
   <div class="card">
-    <h2>Tap BPM Detector</h2>
+    <h2>なわとびテンポチェッカー</h2>
     <p class="dates" data-game="game74"></p>
     <a href="game74/" target="_blank">遊ぶ</a>
   </div>


### PR DESCRIPTION
### Motivation
- Localize and rebrand the Tap BPM utility for jump-rope use as "なわとびテンポチェッカー" with Japanese labels. 
- Modernize and simplify the UI for mobile and casual use by focusing on a large tap pad and clearer primary BPM output.
- Remove secondary diagnostics that clutter the view and make copy/reset flows more friendly for end users.

### Description
- Replaced the page title and UI copy with Japanese text and updated the homepage card title to `なわとびテンポチェッカー` (changed `Tap BPM Detector`).
- Complete visual redesign in `game74/index.html` including new CSS variables, fonts, layout (`.top-space`, `.titlebar`, `.pad` circular tap target), and action button styles (`.action-btn`, `.reset-btn`).
- Simplified the UI by removing tap count and stability displays and keeping only the central BPM readout updated via `bpmEl` and the existing `median` interval calculation; `clearState` and `onTap` logic preserved with minor formatting cleanup.
- Improved clipboard behavior by changing the copied text to `テンポ {BPM} BPM` and updating copy button feedback text handled via `copyBpmBtn`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05db8baf188325a75d0ff08b58074d)