### PR TITLE
game76: remove unused HUD controls and move menu to bottom-left

### DIFF
--- a/game76/app.js
+++ b/game76/app.js
@@ -15,7 +15,6 @@ const state = {
   currentIndex: 0,      // Active index in dataSource
   targetFPS: 24,        // Frames per second for auto-scroll (default: 24)
   isLongPressing: false,
-  isAutoplayOn: false,  // Toggle for persistent auto-scroll without holding
   currentFilter: 'all',
   likedIds: [],         // IDs of liked colors stored in LocalStorage
   isFlipped: false      // Whether the card is currently showing trivia (back face)
@@ -33,21 +32,16 @@ const dom = {
   
   // HUD Displays
   hudIndex: document.getElementById('hud-index-display'),
-  hudTag: document.getElementById('hud-tag-display'),
-  hudRegion: document.getElementById('hud-region-display'),
   
   // Trivia Elements
   triviaTags: document.getElementById('trivia-tags'),
   triviaTitle: document.getElementById('trivia-title'),
   triviaHex: document.getElementById('trivia-hex'),
   triviaText: document.getElementById('trivia-text'),
-  triviaCategoryInfo: document.getElementById('trivia-category-info'),
   triviaIndex: document.getElementById('trivia-index-display'),
   
   // Interactive Buttons
   btnMenu: document.getElementById('btn-menu'),
-  btnLikeToggle: document.getElementById('btn-like-toggle'),
-  btnAutoplay: document.getElementById('btn-autoplay'),
   btnFlipBack: document.getElementById('btn-flip-back'),
   btnCopyPrompt: document.getElementById('btn-copy-prompt'),
   
@@ -89,7 +83,6 @@ function loadLikes() {
 function saveLikes() {
   localStorage.setItem('color_gear_likes', JSON.stringify(state.likedIds));
   renderLikesPanel();
-  updateLikeButtonUI();
 }
 
 function toggleLike(id) {
@@ -145,7 +138,6 @@ function changeCard(nextIndex, force = false) {
   requestAnimationFrame(() => {
     updateMemoryWindow();
     updateHUD();
-    updateLikeButtonUI();
   });
 }
 
@@ -182,10 +174,6 @@ function updateMemoryWindow() {
     dom.triviaTags.appendChild(span);
   });
 
-  // Display category info on bottom right of back card
-  const isJapan = currentCard.tags.includes('japan');
-  dom.triviaCategoryInfo.textContent = isJapan ? 'JAPANESE TRADITIONAL' : 'WESTERN TRADITIONAL';
-
   // Display padded index (e.g. 001 / 500)
   const currentNum = String(curr + 1).padStart(3, '0');
   const totalNum = String(len).padStart(3, '0');
@@ -203,36 +191,10 @@ function updateMemoryWindow() {
 function updateHUD() {
   if (state.dataSource.length === 0) return;
   
-  const currentCard = state.dataSource[state.currentIndex];
   dom.hudIndex.textContent = `${state.currentIndex + 1} / ${state.dataSource.length}`;
   
-  // Filter tag display
-  const filterNames = {
-    all: 'ALL COLORS',
-    japan: '日本の伝統色',
-    west: '西洋の伝統色',
-    red: '赤系 (RED)',
-    blue: '青系 (BLUE)',
-    green: '緑系 (GREEN)',
-    yellow: '黄系 (YELLOW)',
-    purple: '紫系 (PURPLE)',
-    brown: '茶・黒 (BROWN/BLACK)'
-  };
-  dom.hudTag.textContent = filterNames[state.currentFilter] || 'FILTERED';
-  
-  const isJapan = currentCard.tags.includes('japan');
-  dom.hudRegion.textContent = isJapan ? 'JAPANESE' : 'WESTERN';
 }
 
-function updateLikeButtonUI() {
-  if (state.dataSource.length === 0) return;
-  const currentCard = state.dataSource[state.currentIndex];
-  if (state.likedIds.includes(currentCard.id)) {
-    dom.btnLikeToggle.classList.add('is-liked');
-  } else {
-    dom.btnLikeToggle.classList.remove('is-liked');
-  }
-}
 
 // --- 2-Page Step Navigation (0ms Trigger Logic) ---
 function executeSingleTapStep(direction) {
@@ -264,10 +226,6 @@ function executeSingleTapStep(direction) {
 
 // --- Long Press Auto-Scroll Loop (Core Logic 5.2.③) ---
 function handlePointerDown(direction) {
-  if (state.isAutoplayOn) {
-    stopAutoplay();
-  }
-
   // 1. Immediately run single tap action (0ms response)
   executeSingleTapStep(direction);
 
@@ -299,40 +257,6 @@ function handlePointerUp() {
   dom.bgLayer.classList.remove('no-transition');
 }
 
-// --- Autoplay Toggle (Persistent hands-free slideshow) ---
-function toggleAutoplay() {
-  if (state.isAutoplayOn) {
-    stopAutoplay();
-  } else {
-    startAutoplay();
-  }
-}
-
-function startAutoplay() {
-  state.isAutoplayOn = true;
-  dom.btnAutoplay.classList.add('is-playing');
-  document.getElementById('autoplay-text').textContent = 'PLAYING';
-  
-  if (state.isFlipped) {
-    setFlip(false);
-  }
-  
-  dom.bgLayer.classList.add('no-transition');
-  
-  const intervalMs = 1000 / state.targetFPS;
-  frameInterval = setInterval(() => {
-    changeCard(state.currentIndex + 1);
-  }, intervalMs);
-}
-
-function stopAutoplay() {
-  state.isAutoplayOn = false;
-  dom.btnAutoplay.classList.remove('is-playing');
-  document.getElementById('autoplay-text').textContent = 'AUTO';
-  
-  clearInterval(frameInterval);
-  dom.bgLayer.classList.remove('no-transition');
-}
 
 // --- Filter Database ---
 function applyFilter(filterTag) {
@@ -503,11 +427,6 @@ function initEventListeners() {
   dom.zoneAction.addEventListener('pointerdown', (e) => {
     e.preventDefault();
     
-    // Stop autoplay if playing
-    if (state.isAutoplayOn) {
-      stopAutoplay();
-    }
-
     const now = Date.now();
     const timeDiff = now - lastTapTime;
     
@@ -547,26 +466,10 @@ function initEventListeners() {
     copyAIPrompt();
   });
 
-  // Toggle Like button
-  dom.btnLikeToggle.addEventListener('pointerdown', (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    const currentCard = state.dataSource[state.currentIndex];
-    toggleLike(currentCard.id);
-  });
-
-  // Autoplay Button
-  dom.btnAutoplay.addEventListener('pointerdown', (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    toggleAutoplay();
-  });
-
   // Menu / Filter Button
   dom.btnMenu.addEventListener('pointerdown', (e) => {
     e.preventDefault();
     e.stopPropagation();
-    if (state.isAutoplayOn) stopAutoplay();
     dom.panelMenu.classList.add('is-active');
   });
 
@@ -577,7 +480,6 @@ function initEventListeners() {
   // Open Likes Panel (via Index Display or Like Button holding)
   dom.hudIndex.addEventListener('pointerdown', (e) => {
     e.preventDefault();
-    if (state.isAutoplayOn) stopAutoplay();
     renderLikesPanel();
     dom.panelLikes.classList.add('is-active');
   });
@@ -598,11 +500,6 @@ function initEventListeners() {
     dom.fpsControl.querySelectorAll('.segment-btn').forEach(b => b.classList.remove('is-active'));
     btn.classList.add('is-active');
 
-    // If currently autoplaying, restart timer with new FPS interval
-    if (state.isAutoplayOn) {
-      stopAutoplay();
-      startAutoplay();
-    }
     triggerHaptic();
   });
 

--- a/game76/index.html
+++ b/game76/index.html
@@ -21,16 +21,6 @@
       <div class="card-face card-front">
         <div class="front-hud">
           <span class="color-hint" id="hud-index-display">0 / 0</span>
-          <span class="color-hint" id="hud-tag-display">ALL COLORS</span>
-        </div>
-        
-        <!-- Animated tap prompt to help users understand -->
-        <div class="front-center-prompt">
-          <p>TAP CENTER TO REVEAL TRIVIA</p>
-        </div>
-
-        <div class="front-hud" style="justify-content: flex-end;">
-          <span class="color-hint" id="hud-region-display">伝統色</span>
         </div>
       </div>
 
@@ -55,7 +45,6 @@
           </div>
           <div class="back-hud-info">
             <span class="color-hint" id="trivia-index-display">000 / 000</span>
-            <span class="color-hint" style="letter-spacing: 0.1em;" id="trivia-category-info">WESTERN TRADITIONAL</span>
           </div>
         </div>
       </div>
@@ -69,25 +58,13 @@
       <div class="tap-zone zone-next" id="zone-next"></div>
     </div>
 
-    <!-- Floating HUD Controls (Top Left: Menu/Filter, Top Right: Like, Center Bottom: Auto-play) -->
+    <!-- Floating HUD Controls (Bottom Left: Menu/Filter) -->
     <button class="hud-btn" id="btn-menu" aria-label="Menu and Settings">
       <svg viewBox="0 0 24 24">
         <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/>
       </svg>
     </button>
 
-    <button class="hud-btn" id="btn-like-toggle" aria-label="Like this Color">
-      <svg viewBox="0 0 24 24">
-        <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-      </svg>
-    </button>
-
-    <button class="hud-btn" id="btn-autoplay" aria-label="Autoplay mode">
-      <svg viewBox="0 0 24 24" style="width: 14px; height: 14px;">
-        <path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm-6.8 5.2L3.74 7.74C2.9 9.17 2.5 10.63 2.5 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8z"/>
-      </svg>
-      <span id="autoplay-text">AUTO</span>
-    </button>
 
     <!-- Overlay Panel: Menu & Settings -->
     <div class="glass-panel" id="panel-menu">
@@ -97,9 +74,9 @@
       </div>
       <div class="panel-content">
         
-        <!-- Autoplay FPS Setting -->
+        <!-- Long-press speed setting -->
         <div class="setting-row">
-          <label class="setting-label">Autoplay Frame Rate (FPS)</label>
+          <label class="setting-label">Long-Press Speed (FPS)</label>
           <div class="segment-control" id="fps-control">
             <button class="segment-btn" data-fps="1">1</button>
             <button class="segment-btn" data-fps="5">5</button>

--- a/game76/style.css
+++ b/game76/style.css
@@ -113,27 +113,6 @@ body {
   width: 100%;
 }
 
-.front-center-prompt {
-  align-self: center;
-  margin-top: auto;
-  margin-bottom: 80px;
-  text-align: center;
-  opacity: 0;
-  animation: pulse-fade 3s infinite ease-in-out;
-  pointer-events: none;
-}
-
-.front-center-prompt p {
-  font-size: 12px;
-  letter-spacing: 0.15em;
-  color: rgba(255,255,255,0.6);
-  text-shadow: 0 2px 8px rgba(0,0,0,0.4);
-}
-
-@keyframes pulse-fade {
-  0%, 100% { opacity: 0.2; }
-  50% { opacity: 0.7; }
-}
 
 /* Back Face: Trivia and Details (Glassmorphic & Floating Window) */
 .card-back {
@@ -398,46 +377,8 @@ body {
 
 /* Positioning HUD buttons */
 #btn-menu {
-  top: 25px;
-  left: 25px;
-}
-
-#btn-like-toggle {
-  top: 25px;
-  right: 25px;
-}
-
-#btn-like-toggle.is-liked svg {
-  fill: #ff4757;
-}
-
-#btn-autoplay {
   bottom: 25px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: auto;
-  padding: 0 20px;
-  border-radius: 30px;
-  font-weight: 600;
-  font-size: 11px;
-  letter-spacing: 0.1em;
-  gap: 8px;
-}
-
-#btn-autoplay.is-playing {
-  background: rgba(255, 71, 87, 0.2);
-  border-color: rgba(255, 71, 87, 0.5);
-  color: #ff4757;
-}
-
-#btn-autoplay.is-playing svg {
-  fill: #ff4757;
-  animation: rotate-inf 3s infinite linear;
-}
-
-@keyframes rotate-inf {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  left: 25px;
 }
 
 /* Glass Panels (Settings, Menu, Like List) */


### PR DESCRIPTION
### Motivation
- Declutter the game76 UI by removing seldom-used HUD elements (`Like`, `Autoplay`, center tap prompt and collection/region labels) to simplify interaction on mobile screens. 
- Relocate the persistent menu button to a less intrusive position to reduce top-right visual noise and prevent accidental taps.

### Description
- Removed front-face labels and prompts from `game76/index.html`, including the `ALL COLORS` tag, the `TAP CENTER TO REVEAL TRIVIA` prompt, and the front region label, leaving only the index display. 
- Deleted the `btn-like-toggle` and `btn-autoplay` buttons from `game76/index.html` and removed the back-card category label (`trivia-category-info`).
- Updated `game76/style.css` to remove the center prompt styles and reposition the menu HUD (`#btn-menu`) from top-left to bottom-left while stripping autoplay/like-related CSS rules. 
- Cleaned `game76/app.js` by removing DOM references to `hudTag`, `hudRegion`, `triviaCategoryInfo`, `btnLikeToggle`, and `btnAutoplay`, deleted `updateLikeButtonUI` and autoplay code paths/listeners, and removed checks that manipulated now-deleted UI elements; also renamed the menu FPS label to clarify it controls long-press speed (`Long-Press Speed (FPS)`).

### Testing
- Ran `node --check game76/app.js` to validate the JavaScript syntax and it returned no errors. 
- Searched target files with `rg` to confirm removal of UI strings and selectors (`AUTO|Autoplay|autoplay|ALL COLORS|TAP CENTER TO REVEAL TRIVIA|btn-like-toggle|btn-autoplay|hud-tag-display|hud-region-display|trivia-category-info|front-center-prompt`) and found no remaining references in the modified files. 
- Served the game locally with `python3 -m http.server` and fetched `http://127.0.0.1:8000/game76/index.html` via `curl -I` to confirm the page loads successfully. 
- Attempted automated screenshot capture with Playwright but browser install failed in the environment (`npx playwright install` returned a `403 Domain forbidden` when downloading Chromium), so visual verification was not captured automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24f3fe06d883259c2532d9cf903714)