### PR TITLE
game77: remove in-header “百人一首” label and numeric progress counter

### DIFF
--- a/game77/app.js
+++ b/game77/app.js
@@ -19,7 +19,6 @@ const state = {
 const dom = {
   viewport: null,
   progressBar: null,
-  progressText: null,
   fpsSelector: null,
   audioToggleBtn: null,
   audioIconOn: null,
@@ -296,7 +295,6 @@ function stepCard(direction) {
 function updateProgressBar() {
   if (state.dataSource.length === 0) {
     dom.progressBar.style.width = '0%';
-    dom.progressText.textContent = '0 / 0';
     return;
   }
   const currentNum = state.currentIndex + 1;
@@ -304,7 +302,6 @@ function updateProgressBar() {
   const percentage = (currentNum / totalNum) * 100;
   
   dom.progressBar.style.width = `${percentage}%`;
-  dom.progressText.textContent = `${currentNum} / ${totalNum}`;
 }
 
 // --------------------------------------------------------------------------
@@ -551,7 +548,6 @@ function setupEventListeners() {
 function initApp() {
   dom.viewport = document.getElementById('cardViewport');
   dom.progressBar = document.getElementById('progressBar');
-  dom.progressText = document.getElementById('progressText');
   dom.fpsSelector = document.getElementById('fpsSelector');
   dom.audioToggleBtn = document.getElementById('audioToggleBtn');
   dom.audioIconOn = document.getElementById('audioIconOn');

--- a/game77/index.html
+++ b/game77/index.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@300;500;900&family=Yuji+Syuku&family=Montserrat:wght@300;600&display=swap" rel="stylesheet">
   
-  <link rel="stylesheet" href="style.css?v=11.0">
+  <link rel="stylesheet" href="style.css?v=11.1">
 </head>
 <body>
   <!-- 和紙のような質感を表現するためのオーバーレイノイズ -->
@@ -21,7 +21,7 @@
     <!-- ヘッダー / 季節・分類フィルター -->
     <header class="app-header">
       <div class="logo">
-        <span class="eng">Waka-Junkai</span><span class="jp">百人一首</span>
+        <span class="eng">Waka-Junkai</span>
       </div>
       <nav class="filter-tabs" id="filterTabs">
         <button class="tab-btn active" data-filter="all">すべて</button>
@@ -70,7 +70,6 @@
         <div class="progress-track">
           <div id="progressBar" class="progress-fill"></div>
         </div>
-        <span class="progress-text" id="progressText">0 / 0</span>
       </div>
     </footer>
 
@@ -112,6 +111,6 @@
   <!-- 百人一首データベース -->
   <script src="data.js?v=11.0"></script>
   <!-- コアアプリケーションロジック -->
-  <script src="app.js?v=11.0"></script>
+  <script src="app.js?v=11.1"></script>
 </body>
 </html>

--- a/game77/style.css
+++ b/game77/style.css
@@ -600,12 +600,6 @@ body.fast-mode .waka-card {
   box-shadow: 0 0 8px rgba(195, 167, 117, 0.6);
 }
 
-.progress-text {
-  font-family: var(--font-eng);
-  font-size: 0.75rem;
-  letter-spacing: 0.1em;
-  color: var(--color-text-muted);
-}
 
 /* ==========================================================================
    親指操作用トリガーゾーン (画面に覆うオーバーレイ)


### PR DESCRIPTION
### Motivation
- The in-app header should show only the brand name to improve visual design, so the four-character label `百人一首` is removed from the top-left logo while preserving the document `<title>`.
- The numeric page counter in the bottom-right progress area (e.g. `4 / 6`) is redundant for the intended UI and should be removed so only the visual progress bar remains.

### Description
- Removed the in-page Japanese label by deleting `<span class="jp">百人一首</span>` in `game77/index.html` and kept the document title (`<title>Waka-Junkai 百人一首</title>`).
- Removed the numeric progress element `<span class="progress-text" id="progressText">…</span>` from `game77/index.html` and bumped local asset querystrings (`style.css`/`app.js`) to `v=11.1`.
- Cleaned up JavaScript DOM references and updates by removing `dom.progressText` and the text assignment code in `game77/app.js` so only the progress bar (`#progressBar`) is updated.
- Removed the unused CSS rule `.progress-text` from `game77/style.css` to avoid orphaned styling.
- Changes touched `game77/index.html`, `game77/app.js`, and `game77/style.css` and were committed.

### Testing
- Ran static check `node --check game77/app.js`, which completed successfully.
- Ran repository checks `git diff --check` and basic `git status` to ensure clean diffs and commit; these passed.
- Attempted an automated visual check with Playwright (`npx playwright screenshot ...`) but downloading the test browser failed due to environment network restrictions (`403 Domain forbidden`), so no headless screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24fa09ec348325bb7bb5447b7d9227)