### PR TITLE
Refactor game79: Ephemeral echo brush — simplify effects, UI, and rendering

### DIFF
--- a/game79/app.js
+++ b/game79/app.js
@@ -1,59 +1,47 @@
-class SpreadingEchoApp {
+class EphemeralEchoApp {
     constructor() {
         this.canvas = document.getElementById('drawingCanvas');
         this.ctx = this.canvas.getContext('2d');
         this.settings = {
-            echoIntervalMs: 70, echoCountMax: 90, baseAngleDeg: 225, echoDistance: 3,
-            spreadAngleDeg: 50, spreadGrowth: 0.025, branch3Start: 12, branch5Start: 32,
-            spreadMode: 'growing', pulseFrequency: 0.5, pulseDepth: 0.35, spiralRotationPerEcho: 2,
-            scalePerEcho: 0.99, alphaPerEcho: 0.965, blurPerEcho: 0.15,
-            colorMode: 'gradient', strokeColor: '#00c8ff', gradientEndColor: '#ff4fd8', hueShift: 24,
-            strokeWidth: 4, strokeAlpha: 0.85, decorationTheme: 'spark', sparkAmount: 0.45,
-            radialBloomStrength: 0.25, radialBloomRadius: 24, spiralRadius: 10, spiralTightness: 0.8,
-            tornadoLift: 0.35, rippleInterval: 180, rippleRadiusGrowth: 1.8, rippleAlphaDecay: 0.92,
-            stampDensity: 0.12
+            echoIntervalMs: 70,
+            echoCountMax: 80,
+            shiftX: -1,
+            shiftY: -2,
+            scalePerEcho: 0.99,
+            alphaPerEcho: 0.98,
+            strokeColor: '#9ee7ff',
+            strokeWidth: 3,
+            strokeAlpha: 0.75
         };
-        this.presets = this.createPresets();
-        this.strokes = [];
         this.echoes = [];
-        this.particles = [];
-        this.ripples = [];
         this.currentStroke = null;
-        this.lastEchoAt = 0;
+        this.isDrawing = false;
+        this.echoTimer = null;
         this.lastFrameAt = performance.now();
         this.fps = 60;
+
         this.resizeCanvas();
         this.bindEvents();
         this.bindControls();
+        this.startEchoTimer();
         requestAnimationFrame((time) => this.render(time));
     }
 
-    createPresets() {
-        return {
-            softFan: { decorationTheme: 'bloom', spreadMode: 'growing', spreadAngleDeg: 42, branch3Start: 14, branch5Start: 44, strokeColor: '#00c8ff', gradientEndColor: '#ff4fd8', sparkAmount: 0.25 },
-            sparkler: { decorationTheme: 'spark', spreadMode: 'pulse', spreadAngleDeg: 62, branch3Start: 8, branch5Start: 24, strokeColor: '#fff0a8', gradientEndColor: '#ff6a00', colorMode: 'gradient', sparkAmount: 0.85 },
-            spiralRibbon: { decorationTheme: 'spiralRibbon', spreadMode: 'spiral', spreadAngleDeg: 72, branch3Start: 6, branch5Start: 22, strokeColor: '#8dfcff', gradientEndColor: '#b86bff', sparkAmount: 0.45, spiralRadius: 18, spiralTightness: 1.2 },
-            tornado: { decorationTheme: 'tornado', spreadMode: 'spiral', spreadAngleDeg: 88, branch3Start: 5, branch5Start: 18, strokeColor: '#b7ffea', gradientEndColor: '#ffffff', sparkAmount: 0.35, tornadoLift: 0.75 },
-            ripple: { decorationTheme: 'ripple', spreadMode: 'mirror', spreadAngleDeg: 34, branch3Start: 10, branch5Start: 34, strokeColor: '#68d8ff', gradientEndColor: '#b7fff6', sparkAmount: 0.3 },
-            starShower: { decorationTheme: 'stamp', spreadMode: 'growing', spreadAngleDeg: 105, branch3Start: 4, branch5Start: 14, strokeColor: '#ffd166', gradientEndColor: '#ff4fd8', colorMode: 'rainbow', sparkAmount: 0.75, stampDensity: 0.35 }
-        };
-    }
-
     resizeCanvas() {
+        const rect = this.canvas.getBoundingClientRect();
         const dpr = window.devicePixelRatio || 1;
-        this.width = window.innerWidth;
-        this.height = window.innerHeight;
-        this.canvas.width = Math.floor(this.width * dpr);
-        this.canvas.height = Math.floor(this.height * dpr);
-        this.canvas.style.width = `${this.width}px`;
-        this.canvas.style.height = `${this.height}px`;
+        this.width = rect.width;
+        this.height = rect.height;
+        this.canvas.width = rect.width * dpr;
+        this.canvas.height = rect.height * dpr;
         this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     }
 
     bindEvents() {
         window.addEventListener('resize', () => this.resizeCanvas());
-        window.addEventListener('orientationchange', () => setTimeout(() => this.resizeCanvas(), 120));
+        window.addEventListener('orientationchange', () => setTimeout(() => this.resizeCanvas(), 100));
         this.canvas.addEventListener('contextmenu', (event) => event.preventDefault());
+        this.canvas.addEventListener('touchmove', (event) => event.preventDefault(), { passive: false });
         this.canvas.addEventListener('pointerdown', (event) => this.startStroke(event));
         this.canvas.addEventListener('pointermove', (event) => this.moveStroke(event));
         this.canvas.addEventListener('pointerup', (event) => this.endStroke(event));
@@ -63,189 +51,100 @@ class SpreadingEchoApp {
     }
 
     bindControls() {
-        document.querySelectorAll('.preset-button').forEach((button) => {
-            button.addEventListener('click', () => {
-                document.querySelectorAll('.preset-button').forEach((item) => item.classList.remove('active'));
-                button.classList.add('active');
-                Object.assign(this.settings, this.presets[button.dataset.preset]);
-                this.syncControls();
-            });
-        });
-        const controls = ['strokeColor', 'gradientEndColor', 'colorMode', 'strokeWidth', 'strokeAlpha', 'baseAngleDeg', 'echoDistance', 'spreadAngleDeg', 'branch3Start', 'branch5Start', 'spreadMode', 'echoIntervalMs', 'echoCountMax', 'decorationTheme', 'sparkAmount'];
-        controls.forEach((id) => {
+        ['strokeColor', 'strokeWidth', 'strokeAlpha', 'echoIntervalMs', 'echoCountMax'].forEach((id) => {
             const element = document.getElementById(id);
             element.addEventListener('input', () => {
-                const numeric = element.type === 'range';
-                this.settings[id] = numeric ? Number(element.value) : element.value;
-                if (id === 'strokeAlpha' || id === 'sparkAmount') this.settings[id] = Number(element.value) / (id === 'strokeAlpha' ? 100 : 100);
+                const rawValue = element.type === 'range' ? Number(element.value) : element.value;
+                this.settings[id] = id === 'strokeAlpha' ? rawValue / 100 : rawValue;
+                if (id === 'echoIntervalMs') this.restartEchoTimer();
                 if (id === 'echoCountMax') this.trimEchoes();
-                this.updateValueLabels();
+                this.updateLabels();
             });
         });
-        this.syncControls();
+        this.updateLabels();
     }
 
-    syncControls() {
-        Object.entries(this.settings).forEach(([key, value]) => {
-            const element = document.getElementById(key);
-            if (!element) return;
-            element.value = key === 'strokeAlpha' || key === 'sparkAmount' ? Math.round(value * 100) : value;
-        });
-        this.updateValueLabels();
-    }
-
-    updateValueLabels() {
-        const labelMap = { strokeWidth: '', strokeAlpha: '', baseAngleDeg: '', echoDistance: '', spreadAngleDeg: '', branch3Start: '', branch5Start: '', echoIntervalMs: '', echoCountMax: '', sparkAmount: '' };
-        Object.keys(labelMap).forEach((key) => {
+    updateLabels() {
+        const values = {
+            strokeWidth: this.settings.strokeWidth,
+            strokeAlpha: Math.round(this.settings.strokeAlpha * 100),
+            echoIntervalMs: this.settings.echoIntervalMs,
+            echoCountMax: this.settings.echoCountMax
+        };
+        Object.entries(values).forEach(([key, value]) => {
             const label = document.getElementById(`${key}Value`);
-            if (!label) return;
-            const value = key === 'strokeAlpha' || key === 'sparkAmount' ? Math.round(this.settings[key] * 100) : this.settings[key];
-            label.textContent = value;
+            if (label) label.textContent = value;
         });
     }
 
     startStroke(event) {
         event.preventDefault();
         this.canvas.setPointerCapture(event.pointerId);
-        const point = this.getPoint(event);
-        this.currentStroke = { id: this.createId(), points: [point], color: this.settings.strokeColor, width: this.settings.strokeWidth, alpha: this.settings.strokeAlpha, createdAt: performance.now() };
-        this.strokes.push(this.currentStroke);
-        this.addRipple(point, performance.now());
+        this.clear();
+        this.isDrawing = true;
+        this.currentStroke = {
+            color: this.settings.strokeColor,
+            width: this.settings.strokeWidth,
+            alpha: this.settings.strokeAlpha,
+            points: []
+        };
+        this.addPoint(this.getPoint(event));
     }
 
     moveStroke(event) {
-        if (!this.currentStroke) return;
+        if (!this.isDrawing) return;
         event.preventDefault();
-        const point = this.getPoint(event);
-        const points = this.currentStroke.points;
-        const last = points[points.length - 1];
-        const distance = Math.hypot(point.x - last.x, point.y - last.y);
-        const steps = Math.max(1, Math.floor(distance / 6));
-        for (let index = 1; index <= steps; index += 1) {
-            points.push({ x: last.x + ((point.x - last.x) * index) / steps, y: last.y + ((point.y - last.y) * index) / steps, pressure: point.pressure, time: point.time });
-        }
-        if (point.time - this.lastEchoAt > this.settings.echoIntervalMs) {
-            this.createEcho(this.currentStroke, point.time);
-            this.lastEchoAt = point.time;
-        }
+        this.addPoint(this.getPoint(event));
     }
 
     endStroke(event) {
-        if (!this.currentStroke) return;
-        this.moveStroke(event);
-        this.createEcho(this.currentStroke, performance.now());
-        this.currentStroke = null;
+        if (!this.isDrawing) return;
+        event.preventDefault();
+        this.isDrawing = false;
     }
 
     getPoint(event) {
         const rect = this.canvas.getBoundingClientRect();
-        return { x: event.clientX - rect.left, y: event.clientY - rect.top, pressure: event.pressure || 0.5, time: performance.now() };
+        return {
+            x: event.clientX - rect.left,
+            y: event.clientY - rect.top,
+            pressure: event.pressure || 0.5
+        };
     }
 
-    createId() {
-        if (window.crypto && typeof window.crypto.randomUUID === 'function') return window.crypto.randomUUID();
-        return `stroke-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    addPoint(point) {
+        if (!this.currentStroke) return;
+        const points = this.currentStroke.points;
+        const previous = points[points.length - 1];
+        if (previous && Math.hypot(point.x - previous.x, point.y - previous.y) < 2) return;
+        points.push({
+            ...point,
+            width: this.currentStroke.width * (0.5 + point.pressure * 0.5)
+        });
     }
 
-    createEcho(stroke, time) {
-        if (!stroke || stroke.points.length < 1) return;
-        const echoIndex = this.echoes.length ? this.echoes[this.echoes.length - 1].echoIndex + 1 : 1;
-        const branchCount = this.getBranchCount(echoIndex);
-        const offsets = this.getBranchOffsets(branchCount);
-        offsets.forEach((branchOffset, branchIndex) => {
-            const angleDeg = this.getAngle(echoIndex, branchOffset, time);
-            const distance = this.settings.echoDistance * echoIndex;
-            const rad = (angleDeg * Math.PI) / 180;
-            const tornadoLift = this.settings.decorationTheme === 'tornado' ? echoIndex * this.settings.tornadoLift * -1.4 : 0;
-            const echo = {
-                source: stroke, echoIndex, branchIndex, branchCount, angleDeg,
-                dx: Math.cos(rad) * distance,
-                dy: Math.sin(rad) * distance + tornadoLift,
-                scale: Math.pow(this.settings.scalePerEcho, echoIndex),
-                alpha: Math.pow(this.settings.alphaPerEcho, echoIndex),
-                color: this.getEchoColor(echoIndex, branchIndex),
-                blur: this.settings.blurPerEcho * echoIndex,
-                createdAt: time
-            };
-            this.echoes.push(echo);
-            this.decorateEcho(echo, time);
+    startEchoTimer() {
+        this.echoTimer = setInterval(() => this.snapshot(), this.settings.echoIntervalMs);
+    }
+
+    restartEchoTimer() {
+        clearInterval(this.echoTimer);
+        this.startEchoTimer();
+    }
+
+    snapshot() {
+        if (!this.currentStroke || this.currentStroke.points.length === 0) return;
+        this.echoes.unshift({
+            color: this.currentStroke.color,
+            width: this.currentStroke.width,
+            alpha: this.currentStroke.alpha,
+            points: this.currentStroke.points.map((point) => ({ ...point }))
         });
         this.trimEchoes();
     }
 
     trimEchoes() {
-        const max = this.settings.echoCountMax * 5;
-        if (this.echoes.length > max) this.echoes.splice(0, this.echoes.length - max);
-    }
-
-    getBranchCount(echoIndex) {
-        if (echoIndex >= this.settings.branch5Start) return 5;
-        if (echoIndex >= this.settings.branch3Start) return 3;
-        return 1;
-    }
-
-    getBranchOffsets(branchCount) {
-        if (branchCount === 1) return [0];
-        if (branchCount === 3) return [-0.5, 0, 0.5];
-        return [-1, -0.5, 0, 0.5, 1];
-    }
-
-    getSpreadRatio(echoIndex, time) {
-        const growing = Math.min(1, echoIndex * this.settings.spreadGrowth);
-        if (this.settings.spreadMode !== 'pulse') return growing;
-        const pulse = 1 - this.settings.pulseDepth + Math.sin(time * 0.001 * Math.PI * 2 * this.settings.pulseFrequency) * this.settings.pulseDepth;
-        return Math.max(0.08, Math.min(1, growing * pulse));
-    }
-
-    getAngle(echoIndex, branchOffset, time) {
-        let base = this.settings.baseAngleDeg;
-        if (this.settings.spreadMode === 'spiral') base += echoIndex * this.settings.spiralRotationPerEcho;
-        const mirrorBoost = this.settings.spreadMode === 'mirror' ? 1.25 : 1;
-        return base + branchOffset * this.settings.spreadAngleDeg * this.getSpreadRatio(echoIndex, time) * mirrorBoost;
-    }
-
-    getEchoColor(echoIndex, branchIndex) {
-        if (this.settings.colorMode === 'solid') return this.settings.strokeColor;
-        if (this.settings.colorMode === 'rainbow') return `hsl(${(echoIndex * this.settings.hueShift + branchIndex * 34) % 360}, 94%, 66%)`;
-        return this.mixHex(this.settings.strokeColor, this.settings.gradientEndColor, Math.min(1, echoIndex / this.settings.echoCountMax));
-    }
-
-    mixHex(start, end, ratio) {
-        const a = this.hexToRgb(start), b = this.hexToRgb(end);
-        return `rgb(${Math.round(a.r + (b.r - a.r) * ratio)}, ${Math.round(a.g + (b.g - a.g) * ratio)}, ${Math.round(a.b + (b.b - a.b) * ratio)})`;
-    }
-
-    hexToRgb(hex) {
-        const value = hex.replace('#', '');
-        return { r: parseInt(value.slice(0, 2), 16), g: parseInt(value.slice(2, 4), 16), b: parseInt(value.slice(4, 6), 16) };
-    }
-
-    decorateEcho(echo, time) {
-        const points = echo.source.points;
-        const tip = points[points.length - 1];
-        if (!tip) return;
-        const x = tip.x + echo.dx;
-        const y = tip.y + echo.dy;
-        if (this.settings.decorationTheme === 'spark' || this.settings.decorationTheme === 'stamp') this.addSparks(x, y, echo, time);
-        if (this.settings.decorationTheme === 'ripple') this.addRipple({ x, y }, time);
-    }
-
-    addSparks(x, y, echo, time) {
-        const count = Math.round((3 + echo.branchCount * 1.8) * this.settings.sparkAmount);
-        for (let index = 0; index < count; index += 1) {
-            const angle = ((echo.angleDeg + (Math.random() - 0.5) * 80) * Math.PI) / 180;
-            const speed = 0.35 + Math.random() * 1.8;
-            this.particles.push({ x, y, vx: Math.cos(angle) * speed, vy: Math.sin(angle) * speed, size: 1.4 + Math.random() * 3.8, life: 1, decay: 0.018 + Math.random() * 0.02, color: this.settings.decorationTheme === 'stamp' ? this.randomStampColor() : echo.color, stamp: this.settings.decorationTheme === 'stamp' });
-        }
-    }
-
-    randomStampColor() {
-        return ['#fff3a3', '#ff7ac8', '#7afcff', '#b9ff7a', '#ffffff'][Math.floor(Math.random() * 5)];
-    }
-
-    addRipple(point, time) {
-        this.ripples.push({ x: point.x, y: point.y, radius: 4, life: 1, createdAt: time });
-        if (this.ripples.length > 80) this.ripples.shift();
+        while (this.echoes.length > this.settings.echoCountMax) this.echoes.pop();
     }
 
     render(time) {
@@ -253,161 +152,55 @@ class SpreadingEchoApp {
         this.lastFrameAt = time;
         this.fps = this.fps * 0.9 + (1000 / Math.max(delta, 1)) * 0.1;
         this.ctx.clearRect(0, 0, this.width, this.height);
-        this.drawBackgroundGlow(time);
-        this.echoes.forEach((echo) => this.drawEcho(echo, time));
-        this.strokes.forEach((stroke) => this.drawStroke(stroke, { dx: 0, dy: 0, scale: 1, alpha: stroke.alpha, color: stroke.color, blur: 0 }, time));
-        this.drawParticles();
-        this.drawRipples();
+
+        this.echoes.slice().reverse().forEach((echo, index) => this.drawStroke(echo, index));
+        if (this.currentStroke) this.drawStroke(this.currentStroke, 0, true);
+
         document.getElementById('fpsStatus').textContent = `${Math.round(this.fps)} FPS`;
-        const newest = this.echoes[this.echoes.length - 1];
-        document.getElementById('branchStatus').textContent = newest ? `${newest.branchCount}方向` : '1方向';
+        document.getElementById('branchStatus').textContent = this.currentStroke ? '描いている間だけ残る' : '次の線で消える';
         requestAnimationFrame((nextTime) => this.render(nextTime));
     }
 
-    drawBackgroundGlow(time) {
-        const gradient = this.ctx.createRadialGradient(this.width * 0.5, this.height * 0.48, 0, this.width * 0.5, this.height * 0.48, Math.max(this.width, this.height) * 0.7);
-        gradient.addColorStop(0, `rgba(0, 200, 255, ${0.05 + Math.sin(time * 0.001) * 0.02})`);
-        gradient.addColorStop(0.55, 'rgba(255, 79, 216, 0.035)');
-        gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
-        this.ctx.fillStyle = gradient;
-        this.ctx.fillRect(0, 0, this.width, this.height);
-    }
+    drawStroke(stroke, echoIndex, isCurrent = false) {
+        if (stroke.points.length === 0) return;
+        const alpha = isCurrent ? stroke.alpha : stroke.alpha * Math.pow(this.settings.alphaPerEcho, echoIndex);
+        const scale = isCurrent ? 1 : Math.pow(this.settings.scalePerEcho, echoIndex);
+        const dx = isCurrent ? 0 : this.settings.shiftX * echoIndex;
+        const dy = isCurrent ? 0 : this.settings.shiftY * echoIndex;
+        const center = stroke.points[Math.floor(stroke.points.length / 2)] || stroke.points[0];
 
-    drawEcho(echo, time) {
-        this.drawStroke(echo.source, echo, time);
-        if (this.settings.decorationTheme === 'bloom') this.drawBloom(echo);
-        if (this.settings.decorationTheme === 'spiralRibbon') this.drawSpiralRibbon(echo, time);
-        if (this.settings.decorationTheme === 'tornado') this.drawTornadoRings(echo);
-    }
-
-    drawStroke(stroke, echo, time) {
-        if (stroke.points.length < 1) return;
         this.ctx.save();
-        this.ctx.translate(echo.dx, echo.dy);
-        const center = stroke.points[Math.floor(stroke.points.length / 2)] || { x: this.width / 2, y: this.height / 2 };
+        this.ctx.globalAlpha = Math.max(0, Math.min(1, alpha));
+        this.ctx.translate(dx, dy);
         this.ctx.translate(center.x, center.y);
-        this.ctx.scale(echo.scale, echo.scale);
+        this.ctx.scale(scale, scale);
         this.ctx.translate(-center.x, -center.y);
-        this.ctx.globalAlpha = Math.min(1, echo.alpha);
-        this.ctx.strokeStyle = echo.color;
-        this.ctx.lineWidth = Math.max(0.5, stroke.width * echo.scale);
+        this.ctx.strokeStyle = stroke.color;
+        this.ctx.fillStyle = stroke.color;
         this.ctx.lineCap = 'round';
         this.ctx.lineJoin = 'round';
-        this.ctx.shadowColor = echo.color;
-        this.ctx.shadowBlur = Math.min(26, echo.blur + 7);
+        this.ctx.shadowColor = stroke.color;
+        this.ctx.shadowBlur = isCurrent ? 3 : 8;
+
         this.ctx.beginPath();
         this.ctx.moveTo(stroke.points[0].x, stroke.points[0].y);
         if (stroke.points.length === 1) {
             this.ctx.arc(stroke.points[0].x, stroke.points[0].y, Math.max(1, stroke.width * 0.5), 0, Math.PI * 2);
-            this.ctx.fillStyle = echo.color;
             this.ctx.fill();
-        }
-        for (let index = 1; index < stroke.points.length; index += 1) {
-            const point = stroke.points[index];
-            this.ctx.lineTo(point.x, point.y);
-        }
-        this.ctx.stroke();
-        this.ctx.restore();
-    }
-
-    drawBloom(echo) {
-        const points = echo.source.points;
-        if (!points.length) return;
-        const point = points[Math.floor(points.length * 0.65)];
-        const radius = this.settings.radialBloomRadius + echo.echoIndex * 1.4;
-        this.ctx.save();
-        this.ctx.globalAlpha = this.settings.radialBloomStrength * echo.alpha;
-        this.ctx.strokeStyle = echo.color;
-        this.ctx.lineWidth = 1.2;
-        this.ctx.beginPath();
-        this.ctx.ellipse(point.x + echo.dx, point.y + echo.dy, radius * 1.4, radius, echo.angleDeg, 0, Math.PI * 2);
-        this.ctx.stroke();
-        this.ctx.restore();
-    }
-
-    drawSpiralRibbon(echo, time) {
-        const points = echo.source.points;
-        if (points.length < 2) return;
-        this.ctx.save();
-        this.ctx.globalAlpha = echo.alpha * 0.55;
-        this.ctx.strokeStyle = echo.color;
-        this.ctx.lineWidth = 1.2;
-        this.ctx.beginPath();
-        points.forEach((point, index) => {
-            const wave = Math.sin(index * this.settings.spiralTightness + time * 0.006 + echo.echoIndex * 0.3) * this.settings.spiralRadius;
-            const x = point.x + echo.dx + Math.cos((echo.angleDeg + 90) * Math.PI / 180) * wave;
-            const y = point.y + echo.dy + Math.sin((echo.angleDeg + 90) * Math.PI / 180) * wave;
-            if (index === 0) this.ctx.moveTo(x, y); else this.ctx.lineTo(x, y);
-        });
-        this.ctx.stroke();
-        this.ctx.restore();
-    }
-
-    drawTornadoRings(echo) {
-        if (echo.echoIndex % 3 !== 0) return;
-        const points = echo.source.points;
-        const point = points[points.length - 1];
-        this.ctx.save();
-        this.ctx.globalAlpha = echo.alpha * 0.45;
-        this.ctx.strokeStyle = echo.color;
-        this.ctx.lineWidth = 1;
-        this.ctx.beginPath();
-        this.ctx.ellipse(point.x + echo.dx, point.y + echo.dy, 12 + echo.echoIndex * 0.6, 5 + echo.echoIndex * 0.22, echo.angleDeg, 0, Math.PI * 2);
-        this.ctx.stroke();
-        this.ctx.restore();
-    }
-
-    drawParticles() {
-        this.particles = this.particles.filter((particle) => particle.life > 0);
-        this.particles.forEach((particle) => {
-            particle.x += particle.vx;
-            particle.y += particle.vy;
-            particle.vy += 0.01;
-            particle.life -= particle.decay;
-            this.ctx.save();
-            this.ctx.globalAlpha = Math.max(0, particle.life);
-            this.ctx.fillStyle = particle.color;
-            this.ctx.shadowColor = particle.color;
-            this.ctx.shadowBlur = 12;
-            this.ctx.beginPath();
-            if (particle.stamp) this.drawStar(particle.x, particle.y, particle.size * 1.8); else this.ctx.arc(particle.x, particle.y, particle.size, 0, Math.PI * 2);
-            this.ctx.fill();
-            this.ctx.restore();
-        });
-    }
-
-    drawStar(x, y, radius) {
-        for (let index = 0; index < 10; index += 1) {
-            const angle = -Math.PI / 2 + index * Math.PI / 5;
-            const r = index % 2 === 0 ? radius : radius * 0.45;
-            const px = x + Math.cos(angle) * r;
-            const py = y + Math.sin(angle) * r;
-            if (index === 0) this.ctx.moveTo(px, py); else this.ctx.lineTo(px, py);
-        }
-        this.ctx.closePath();
-    }
-
-    drawRipples() {
-        this.ripples = this.ripples.filter((ripple) => ripple.life > 0);
-        this.ripples.forEach((ripple) => {
-            ripple.radius += this.settings.rippleRadiusGrowth;
-            ripple.life *= this.settings.rippleAlphaDecay;
-            this.ctx.save();
-            this.ctx.globalAlpha = ripple.life * 0.55;
-            this.ctx.strokeStyle = this.settings.gradientEndColor;
-            this.ctx.lineWidth = 1.4;
-            this.ctx.beginPath();
-            this.ctx.arc(ripple.x, ripple.y, ripple.radius, 0, Math.PI * 2);
+        } else {
+            for (let index = 1; index < stroke.points.length; index += 1) {
+                const point = stroke.points[index];
+                this.ctx.lineWidth = Math.max(0.5, (point.width || stroke.width) * scale);
+                this.ctx.lineTo(point.x, point.y);
+            }
             this.ctx.stroke();
-            this.ctx.restore();
-        });
+        }
+        this.ctx.restore();
     }
 
     clear() {
-        this.strokes = [];
         this.echoes = [];
-        this.particles = [];
-        this.ripples = [];
+        this.currentStroke = null;
     }
 
     togglePanel() {
@@ -420,4 +213,4 @@ class SpreadingEchoApp {
     }
 }
 
-window.addEventListener('DOMContentLoaded', () => new SpreadingEchoApp());
+window.addEventListener('DOMContentLoaded', () => new EphemeralEchoApp());

--- a/game79/index.html
+++ b/game79/index.html
@@ -3,16 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-    <title>ひろがるエコーお絵描き</title>
+    <title>儚いエコーお絵描き</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <main class="app-shell">
-        <canvas id="drawingCanvas" aria-label="ひろがるエコーを描くキャンバス"></canvas>
+        <canvas id="drawingCanvas" aria-label="儚いエコーを描くキャンバス"></canvas>
 
         <section class="hud" aria-live="polite">
-            <strong>ひろがるエコー</strong>
-            <span id="branchStatus">1方向</span>
+            <strong>儚いエコー</strong>
+            <span id="branchStatus">次の線で消える</span>
             <span id="fpsStatus">60 FPS</span>
         </section>
 
@@ -20,76 +20,27 @@
             <header class="panel-header">
                 <div>
                     <p class="eyebrow">game79</p>
-                    <h1>ひろがるエコー</h1>
+                    <h1>儚いエコー</h1>
                 </div>
                 <button id="togglePanel" class="icon-button" type="button" aria-expanded="true" aria-controls="panelBody">▼</button>
             </header>
 
             <div id="panelBody" class="panel-body">
                 <div class="button-row">
-                    <button id="clearCanvas" class="primary-button" type="button">ぜんぶ消す</button>
+                    <button id="clearCanvas" class="primary-button" type="button">消す</button>
                 </div>
 
                 <section class="control-group">
-                    <h2>プリセット</h2>
-                    <div class="preset-grid">
-                        <button class="preset-button active" type="button" data-preset="softFan">ソフトファン</button>
-                        <button class="preset-button" type="button" data-preset="sparkler">てもち花火</button>
-                        <button class="preset-button" type="button" data-preset="spiralRibbon">うずまき</button>
-                        <button class="preset-button" type="button" data-preset="tornado">たつまき</button>
-                        <button class="preset-button" type="button" data-preset="ripple">はもん</button>
-                        <button class="preset-button" type="button" data-preset="starShower">スター</button>
-                    </div>
+                    <h2>線</h2>
+                    <label>色 <input id="strokeColor" type="color" value="#9ee7ff"></label>
+                    <label>太さ <span id="strokeWidthValue">3</span>px<input id="strokeWidth" type="range" min="1" max="10" step="0.5" value="3"></label>
+                    <label>不透明度 <span id="strokeAlphaValue">75</span>%<input id="strokeAlpha" type="range" min="15" max="100" step="5" value="75"></label>
                 </section>
 
                 <section class="control-group">
-                    <h2>ブラシ</h2>
-                    <label>色 <input id="strokeColor" type="color" value="#00c8ff"></label>
-                    <label>終点色 <input id="gradientEndColor" type="color" value="#ff4fd8"></label>
-                    <label>色モード
-                        <select id="colorMode">
-                            <option value="gradient">グラデーション</option>
-                            <option value="rainbow">レインボー</option>
-                            <option value="solid">単色</option>
-                        </select>
-                    </label>
-                    <label>太さ <span id="strokeWidthValue">4</span>px<input id="strokeWidth" type="range" min="1" max="16" step="0.5" value="4"></label>
-                    <label>不透明度 <span id="strokeAlphaValue">85</span>%<input id="strokeAlpha" type="range" min="10" max="100" step="5" value="85"></label>
-                </section>
-
-                <section class="control-group">
-                    <h2>広がり</h2>
-                    <label>基準角度 <span id="baseAngleDegValue">225</span>°<input id="baseAngleDeg" type="range" min="0" max="360" step="1" value="225"></label>
-                    <label>移動量 <span id="echoDistanceValue">3</span>px<input id="echoDistance" type="range" min="0" max="12" step="0.5" value="3"></label>
-                    <label>最大拡散角 <span id="spreadAngleDegValue">50</span>°<input id="spreadAngleDeg" type="range" min="0" max="140" step="1" value="50"></label>
-                    <label>3方向開始 <span id="branch3StartValue">12</span><input id="branch3Start" type="range" min="1" max="60" step="1" value="12"></label>
-                    <label>5方向開始 <span id="branch5StartValue">32</span><input id="branch5Start" type="range" min="2" max="90" step="1" value="32"></label>
-                    <label>モード
-                        <select id="spreadMode">
-                            <option value="growing">グローイング</option>
-                            <option value="pulse">パルス</option>
-                            <option value="spiral">スパイラル</option>
-                            <option value="mirror">ミラー</option>
-                        </select>
-                    </label>
-                </section>
-
-                <section class="control-group">
-                    <h2>エコーと装飾</h2>
-                    <label>エコー間隔 <span id="echoIntervalMsValue">70</span>ms<input id="echoIntervalMs" type="range" min="30" max="180" step="10" value="70"></label>
-                    <label>最大数 <span id="echoCountMaxValue">90</span><input id="echoCountMax" type="range" min="12" max="180" step="2" value="90"></label>
-                    <label>装飾
-                        <select id="decorationTheme">
-                            <option value="spark">火花</option>
-                            <option value="bloom">ブルーム</option>
-                            <option value="spiralRibbon">螺旋リボン</option>
-                            <option value="tornado">たつまき</option>
-                            <option value="ripple">波紋</option>
-                            <option value="stamp">星スタンプ</option>
-                            <option value="none">なし</option>
-                        </select>
-                    </label>
-                    <label>装飾量 <span id="sparkAmountValue">45</span>%<input id="sparkAmount" type="range" min="0" max="100" step="5" value="45"></label>
+                    <h2>余韻</h2>
+                    <label>間隔 <span id="echoIntervalMsValue">70</span>ms<input id="echoIntervalMs" type="range" min="35" max="180" step="5" value="70"></label>
+                    <label>残像数 <span id="echoCountMaxValue">80</span><input id="echoCountMax" type="range" min="10" max="140" step="5" value="80"></label>
                 </section>
             </div>
         </aside>

--- a/game79/style.css
+++ b/game79/style.css
@@ -4,9 +4,8 @@ body {
     font-family: ui-rounded, "Hiragino Maru Gothic ProN", "Yu Gothic", system-ui, sans-serif;
     color: #f8fbff;
     background:
-        radial-gradient(circle at 20% 20%, rgba(0, 200, 255, 0.28), transparent 34%),
-        radial-gradient(circle at 80% 15%, rgba(255, 79, 216, 0.2), transparent 28%),
-        linear-gradient(135deg, #07111f 0%, #130c27 45%, #061923 100%);
+        radial-gradient(circle at 50% 45%, rgba(158, 231, 255, 0.12), transparent 38%),
+        linear-gradient(135deg, #07111f 0%, #0a1320 55%, #050b12 100%);
 }
 .app-shell { position: relative; width: 100vw; height: 100vh; isolation: isolate; }
 .app-shell::before {
@@ -17,7 +16,7 @@ body {
     background-image:
         linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
         linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
-    background-size: 42px 42px;
+    background-size: 56px 56px;
     mask-image: radial-gradient(circle at center, black, transparent 75%);
 }
 #drawingCanvas {
@@ -75,14 +74,11 @@ h2 { margin: 0 0 12px; color: #e7f8ff; font-size: 14px; }
     font-weight: 700;
 }
 .icon-button { width: 34px; height: 34px; }
-.primary-button { width: 100%; padding: 12px; background: linear-gradient(135deg, #00c8ff, #ff4fd8); }
+.primary-button { width: 100%; padding: 12px; background: linear-gradient(135deg, #5fcceb, #9ee7ff); }
 .panel-body { max-height: calc(100vh - 104px); overflow: auto; padding: 0 18px 18px; transition: max-height 180ms ease, opacity 180ms ease; }
 .settings-panel.collapsed .panel-body { max-height: 0; opacity: 0; padding-bottom: 0; }
 .control-group { padding: 14px 0; border-top: 1px solid rgba(255,255,255,0.12); }
 .button-row { padding: 4px 0 14px; }
-.preset-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
-.preset-button { padding: 10px 8px; font-size: 13px; }
-.preset-button.active { background: rgba(0,200,255,0.32); box-shadow: inset 0 0 0 1px rgba(121,232,255,0.7); }
 label { display: grid; gap: 6px; margin: 11px 0; color: #d8eef8; font-size: 13px; }
 input[type="range"] { width: 100%; accent-color: #00c8ff; }
 input[type="color"] { width: 100%; height: 34px; border: 0; border-radius: 10px; background: transparent; }

--- a/index.html
+++ b/index.html
@@ -356,6 +356,11 @@
     <p class="dates" data-game="game78"></p>
     <a href="game78/" target="_blank">遊ぶ</a>
   </div>
+  <div class="card">
+    <h2>儚いエコー</h2>
+    <p class="dates" data-game="game79"></p>
+    <a href="game79/" target="_blank">遊ぶ</a>
+  </div>
 </div>
 <script src="script.js"></script>
 </body>


### PR DESCRIPTION
### Motivation
- Replace the previous multi-featured spreading-echo brush with a lightweight, ephemeral echo effect that only persists visually while drawing to improve responsiveness and simplify the experience.
- Reduce complexity by removing many decorative systems (particles, ripples, presets) and streamline controls for a focused, minimal brush.

### Description
- Renamed `SpreadingEchoApp` to `EphemeralEchoApp`, simplified the `settings` object, and removed many legacy parameters and preset logic in `game79/app.js`.
- Reworked stroke lifecycle by introducing `addPoint` and `snapshot`, starting a periodic `startEchoTimer` that captures ephemeral echoes, clearing previous echoes on `startStroke`, and using `trimEchoes` to enforce `echoCountMax`.
- Simplified rendering to a single `drawStroke` that handles both the current stroke and echoed snapshots using `shiftX/shiftY`, `scalePerEcho`, and `alphaPerEcho`, and removed complex decoration/draw helpers (particles, ripples, bloom, spiral ribbons, tornado rings, etc.).
- Updated UI and assets: `game79/index.html` was adjusted for the new feature set and labels, `style.css` was tweaked for updated visuals, and the site-level `index.html` was updated to add a card entry for the new "儚いエコー" page.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57ac2df83c832584458d42af4be354)