### PR TITLE
Refine game77 UI: hide tap labels, remove borders, update branding to Waka-Junkai

### DIFF
--- a/game77/app.js
+++ b/game77/app.js
@@ -148,7 +148,6 @@ function createCardDOM(waka) {
           </div>
         </div>
       </div>
-      <div class="action-tip">右側タップで下の句へ</div>
     </div>
     
     <!-- カード裏面（解説・上の句＋下の句併記） -->

--- a/game77/index.html
+++ b/game77/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-  <title>Gear: Waka-Zen - 超高速百人一首巡回エンジン</title>
+  <title>Waka-Junkai 百人一首</title>
   
   <!-- Google Fonts: 麗しい和風フォントと洗練されたゴシック/明朝 -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -21,7 +21,7 @@
     <!-- ヘッダー / 季節・分類フィルター -->
     <header class="app-header">
       <div class="logo">
-        <span class="eng">Gear</span><span class="jp">和歌禅</span>
+        <span class="eng">Waka-Junkai</span><span class="jp">百人一首</span>
       </div>
       <nav class="filter-tabs" id="filterTabs">
         <button class="tab-btn active" data-filter="all">すべて</button>
@@ -76,19 +76,15 @@
 
     <!-- 親指操作用トリガーゾーン (画面上に重ねる透明なレイヤー) -->
     <div id="triggerOverlay">
-      <div id="triggerPrev" class="trigger-zone" data-action="PREV">
-        <span class="trigger-label">戻る</span>
-      </div>
-      <div id="triggerNext" class="trigger-zone" data-action="NEXT">
-        <span class="trigger-label">進む (長押し自動)</span>
-      </div>
+      <div id="triggerPrev" class="trigger-zone" data-action="PREV"></div>
+      <div id="triggerNext" class="trigger-zone" data-action="NEXT"></div>
     </div>
   </div>
 
   <!-- 初回ヘルプ/ウェルカムモーダル -->
   <div id="helpModal" class="modal">
     <div class="modal-content">
-      <h2>「和歌禅」へようこそ</h2>
+      <h2>「Waka-Junkai 百人一首」へようこそ</h2>
       <p class="modal-lead">指先で百人一首を爆速で巡る、極上の禅体験。</p>
       
       <div class="help-sections">

--- a/game77/style.css
+++ b/game77/style.css
@@ -636,27 +636,10 @@ body.fast-mode .waka-card {
 
 #triggerPrev {
   width: 25%;
-  border-right: 1px dashed rgba(255, 255, 255, 0.05);
 }
 
 #triggerNext {
   width: 25%;
-  border-left: 1px dashed rgba(255, 255, 255, 0.05);
-}
-
-/* 操作ガイド用ラベル（薄く表示） */
-.trigger-label {
-  font-size: 0.7rem;
-  letter-spacing: 0.2em;
-  color: var(--color-text-muted);
-  opacity: 0; /* 通常は見えないようにし、画面をスッキリ見せる */
-  transition: opacity 0.3s ease;
-  pointer-events: none;
-}
-
-/* ホバーまたは長押しガイド表示用（該当するゾーンのみ表示） */
-.trigger-zone:hover .trigger-label {
-  opacity: 0.4;
 }
 
 /* タップ・クリックした瞬間の波紋アニメーション */

--- a/index.html
+++ b/index.html
@@ -347,7 +347,7 @@
     <a href="game76/" target="_blank">遊ぶ</a>
   </div>
   <div class="card">
-    <h2>Gear: Waka-Zen - 超高速百人一首巡回エンジン</h2>
+    <h2>Waka-Junkai 百人一首</h2>
     <p class="dates" data-game="game77"></p>
     <a href="game77/" target="_blank">遊ぶ</a>
   </div>


### PR DESCRIPTION
### Motivation
- Improve visual clarity by removing faint instructional chrome and redundant guidance from the mobile tap overlay and card front. 
- Preserve tap interaction areas while making the interface more minimal and intuitive. 
- Update branding/title to `Waka-Junkai 百人一首` across the game page and the root index. 

### Description
- Renamed page title and header branding to `Waka-Junkai 百人一首` in `game77/index.html` and updated the game card title in `index.html`.
- Removed the visible `戻る` and `進む (長押し自動)` labels from the tap overlay while keeping the overlay elements (`#triggerPrev` / `#triggerNext`) intact in `game77/index.html`.
- Deleted the front-card action tip (`右側タップで下の句へ`) in `game77/app.js` so the small inline hint no longer appears.
- Removed the faint vertical dashed borders and the `.trigger-label` CSS (hover label rules) from `game77/style.css` to eliminate the subtle dividing lines and label styling.

### Testing
- Ran `node --check game77/app.js` and it completed successfully. 
- Searched for removed strings with `rg` (checks for `右側タップで下の句へ`, `進む (長押し自動)`, `<span class="trigger-label">戻る`, `trigger-label`, and the dashed `border-left`/`border-right` rules) and found no remaining occurrences in `game77/index.html`, `game77/app.js`, or `game77/style.css` (success).
- Verified updated titles with `rg` for `<title>Waka-Junkai 百人一首</title>` and `<h2>Waka-Junkai 百人一首</h2>` in `game77/index.html` and `index.html` respectively (success).
- Ran `git diff --check` to confirm there are no whitespace/merge errors (success).
- Attempted an automated screenshot with Playwright to verify visual result, but browser installation/download failed due to an environment CDN 403 `Domain forbidden`, so the screenshot step did not complete (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24f1ba76b48325b80a9635fd268abd)