### PR TITLE
game75: show feedback inline and reset scroll between questions

### DIFF
--- a/game75/app.js
+++ b/game75/app.js
@@ -173,6 +173,7 @@ function startMode(mode) {
   document.getElementById("round-total").textContent = meta.total;
   renderRoundTrack();
   showScreen("play-screen");
+  scrollPlayTop();
   renderQuestion();
 }
 
@@ -206,6 +207,7 @@ function renderQuestion() {
   if (question.type === "season") renderSeasonQuestion(question.item);
   if (question.type === "name") renderNameQuestion(question.item);
   if (question.type === "match") renderMatchQuestion(question.item);
+  scrollPlayTop();
 }
 
 function renderSeasonQuestion(item) {
@@ -401,6 +403,7 @@ function renderFeedback(isCorrect, item, selectedItem, customDescription) {
     ${customDescription || item.description}
     ${selectedLine ? `<br>${selectedLine}` : ""}
   `;
+  panel.scrollIntoView({ behavior: "smooth", block: "nearest" });
 }
 
 function nextQuestion() {
@@ -410,6 +413,10 @@ function nextQuestion() {
     return;
   }
   renderQuestion();
+}
+
+function scrollPlayTop() {
+  window.scrollTo({ top: 0, behavior: "auto" });
 }
 
 function showResult() {

--- a/game75/index.html
+++ b/game75/index.html
@@ -83,13 +83,14 @@
       <div id="round-track" class="round-track" aria-hidden="true"></div>
 
       <div id="question-stage" class="question-stage"></div>
-      <div id="answer-area" class="answer-area"></div>
 
       <div id="feedback-panel" class="feedback-panel" hidden>
         <div id="feedback-mark" class="feedback-mark"></div>
         <div id="feedback-copy" class="feedback-copy"></div>
         <button id="next-question" class="primary-button" type="button">つぎへ</button>
       </div>
+
+      <div id="answer-area" class="answer-area"></div>
     </section>
 
     <section id="result-screen" class="screen">

--- a/game75/style.css
+++ b/game75/style.css
@@ -397,14 +397,14 @@ h2 {
 }
 
 .answer-button {
-  min-height: 78px;
-  padding: 16px;
-  font-size: 1.3rem;
+  min-height: 68px;
+  padding: 12px;
+  font-size: 1.15rem;
 }
 
 .image-choice {
-  min-height: 180px;
-  padding: 10px;
+  min-height: 148px;
+  padding: 8px;
 }
 
 .image-choice img {
@@ -575,5 +575,53 @@ h2 {
 
   .library-grid {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .question-stage {
+    gap: 12px;
+    margin-top: 10px;
+  }
+
+  .item-picture {
+    width: min(230px, 66vw);
+  }
+
+  .question-copy {
+    font-size: 1.18rem;
+  }
+
+  .answer-area {
+    gap: 9px;
+    margin-top: 12px;
+  }
+
+  .answer-button,
+  .season-chip {
+    min-height: 58px;
+    font-size: 1rem;
+    padding: 10px;
+  }
+
+  .image-choice {
+    min-height: 120px;
+  }
+
+  .image-choice img {
+    width: 84px;
+    height: 84px;
+  }
+
+  .feedback-panel {
+    margin-top: 12px;
+    padding: 14px;
+  }
+
+  .feedback-mark {
+    font-size: 1.7rem;
+  }
+
+  .feedback-copy {
+    font-size: 1rem;
+    margin-bottom: 12px;
   }
 }


### PR DESCRIPTION
### Motivation
- On small screens (iPhone) the correctness feedback appeared below the choices so users had to scroll to see it, and the feedback popup could obscure the question context.  
- When moving from one question to the next the viewport could remain scrolled away from the top, sometimes showing a blank/offset view instead of the new question.

### Description
- Moved the feedback panel so it is rendered directly under the question area and above the answer choices in `game75/index.html` so feedback appears near the question and image.  
- Adjusted compact sizing for choices and image cards in `game75/style.css` and added tighter mobile-specific rules under `@media (max-width: 460px)` to help fit the entire question + feedback on a single screen.  
- Added automatic scroll reset via a new `scrollPlayTop()` helper and invoked it from `startMode()` and `renderQuestion()` in `game75/app.js` so the play screen scrolls to top when a mode starts and whenever a new question is rendered.  
- After showing feedback the feedback panel is brought into view with `panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' })` so the result is visible without manual scrolling.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d91c36bcc8325bce9b0064b9290a8)